### PR TITLE
Rust UART HAL Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,8 +588,9 @@ dependencies = [
 
 [[package]]
 name = "rust-uart"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "failure 1.0.0 (git+https://github.com/rust-lang-nursery/failure)",
  "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/hal/rust-hal/rust-uart/Cargo.toml
+++ b/hal/rust-hal/rust-uart/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rust-uart"
-version = "0.1.0"
-authors = ["William Greer <wgreer184@gmail.com>"]
+version = "0.2.0"
+authors = ["William Greer <wgreer184@gmail.com>", "Catherine Garabedian <catherine@kubos.co>"]
 
 [dependencies]
 serial = "0.4.0"
+failure = { git = "https://github.com/rust-lang-nursery/failure" }

--- a/hal/rust-hal/rust-uart/src/error.rs
+++ b/hal/rust-hal/rust-uart/src/error.rs
@@ -1,0 +1,63 @@
+//
+// Copyright (C) 2018 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::error::Error;
+use super::*;
+
+/// Custom errors for UART actions
+#[derive(Fail, Display, Debug, Clone, PartialEq)]
+pub enum UartError {
+    /// Catch-all error case
+    #[display(fmt = "Generic Error")]
+    GenericError,
+    #[display(fmt = "Serial Error: {}", description)]
+    /// An error was thrown by the serial driver
+    SerialError {
+        /// The underlying error type
+        cause: serial::ErrorKind,
+        /// Error description
+        description: String,
+    },
+    #[display(fmt = "IO Error: {}", description)]
+    /// An I/O error was thrown by the kernel
+    IoError {
+        /// The underlying error type
+        cause: std::io::ErrorKind,
+        /// Error description
+        description: String,
+    },
+}
+
+impl From<std::io::Error> for UartError {
+    fn from(error: std::io::Error) -> Self {
+        UartError::IoError {
+            cause: error.kind(),
+            description: error.description().to_owned(),
+        }
+    }
+}
+
+impl From<serial::Error> for UartError {
+    fn from(error: serial::Error) -> Self {
+        UartError::SerialError {
+            cause: error.kind(),
+            description: error.description().to_owned(),
+        }
+    }
+}
+
+/// Errors that occur while reading from and writing to stream
+pub type UartResult<T> = Result<T, UartError>;

--- a/hal/rust-hal/rust-uart/src/error.rs
+++ b/hal/rust-hal/rust-uart/src/error.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-use std::error::Error;
 use super::*;
+use std::error::Error;
 
 /// Custom errors for UART actions
 #[derive(Fail, Display, Debug, Clone, PartialEq)]

--- a/hal/rust-hal/rust-uart/src/error.rs
+++ b/hal/rust-hal/rust-uart/src/error.rs
@@ -23,19 +23,22 @@ pub enum UartError {
     /// Catch-all error case
     #[display(fmt = "Generic Error")]
     GenericError,
-    #[display(fmt = "Serial Error: {}", description)]
-    /// An error was thrown by the serial driver
-    SerialError {
-        /// The underlying error type
-        cause: serial::ErrorKind,
-        /// Error description
-        description: String,
-    },
-    #[display(fmt = "IO Error: {}", description)]
+    /// A read/write call was made while another call was already in-progress
+    #[display(fmt = "Serial port already in-use")]
+    PortBusy,
     /// An I/O error was thrown by the kernel
+    #[display(fmt = "IO Error: {}", description)]
     IoError {
         /// The underlying error type
         cause: std::io::ErrorKind,
+        /// Error description
+        description: String,
+    },
+    /// An error was thrown by the serial driver
+    #[display(fmt = "Serial Error: {}", description)]
+    SerialError {
+        /// The underlying error type
+        cause: serial::ErrorKind,
         /// Error description
         description: String,
     },

--- a/hal/rust-hal/rust-uart/src/lib.rs
+++ b/hal/rust-hal/rust-uart/src/lib.rs
@@ -21,66 +21,22 @@
 extern crate failure;
 extern crate serial;
 
+mod error;
 pub mod mock;
 #[cfg(test)]
 mod tests;
 
+use error::*;
 use std::io::prelude::*;
 use serial::prelude::*;
 use std::time::Duration;
 use std::cell::RefCell;
-use std::error::Error;
 
 /// Wrapper for UART stream
 pub struct Connection {
     /// Any boxed stream that allows for communication over serial ports
     pub stream: Box<Stream>,
 }
-
-/// Custom errors for UART actions
-#[derive(Fail, Display, Debug, Clone, PartialEq)]
-pub enum UartError {
-    /// Catch-all error case
-    #[display(fmt = "Generic Error")]
-    GenericError,
-    #[display(fmt = "Serial Error: {}", description)]
-    /// An error was thrown by the serial driver
-    SerialError {
-        /// The underlying error type
-        cause: serial::ErrorKind,
-        /// Error description
-        description: String,
-    },
-    #[display(fmt = "IO Error: {}", description)]
-    /// An I/O error was thrown by the kernel
-    IoError {
-        /// The underlying error type
-        cause: std::io::ErrorKind,
-        /// Error description
-        description: String,
-    },
-}
-
-impl From<std::io::Error> for UartError {
-    fn from(error: std::io::Error) -> Self {
-        UartError::IoError {
-            cause: error.kind(),
-            description: error.description().to_owned(),
-        }
-    }
-}
-
-impl From<serial::Error> for UartError {
-    fn from(error: serial::Error) -> Self {
-        UartError::SerialError {
-            cause: error.kind(),
-            description: error.description().to_owned(),
-        }
-    }
-}
-
-/// Errors that occur while reading from and writing to stream
-pub type UartResult<T> = Result<T, UartError>;
 
 impl Connection {
     /// Constructor to creation connection with provided stream

--- a/hal/rust-hal/rust-uart/src/lib.rs
+++ b/hal/rust-hal/rust-uart/src/lib.rs
@@ -26,7 +26,7 @@ pub mod mock;
 #[cfg(test)]
 mod tests;
 
-use error::*;
+pub use error::*;
 use serial::prelude::*;
 use std::cell::RefCell;
 use std::io::prelude::*;

--- a/hal/rust-hal/rust-uart/src/lib.rs
+++ b/hal/rust-hal/rust-uart/src/lib.rs
@@ -97,7 +97,7 @@ impl SerialStream {
 // Read and write implementations for the serial stream
 impl Stream for SerialStream {
     fn write(&self, data: &[u8]) -> UartResult<()> {
-        let mut port = self.port.try_borrow_mut().unwrap();
+        let mut port = self.port.try_borrow_mut().map_err(|_| UartError::PortBusy)?;
         port.set_timeout(self.timeout)?;
 
         port.write_all(data)?;
@@ -106,7 +106,7 @@ impl Stream for SerialStream {
     }
 
     fn read(&self, len: usize, timeout: Duration) -> UartResult<Vec<u8>> {
-        let mut port = self.port.try_borrow_mut().unwrap();
+        let mut port = self.port.try_borrow_mut().map_err(|_| UartError::PortBusy)?;
 
         port.set_timeout(timeout)?;
 

--- a/hal/rust-hal/rust-uart/src/lib.rs
+++ b/hal/rust-hal/rust-uart/src/lib.rs
@@ -1,10 +1,35 @@
+//
+// Copyright (C) 2018 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 #![deny(missing_docs)]
 
 //! A generalized HAL for communicating over serial ports
+#[macro_use]
+extern crate failure;
 extern crate serial;
+
+pub mod mock;
+#[cfg(test)]
+mod tests;
 
 use std::io::prelude::*;
 use serial::prelude::*;
+use std::time::Duration;
+use std::cell::RefCell;
+use std::error::Error;
 
 /// Wrapper for UART stream
 pub struct Connection {
@@ -12,8 +37,50 @@ pub struct Connection {
     pub stream: Box<Stream>,
 }
 
+/// Custom errors for UART actions
+#[derive(Fail, Display, Debug, Clone, PartialEq)]
+pub enum UartError {
+    /// Catch-all error case
+    #[display(fmt = "Generic Error")]
+    GenericError,
+    #[display(fmt = "Serial Error: {}", description)]
+    /// An error was thrown by the serial driver
+    SerialError {
+        /// The underlying error type
+        cause: serial::ErrorKind,
+        /// Error description
+        description: String,
+    },
+    #[display(fmt = "IO Error: {}", description)]
+    /// An I/O error was thrown by the kernel
+    IoError {
+        /// The underlying error type
+        cause: std::io::ErrorKind,
+        /// Error description
+        description: String,
+    },
+}
+
+impl From<std::io::Error> for UartError {
+    fn from(error: std::io::Error) -> Self {
+        UartError::IoError {
+            cause: error.kind(),
+            description: error.description().to_owned(),
+        }
+    }
+}
+
+impl From<serial::Error> for UartError {
+    fn from(error: serial::Error) -> Self {
+        UartError::SerialError {
+            cause: error.kind(),
+            description: error.description().to_owned(),
+        }
+    }
+}
+
 /// Errors that occur while reading from and writing to stream
-pub type UartResult<T> = Result<T, std::io::Error>;
+pub type UartResult<T> = Result<T, UartError>;
 
 impl Connection {
     /// Constructor to creation connection with provided stream
@@ -22,19 +89,14 @@ impl Connection {
     }
 
     /// Convenience constructor to create connection from bus path
-    pub fn from_path(bus: String) -> Connection {
-        Connection {
-            stream: Box::new(SerialStream {
-                bus,
-                settings: serial::PortSettings {
-                    baud_rate: serial::Baud115200,
-                    char_size: serial::Bits8,
-                    parity: serial::ParityNone,
-                    stop_bits: serial::Stop1,
-                    flow_control: serial::FlowNone,
-                },
-            }),
-        }
+    pub fn from_path(
+        bus: &str,
+        settings: serial::PortSettings,
+        timeout: Duration,
+    ) -> UartResult<Connection> {
+        Ok(Connection {
+            stream: Box::new(SerialStream::new(bus, settings, timeout)?),
+        })
     }
 
     /// Writes out raw bytes to the stream
@@ -43,42 +105,54 @@ impl Connection {
     }
 
     /// Reads messages upto specified length recieved on the bus
-    pub fn read(&self, len: usize) -> UartResult<Vec<u8>> {
-        self.stream.read(len)
+    pub fn read(&self, len: usize, timeout: Duration) -> UartResult<Vec<u8>> {
+        self.stream.read(len, timeout)
     }
 }
 
 /// This trait is used to represent streams and allows for mocking for api unit tests
-pub trait Stream {
+pub trait Stream: Send {
     /// Write raw bytes to stream
     fn write(&self, data: &[u8]) -> UartResult<()>;
 
     /// Read upto a specified amount of raw bytes from the stream
-    fn read(&self, len: usize) -> UartResult<Vec<u8>>;
+    fn read(&self, len: usize, timeout: Duration) -> UartResult<Vec<u8>>;
 }
 
 // This is the actual stream that data is tranferred over
 struct SerialStream {
-    bus: String,
-    settings: serial::PortSettings,
+    port: RefCell<serial::SystemPort>,
+    timeout: Duration,
+}
+
+impl SerialStream {
+    fn new(bus: &str, settings: serial::PortSettings, timeout: Duration) -> UartResult<Self> {
+        let mut port = serial::open(bus)?;
+
+        port.configure(&settings)?;
+
+        Ok(SerialStream {
+            port: RefCell::new(port),
+            timeout,
+        })
+    }
 }
 
 // Read and write implementations for the serial stream
 impl Stream for SerialStream {
     fn write(&self, data: &[u8]) -> UartResult<()> {
-        let mut port = serial::open(self.bus.as_str())?;
-
-        port.configure(&self.settings)?;
+        let mut port = self.port.try_borrow_mut().unwrap();
+        port.set_timeout(self.timeout)?;
 
         port.write_all(data)?;
 
         Ok(())
     }
 
-    fn read(&self, len: usize) -> UartResult<Vec<u8>> {
-        let mut port = serial::open(self.bus.as_str())?;
+    fn read(&self, len: usize, timeout: Duration) -> UartResult<Vec<u8>> {
+        let mut port = self.port.try_borrow_mut().unwrap();
 
-        port.configure(&self.settings)?;
+        port.set_timeout(timeout)?;
 
         let mut response: Vec<u8> = vec![0; len];
 

--- a/hal/rust-hal/rust-uart/src/lib.rs
+++ b/hal/rust-hal/rust-uart/src/lib.rs
@@ -27,10 +27,10 @@ pub mod mock;
 mod tests;
 
 use error::*;
-use std::io::prelude::*;
 use serial::prelude::*;
-use std::time::Duration;
 use std::cell::RefCell;
+use std::io::prelude::*;
+use std::time::Duration;
 
 /// Wrapper for UART stream
 pub struct Connection {

--- a/hal/rust-hal/rust-uart/src/mock.rs
+++ b/hal/rust-hal/rust-uart/src/mock.rs
@@ -1,0 +1,240 @@
+//
+// Copyright (C) 2018 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Mock objects for use with unit tests
+//!
+//! Note: This module was created because the crate we previously used for mocking
+//! functions, [Double](https://github.com/DonaldWhyte/double), was written specifically
+//! for single-threaded code. Our APIs and services which utilize this crate are not
+//! guaranteed to be single-threaded, so we made the decision to create our own mock objects.
+
+use super::*;
+use std::io::Cursor;
+
+/// Structure containing the input data to verify and/or result to return
+/// when the MockStream's write function is called
+pub struct WriteStruct {
+    input: Option<Vec<u8>>,
+    result: UartResult<()>,
+}
+
+impl WriteStruct {
+    /// Set the result to be returned for any write() calls
+    ///
+    /// Note: This will be ignored if set_input is also used
+    ///
+    /// # Arguments
+    ///
+    /// * result - The UartResult to return in future write() calls
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_uart::*;
+    /// use rust_uart::mock::*;
+    ///
+    /// fn test_write_error() {
+    ///     let mut mock = MockStream::default();
+    ///
+    ///     mock.write
+    ///         .set_result(Err(UartError::GenericError.into()));
+    ///
+    ///     let connection = Connection {
+    ///         stream: Box::new(mock),
+    ///     };
+    ///
+    ///     let packet: [u8; 40] = [0; 40];
+    ///
+    ///     assert_eq!(
+    ///         connection.write(&packet).unwrap_err(),
+    ///         UartError::GenericError
+    ///     );
+    /// }
+    /// ```
+    pub fn set_result(&mut self, result: UartResult<()>) {
+        self.result = result;
+    }
+
+    /// Set the input to validate for any write() calls
+    ///
+    /// # Arguments
+    ///
+    /// * input - The input data expected from write() calls
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_uart::*;
+    /// use rust_uart::mock::*;
+    ///
+    /// fn test_write_good() {
+    ///     let mut mock = MockStream::default();
+    ///
+    ///     mock.write.set_input(vec![0, 1, 2, 3]);
+    ///
+    ///     let connection = Connection {
+    ///         stream: Box::new(mock),
+    ///     };
+    ///
+    ///     let packet: [u8; 4] = [0, 1, 2, 3];
+    ///
+    ///     assert_eq!(connection.write(&packet), Ok(()));
+    /// }
+    /// ```
+    pub fn set_input(&mut self, input: Vec<u8>) {
+        self.input = Some(input)
+    }
+}
+
+/// Structure containing the output data or result to return
+/// when the MockStream's read function is called
+pub struct ReadStruct {
+    output: Option<RefCell<Cursor<Vec<u8>>>>,
+    result: UartResult<Vec<u8>>,
+}
+
+impl ReadStruct {
+    /// Set the result to be returned for any read() calls
+    ///
+    /// Note: This will be ignored if set_output is also used
+    ///
+    /// # Arguments
+    ///
+    /// * result - The UartResult to return in future read() calls
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_uart::*;
+    /// use rust_uart::mock::*;
+    /// use std::time::Duration;
+    ///
+    /// fn test_read_error_io() {
+    ///     let mut mock = MockStream::default();
+    ///
+    ///     mock.read
+    ///         .set_result(Err(UartError::GenericError.into()));
+    ///
+    ///     let connection = Connection {
+    ///         stream: Box::new(mock),
+    ///     };
+    ///
+    ///     assert_eq!(
+    ///         connection.read(5, Duration::new(0, 0)).unwrap_err(),
+    ///         UartError::GenericError
+    ///     );
+    /// }
+    /// ```
+    pub fn set_result(&mut self, result: UartResult<Vec<u8>>) {
+        self.result = result;
+    }
+
+    /// Set the output data
+    ///
+    /// # Arguments
+    ///
+    /// * output - The output buffer which future read() calls should
+    ///            retrieve data from
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_uart::*;
+    /// use rust_uart::mock::*;
+    /// use std::time::Duration;
+    ///
+    /// fn test_read_good_multi() {
+    ///     let mut mock = MockStream::default();
+    ///
+    ///     let expected = vec![0, 1, 2, 3, 4, 5];
+    ///
+    ///     mock.read.set_output(expected.clone());
+    ///
+    ///     let connection = Connection {
+    ///         stream: Box::new(mock),
+    ///     };
+    ///
+    ///     assert_eq!(
+    ///         connection.read(3, Duration::new(0, 0)).unwrap(),
+    ///         vec![0, 1, 2]
+    ///     );
+    ///     assert_eq!(
+    ///         connection.read(3, Duration::new(0, 0)).unwrap(),
+    ///         vec![3, 4, 5]
+    ///     );
+    /// }
+    /// ```
+    pub fn set_output(&mut self, output: Vec<u8>) {
+        self.output = Some(RefCell::new(Cursor::new(output)))
+    }
+}
+
+/// Mock object for simulating a UART data stream
+pub struct MockStream {
+    /// Information to use when write() calls are made
+    pub write: WriteStruct,
+    /// Information to use when read() calls are made
+    pub read: ReadStruct,
+}
+
+impl Default for MockStream {
+    fn default() -> Self {
+        MockStream {
+            write: WriteStruct {
+                result: Err(UartError::GenericError.into()),
+                input: None,
+            },
+            read: ReadStruct {
+                result: Err(UartError::GenericError.into()),
+                output: None,
+            },
+        }
+    }
+}
+
+impl Stream for MockStream {
+    fn write(&self, data: &[u8]) -> UartResult<()> {
+        if let Some(ref input) = self.write.input {
+            //Verify input matches data
+            assert_eq!(input.as_slice(), data);
+            Ok(())
+        } else {
+            self.write.result.clone()
+        }
+    }
+
+    fn read(&self, len: usize, _timeout: Duration) -> UartResult<Vec<u8>> {
+        if let Some(ref output) = self.read.output {
+            let mut response: Vec<u8> = vec![0; len];
+
+            match output.borrow_mut().read_exact(response.as_mut_slice()) {
+                Ok(_) => Ok(response),
+                Err(_) => {
+                    // Our buffer will throw an EOF error when it's empty,
+                    // but, in reality, our UART stream would throw a timeout
+                    // error when it was unable to read the requested number of
+                    // bytes within the timeout period
+                    Err(UartError::from(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "Operation timed out",
+                    )))
+                }
+            }
+        } else {
+            self.read.result.clone()
+        }
+    }
+}

--- a/hal/rust-hal/rust-uart/src/tests.rs
+++ b/hal/rust-hal/rust-uart/src/tests.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-use mock::*;
 use super::*;
+use mock::*;
 use std::time::Duration;
 
 #[test]

--- a/hal/rust-hal/rust-uart/src/tests.rs
+++ b/hal/rust-hal/rust-uart/src/tests.rs
@@ -1,0 +1,244 @@
+//
+// Copyright (C) 2018 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use mock::*;
+use super::*;
+use std::time::Duration;
+
+#[test]
+fn mock_test() {
+    let mock = MockStream::default();
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    let packet: [u8; 40] = [0; 40];
+
+    assert_eq!(
+        connection.write(&packet).unwrap_err(),
+        UartError::GenericError
+    );
+}
+
+#[test]
+fn test_write_error_io() {
+    let mut mock = MockStream::default();
+
+    mock.write
+        .set_result(Err(UartError::from(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "Operation timed out",
+        ))));
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    let packet: [u8; 40] = [0; 40];
+
+    assert_eq!(
+        connection.write(&packet).unwrap_err(),
+        UartError::IoError {
+            cause: std::io::ErrorKind::TimedOut,
+            description: "Operation timed out".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_write_error_serial() {
+    let mut mock = MockStream::default();
+
+    mock.write
+        .set_result(Err(UartError::from(serial::Error::new(
+            serial::ErrorKind::NoDevice,
+            "Device unavailable",
+        ))));
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    let packet: [u8; 40] = [0; 40];
+
+    assert_eq!(
+        connection.write(&packet).unwrap_err(),
+        UartError::SerialError {
+            cause: serial::ErrorKind::NoDevice,
+            description: "Device unavailable".to_owned(),
+        }
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_write_bad_input() {
+    let mut mock = MockStream::default();
+
+    mock.write.set_input([0, 1, 2, 3].to_vec());
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    let packet: [u8; 40] = [0; 40];
+
+    // This will fail under the covers because the passed input argument
+    // doesn't match what we said we were expecting
+    let _result = connection.write(&packet);
+}
+
+#[test]
+fn test_write_good() {
+    let mut mock = MockStream::default();
+
+    mock.write.set_input(vec![0, 1, 2, 3]);
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    let packet: [u8; 4] = [0, 1, 2, 3];
+
+    assert_eq!(connection.write(&packet), Ok(()));
+}
+
+#[test]
+fn test_read_error_io() {
+    let mut mock = MockStream::default();
+
+    mock.read
+        .set_result(Err(UartError::from(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "Operation timed out",
+        ))));
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    assert_eq!(
+        connection.read(5, Duration::new(0, 0)).unwrap_err(),
+        UartError::IoError {
+            cause: std::io::ErrorKind::TimedOut,
+            description: "Operation timed out".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_read_error_serial() {
+    let mut mock = MockStream::default();
+
+    mock.read.set_result(Err(UartError::from(serial::Error::new(
+        serial::ErrorKind::NoDevice,
+        "Device unavailable",
+    ))));
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    assert_eq!(
+        connection.read(5, Duration::new(0, 0)).unwrap_err(),
+        UartError::SerialError {
+            cause: serial::ErrorKind::NoDevice,
+            description: "Device unavailable".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_read_bad_len() {
+    let mut mock = MockStream::default();
+
+    let expected = vec![0, 1, 2, 3, 4, 5];
+
+    mock.read.set_output(expected.clone());
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    // Explicitly setting the read to be one byte short
+    let result = connection.read(5, Duration::new(0, 0));
+
+    assert!(result.is_ok());
+    assert_ne!(result.unwrap(), expected);
+}
+
+#[test]
+fn test_read_bad_multi() {
+    let mut mock = MockStream::default();
+
+    let expected = vec![0, 1, 2, 3, 4, 5];
+
+    mock.read.set_output(expected.clone());
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    assert_eq!(
+        connection.read(3, Duration::new(0, 0)).unwrap(),
+        vec![0, 1, 2]
+    );
+    assert_eq!(
+        connection.read(4, Duration::new(0, 0)).unwrap_err(),
+        UartError::IoError {
+            cause: std::io::ErrorKind::TimedOut,
+            description: "Operation timed out".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_read_good_single() {
+    let mut mock = MockStream::default();
+
+    let expected = vec![0, 1, 2, 3, 4, 5];
+
+    mock.read.set_output(expected.clone());
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    assert_eq!(connection.read(6, Duration::new(0, 0)).unwrap(), expected);
+}
+
+#[test]
+fn test_read_good_multi() {
+    let mut mock = MockStream::default();
+
+    let expected = vec![0, 1, 2, 3, 4, 5];
+
+    mock.read.set_output(expected.clone());
+
+    let connection = Connection {
+        stream: Box::new(mock),
+    };
+
+    assert_eq!(
+        connection.read(3, Duration::new(0, 0)).unwrap(),
+        vec![0, 1, 2]
+    );
+    assert_eq!(
+        connection.read(3, Duration::new(0, 0)).unwrap(),
+        vec![3, 4, 5]
+    );
+}


### PR DESCRIPTION
This PR adds a few features which I found that I needed while working on the NovAtel OEM6 API in kubos#74:

- Updated `Connection::from_path` to have two new parameters: settings and timeout.
- [Failure](https://github.com/rust-lang-nursery/failure) is our error-handling crate-of-choice, so converted the current error type into a Failure error type
- Changed the code to open the connection to the serial port once, during the `SerialStream::new()` call, rather than during each `write()` and `read()` call, so that messages which require multiple read calls (ex. where we need to read a header to then get the length of the whole message) will work
- Tweaked the `read` calls to add a timeout parameter. There's currently no way to do an indefinite `read` call with the [serial crate](https://github.com/dcuddeback/serial-rs), so my intent with this is to set a longer timeout (ex. one second) for reads which need to wait for data to come in, but then make the timeout short (ex. 50 milliseconds) for reads which should return almost instantly. This is especially useful for multi-part reads, where I want to wait for a message, read only the header, then read the message body.
- Marked the `Stream` trait as `Send` compatible, so that we can use a stream in multi-threaded code (note: doing this properly requires the use of a mutex, but that burden will be placed on the caller since this library isn't inherently multi-threaded)
- Created `MockStream` so that we can create unit tests. We were using [Double](https://github.com/DonaldWhyte/double), but that isn't multi-thread compatible (they use `Rc`s :disappointed:)