### PR TITLE
[WIP] Add TRXVU transports to lua communication service.

### DIFF
--- a/services/communication-service/libs/codec-kiss-ax25.lua
+++ b/services/communication-service/libs/codec-kiss-ax25.lua
@@ -1,0 +1,83 @@
+local kiss = require 'codec-slip' -- SLIP and KISS are the same protocol
+local bit = require 'bit'
+local rshift = bit.rshift
+local lshift = bit.lshift
+local band = bit.band
+local bor = bit.bor
+local char = string.char
+local byte = string.byte
+local sub = string.sub
+local concat = table.concat
+
+local function encode(message)
+  local dest = assert(message.dest, "Missing `dest`")
+  assert(type(dest) == 'table', '`dest` must be table')
+  local d_callsign = assert(dest.callsign, 'Missing `dest.callsign`')
+  assert(type(d_callsign) == 'string', '`dest.callsign` must be string')
+  local d_ssid = assert(dest.ssid, 'Missing `dest.ssid`')
+  assert(type(d_ssid) == 'number', '`dest.ssid` must be number')
+  local d_bit = dest.bit
+  assert(type(d_bit) == "boolean", "`dest.bit` must be boolean")
+  local source = assert(message.source, "Missing `source`")
+  assert(type(source) == 'table', '`source` must be table')
+  local s_callsign = assert(source.callsign, 'Missing `source.callsign`')
+  assert(type(s_callsign) == 'string', '`source.callsign` must be string')
+  local s_ssid = assert(source.ssid, 'Missing `source.ssid`')
+  assert(type(s_ssid) == 'number', '`source.ssid` must be number')
+  local s_bit = source.bit
+  assert(type(s_bit) == "boolean", "`source.bit` must be boolean")
+  local data = assert(message.data, "Missing `data`")
+  assert(type(data) == 'string', "`data` must be string")
+  local frame = concat {
+    char(lshift(byte(d_callsign, 1) or 0x20, 1)),
+    char(lshift(byte(d_callsign, 2) or 0x20, 1)),
+    char(lshift(byte(d_callsign, 3) or 0x20, 1)),
+    char(lshift(byte(d_callsign, 4) or 0x20, 1)),
+    char(lshift(byte(d_callsign, 5) or 0x20, 1)),
+    char(lshift(byte(d_callsign, 6) or 0x20, 1)),
+    char(bor(lshift(d_ssid, 1), d_bit and 0xe0 or 0x60)),
+    char(lshift(byte(s_callsign, 1) or 0x20, 1)),
+    char(lshift(byte(s_callsign, 2) or 0x20, 1)),
+    char(lshift(byte(s_callsign, 3) or 0x20, 1)),
+    char(lshift(byte(s_callsign, 4) or 0x20, 1)),
+    char(lshift(byte(s_callsign, 5) or 0x20, 1)),
+    char(lshift(byte(s_callsign, 6) or 0x20, 1)),
+    char(bor(lshift(s_ssid, 1), s_bit and 0xe1 or 0x61)),
+    "\x03\xf0",
+    data
+  }
+  return kiss.encode(frame)
+end
+
+local function parse_callsign(chunk, index)
+  local callsign = concat {
+    char(rshift(byte(chunk, index), 1)),
+    char(rshift(byte(chunk, index + 1), 1)),
+    char(rshift(byte(chunk, index + 2), 1)),
+    char(rshift(byte(chunk, index + 3), 1)),
+    char(rshift(byte(chunk, index + 4), 1)),
+    char(rshift(byte(chunk, index + 5), 1)),
+  }
+  local ssid = rshift(band(byte(chunk, index + 6), 0x1e), 1)
+  return {
+    callsign = callsign,
+    ssid = ssid,
+    bit = rshift(byte(chunk, index + 6), 7) == 1
+  }
+end
+
+local function decode(chunk, index)
+  local frame
+  frame, index = kiss.decode(chunk, index)
+  if not frame then return end
+  return {
+    dest = parse_callsign(frame, 1),
+    source = parse_callsign(frame, 8),
+    data = sub(frame, 17)
+  }, index
+end
+
+return {
+  encode = encode,
+  decode = decode
+}

--- a/services/communication-service/libs/transport-trxvu-serial.lua
+++ b/services/communication-service/libs/transport-trxvu-serial.lua
@@ -1,0 +1,11 @@
+-- This transport speaks to the on-flight twxvu radio over it's serial
+-- interface.
+local radio = require 'trxvu'
+
+return function ()
+  assert(radio.init())
+  local read = radio.recv
+  local write = radio.send
+
+  return read, write
+end

