### PR TITLE
Clearing doc gen warnings

### DIFF
--- a/hal/kubos-hal-linux/source/i2c.c
+++ b/hal/kubos-hal-linux/source/i2c.c
@@ -35,8 +35,13 @@
 
 #include "kubos-hal/i2c.h"
 
- #define STRINGIFY(s) TOSTRING(s)
- #define TOSTRING(s) #s
+/**
+ * Convert constant to string value
+ */
+#define STRINGIFY(s) TOSTRING(s)
+/** \cond */
+#define TOSTRING(s) #s
+/** \endcond */
 
 /**
  * Static array of I2C bus file descriptors

--- a/libcsp/docs/Doxyfile
+++ b/libcsp/docs/Doxyfile
@@ -453,7 +453,7 @@ EXTRACT_LOCAL_METHODS  = NO
 # are hidden.
 # The default value is: NO.
 
-EXTRACT_ANON_NSPACES   = NO
+EXTRACT_ANON_NSPACES   = YES
 
 # If the HIDE_UNDOC_MEMBERS tag is set to YES, doxygen will hide all
 # undocumented members inside documented classes or files. If set to NO these
@@ -2000,7 +2000,7 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = __attribute__(x)= \
-                         CSP_LITTLE_ENDIAN
+                         CSP_LITTLE_ENDIAN DOXYGEN
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/libcsp/docs/Doxyfile
+++ b/libcsp/docs/Doxyfile
@@ -453,7 +453,7 @@ EXTRACT_LOCAL_METHODS  = NO
 # are hidden.
 # The default value is: NO.
 
-EXTRACT_ANON_NSPACES   = YES
+EXTRACT_ANON_NSPACES   = NO
 
 # If the HIDE_UNDOC_MEMBERS tag is set to YES, doxygen will hide all
 # undocumented members inside documented classes or files. If set to NO these

--- a/libcsp/include/csp/csp_types.h
+++ b/libcsp/include/csp/csp_types.h
@@ -105,7 +105,11 @@ typedef enum {
 /** @brief This union defines a CSP identifier and allows access to the individual fields or the entire identifier */
 typedef union {
 	uint32_t ext;
+#ifdef DOXYGEN /* For doc generation purposes only */
 	struct __fields __attribute__((__packed__)) {
+#else
+	struct __attribute__((__packed__)) {
+#endif
 #if defined(CSP_BIG_ENDIAN) && !defined(CSP_LITTLE_ENDIAN)
 		unsigned int pri : CSP_ID_PRIO_SIZE;
 		unsigned int src : CSP_ID_HOST_SIZE;

--- a/libcsp/include/csp/csp_types.h
+++ b/libcsp/include/csp/csp_types.h
@@ -105,7 +105,7 @@ typedef enum {
 /** @brief This union defines a CSP identifier and allows access to the individual fields or the entire identifier */
 typedef union {
 	uint32_t ext;
-	struct __attribute__((__packed__)) {
+	struct __fields __attribute__((__packed__)) {
 #if defined(CSP_BIG_ENDIAN) && !defined(CSP_LITTLE_ENDIAN)
 		unsigned int pri : CSP_ID_PRIO_SIZE;
 		unsigned int src : CSP_ID_HOST_SIZE;


### PR DESCRIPTION
There are two legacy warnings which pop up when running `gendocs.py`. This PR is fixing them.

```
/home/vagrant/sharedOS/hal/kubos-hal-linux/source/i2c.c:38: warning: Member STRINGIFY(s) (macro definition) of group LINUX_HAL_I2C is not documented.
/home/vagrant/sharedOS/hal/kubos-hal-linux/source/i2c.c:39: warning: Member TOSTRING(s) (macro definition) of group LINUX_HAL_I2C is not documented.
```
and

```
/home/vagrant/sharedOS/docs/apis/libcsp/types.rst:4: WARNING: Invalid definition: Expected identifier in nested name. [error at 17]
  struct csp_id_t::@7 csp_id_t::@8
  -----------------^
```