### PR TITLE
Force downgrade pip to <v10

### DIFF
--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get install -y unzip wget
 
 #do the pip setup and installation things
 RUN easy_install pip
-RUN pip install --upgrade pip
+# Need to install pip<v10 due to this issue: https://github.com/ARMmbed/yotta/issues/835
+# Forcibly controlling version until this is resolved
+RUN pip install pip==9.0.3
 
 #Kubos Linux setup
 RUN echo "Installing Kubos Linux Toolchain"


### PR DESCRIPTION
There's a dependency incompatibility issue which causes the `RUN pip install -r https://raw.githubusercontent.com/kubos/kubos-cli/master/requirements.txt` command to fail: https://github.com/ARMmbed/yotta/issues/835
Forcing the pip install to remain at v9 until the issue is resolved