--- a/services/communication-service/libs/transport-trxvu-tcp.lua
+++ b/services/communication-service/libs/transport-trxvu-tcp.lua
@@ -1,0 +1,69 @@
+-- This transport was originally made for the ground station for the twxvu
+-- radio.  It connects to a TCP port and speaks KISS framed AX.25 messages.
+local codec = require 'codec-kiss-ax25'
+local connect = require('coro-net').connect
+local getaddrinfo = require('uv').getaddrinfo
+local match = string.match
+local gsub = string.gsub
+
+
+local ipv4_pattern = '(%d+)%.(%d+)%.(%d+)%.(%d+)'
+local ipv6_pattern = gsub('(%h*):(%h*):(%h*):(%h*):(%h*):(%h*):(%h*):(%h*)',
+  '%%h', '[a-fA-F0-9]')
+
+local function guess_host_family(host)
+  assert(type(host) == 'string', 'Host must be a string')
+
+  -- Check for dotted decimal IPv4 strings
+  local chunks = { match(host, ipv4_pattern) }
+  if #chunks == 4 then
+    for _,v in pairs(chunks) do
+      local num = tonumber(v)
+      if not num or num < 0 or num > 255 then return end
+    end
+    return 'inet'
+  end
+
+  -- check for ipv6 format.
+  chunks = { match(host, ipv6_pattern) }
+  if #chunks <= 8 and #chunks > 1 then
+    for _,v in pairs(chunks) do
+      p{v=v}
+      if #v > 0 then
+        local num = tonumber(v, 16)
+        if not num or num < 0 or num > 65535 then return end
+      end
+    end
+    return 'inet6'
+  end
+end
+
+return function (host, port)
+  assert(host, 'Missing host paremeter')
+  assert(port, 'Missing port parameter')
+  port = assert(tonumber(port), 'port is not a number')
+  print 'Connecting to TCP socket speaking kiss framed ax.25'
+
+  local family = guess_host_family(host)
+
+  if not family then
+    local info = unpack(getaddrinfo(host, nil, {socktype = 'stream'}))
+    if info then
+      host = info.addr
+      family = info.family
+    end
+  end
+  print 'TCP endpoint:'
+  p {
+    host = host,
+    port = port,
+    family = family,
+  }
+  return assert(connect {
+    host = host,
+    port = port,
+    family = family,
+    encode = codec.encode,
+    decode = codec.decode,
+  })
+end

--- a/services/communication-service/libs/trxvu.h
+++ b/services/communication-service/libs/trxvu.h
@@ -1,0 +1,53 @@
+typedef enum {
+  RX_MAX_SIZE = 200
+} ffi_constants;
+typedef enum {
+  RADIO_OK = 0,
+  RADIO_RX_EMPTY,
+  RADIO_ERROR,
+  RADIO_ERROR_CONFIG
+} KRadioStatus;
+typedef enum {
+    RADIO_TX_RATE_1200 = 0x01,
+    RADIO_TX_RATE_2400 = 0x02,
+    RADIO_TX_RATE_4800 = 0x04,
+    RADIO_TX_RATE_9600 = 0x08
+} RadioTXRate;
+typedef enum {
+    RADIO_IDLE_UNKNOWN = 0,
+    RADIO_IDLE_OFF,
+    RADIO_IDLE_ON
+} RadioIdleState;
+typedef enum {
+    RADIO_HARD_RESET,
+    RADIO_SOFT_RESET
+} KRadioReset;
+typedef struct {
+    uint16_t interval;
+    char *   msg;
+    uint8_t  len;
+} radio_tx_beacon;
+typedef struct {
+    uint8_t ascii[6];
+    uint8_t ssid;
+} ax25_callsign;
+typedef struct {
+    RadioTXRate     data_rate;
+    RadioIdleState  idle;
+    radio_tx_beacon beacon;
+    ax25_callsign   to;
+    ax25_callsign   from;
+} radio_config;
+typedef struct {
+    uint16_t msg_size;
+    uint16_t doppler_offset;
+    uint16_t signal_strength;
+    uint8_t message[RX_MAX_SIZE];
+} radio_rx_message;
+
+KRadioStatus k_radio_init(void);
+void k_radio_terminate(void);
+KRadioStatus k_radio_configure(radio_config * config);
+KRadioStatus k_radio_reset(KRadioReset type);
+KRadioStatus k_radio_send(char * buffer, int len, uint8_t * response);
+KRadioStatus k_radio_recv(radio_rx_message * buffer, uint8_t * len);

