### PR TITLE
Kubostech->kubos name change cleanup

### DIFF
--- a/examples/adc-thermistor/README.md
+++ b/examples/adc-thermistor/README.md
@@ -1,6 +1,6 @@
 # ADC Demo with Kubos Linux
 
-This is a simple application built on top of the [KubOS Linux Platform](https://github.com/kubostech/kubos-linux-build) 
+This is a simple application built on top of the [KubOS Linux Platform](https://github.com/kubos/kubos-linux-build) 
 demonstrating some basic data gathering from a thermistor connected to an ADC pin.
 
 The project reads ADC values from the thermistor and then converts it to the temperature (in celsius) using the 

--- a/examples/adc-thermistor/module.json
+++ b/examples/adc-thermistor/module.json
@@ -8,7 +8,7 @@
     },
     "version":"0.1.0",
     "dependencies":{
-	"csp":"kubostech/libcsp"
+	"csp":"kubos/libcsp"
     },
     "homepage":"https://<homepage>",
     "description":"Example Kubos app which reads the temperature from a thermistor"

--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -39,7 +39,7 @@ RUN rm ./bbb_toolchain.tar.gz
 
 RUN pip install --upgrade setuptools
 RUN pip install -r https://raw.githubusercontent.com/kubos/kubos-cli/master/requirements.txt
-RUN pip install git+https://github.com/kubostech/kubos-cli
+RUN pip install git+https://github.com/kubos/kubos-cli
 
 RUN mkdir -p /usr/local/lib/yotta_modules
 RUN mkdir -p /usr/local/lib/yotta_targets


### PR DESCRIPTION
Fixing a few kubostech->kubos stragglers.

Note: There are two places where "kubostech" will still exist
1. In the changelog with the links to old JIRA stories
2. In our CLA link (https://www.clahub.com/agreements/kubostech/KubOS)