--- a/services/communication-service/libs/trxvu.lua
+++ b/services/communication-service/libs/trxvu.lua
@@ -1,0 +1,131 @@
+local ffi = require 'ffi'
+
+ffi.cdef((module:load("./trxvu.h")))
+local K = ffi.load("/home/system/usr/lib/libtrxvu.so")
+
+local rate_table = {
+  [1200] = K.RADIO_TX_RATE_1200,
+  [2400] = K.RADIO_TX_RATE_2400,
+  [4800] = K.RADIO_TX_RATE_4800,
+  [9600] = K.RADIO_TX_RATE_9600,
+}
+
+local idle_table = {
+  [false] = K.RADIO_IDLE_OFF,
+  [true]  = K.RADIO_IDLE_ON,
+}
+
+local reset_table = {
+  hard = K.RADIO_HARD_RESET,
+  soft = K.RADIO_SOFT_RESET
+}
+
+local function check_status(status, value, empty)
+  if status == K.RADIO_OK then
+    return value or 1
+  end
+  if status == K.RADIO_RX_EMPTY then
+    return empty or 0
+  end
+  if status == K.RADIO_ERROR then
+    return nil, "RADIO_ERROR"
+  end
+  if status == K.RADIO_ERROR_CONFIG then
+    return nil, "RADIO_ERROR_CONFIG"
+  end
+end
+
+-- handle to prevent gc of latest msg value
+local beacon_msg
+
+local function radio_init()
+  return check_status(K.k_radio_init())
+end
+
+local function radio_terminate()
+  return K.k_radio_terminate()
+end
+
+local function radio_configure(options)
+  local config = ffi.new("radio_config")
+
+  config.data_rate = assert(
+    rate_table[options.data_rate],
+    "Invalid `data_rate` (must be 1200, 2400, 4800, or 9600)"
+  )
+
+  config.idle = assert(
+    idle_table[options.idle] or options.idle == nil and K.RADIO_IDLE_UNKNOWN,
+    "Invalid `idle` (must be true, false or nil)"
+  )
+
+  local beacon = assert(options.beacon, "Missing `beacon` option")
+  assert(type(beacon) == 'table', "`beacon` must be table")
+  local interval = assert(beacon.interval, "Missing `beacon.interval`")
+  assert(type(interval) == 'number', "`beacon.interval` must be number")
+  local msg = assert(beacon.msg, "Missing `beacon.msg`")
+  assert(type(msg) == 'string', '`beacon.msg` must be number')
+  local len = #msg
+  beacon_msg = ffi.new("char[?]", len, msg)
+  config.beacon.interval = interval
+  config.beacon.msg = beacon_msg
+  config.beacon.len = #msg
+
+  local to = options.to
+  assert(type(to) == 'table', '`to` must be table')
+  local ascii = assert(to.ascii, 'Missing `to.ascii`')
+  assert(type(ascii) == 'string', '`to.ascii` must be string')
+  local ssid = assert(to.ssid, 'Missing `to.ssid`')
+  assert(type(ssid) == 'number', '`to.ssid` must be number')
+  ffi.copy(config.to.ascii, ascii, 6)
+  config.to.ssid = ssid
+
+  local from = options.from
+  assert(type(from) == 'table', '`from` must be table')
+  ascii = assert(from.ascii, 'Missing `from.ascii`')
+  assert(type(ascii) == 'string', '`from.ascii` must be string')
+  ssid = assert(from.ssid, 'Missing `from.ssid`')
+  assert(type(ssid) == 'number', '`from.ssid` must be number')
+  ffi.copy(config.from.ascii, ascii, 6)
+  config.from.ssid = ssid
+
+  return check_status(K.k_radio_configure(config))
+end
+
+local function radio_reset(type)
+  local ktype = assert(reset_table[type], "type must be 'hard' or 'soft'")
+  return check_status(K.k_radio_reset(ktype))
+end
+
+local function radio_recv()
+  local buffer = ffi.new 'radio_rx_message'
+  local len = ffi.new 'uint8_t[1]'
+  local status = K.k_radio_recv(buffer, len)
+  local result
+  if status == K.RADIO_OK then
+    result = {
+      doppler = buffer.doppler_offset,
+      strength = buffer.signal_strength,
+      msg = ffi.string(buffer.message, buffer.msg_size),
+    }
+  end
+
+  return check_status(status, result, {})
+end
+
+local function radio_send(data)
+  local len = #data
+  local buffer = ffi.new('char[?]', len, data)
+  local response = ffi.new 'uint8_t[1]'
+  local status = K.k_radio_send(buffer, len, response)
+  return check_status(status, response[0])
+end
+
+return {
+  init = radio_init,
+  terminate = radio_terminate,
+  configure = radio_configure,
+  reset = radio_reset,
+  send = radio_send,
+  recv = radio_recv
+}


### PR DESCRIPTION
The flight side of this depends on the C library being built as a `.so` file and is consumed using luajit ffi.  The ground side speaks the kiss+ax25 protocol over tcp.