### PR TITLE
OEM6 Service: Phase 4

### DIFF
--- a/apis/novatel-oem6-api/src/lib.rs
+++ b/apis/novatel-oem6-api/src/lib.rs
@@ -65,6 +65,7 @@
 //Need a higher recursion limit for nom when parsing larger (>60 bytes) structures
 #![recursion_limit = "256"]
 
+#[macro_use]
 extern crate bitflags;
 extern crate byteorder;
 #[macro_use]
@@ -83,6 +84,7 @@ mod tests;
 pub use messages::MessageID;
 pub use messages::commands::ResponseID;
 pub use messages::logs::*;
+pub use messages::ReceiverStatusFlags;
 pub use oem6::*;
 pub use rust_uart::{mock, Connection, UartError};
 pub use serial::BaudRate;

--- a/apis/novatel-oem6-api/src/messages/logs/best_xyz.rs
+++ b/apis/novatel-oem6-api/src/messages/logs/best_xyz.rs
@@ -15,10 +15,13 @@
 //
 
 use nom::*;
+use super::*;
 
 /// Log message containing position information
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct BestXYZLog {
+    /// Current status of receiver
+    pub recv_status: ReceiverStatusFlags,
     /// Validity of the time information
     pub time_status: u8,
     /// GPS reference week
@@ -67,12 +70,19 @@ pub struct BestXYZLog {
 
 impl BestXYZLog {
     /// Convert a raw data buffer into a useable struct
-    pub fn new(time_status: u8, week: u16, ms: i32, raw: Vec<u8>) -> Option<Self> {
+    pub fn new(
+        recv_status: ReceiverStatusFlags,
+        time_status: u8,
+        week: u16,
+        ms: i32,
+        raw: Vec<u8>,
+    ) -> Option<Self> {
         let mut log = match parse_bestxyz(&raw) {
             Ok(conv) => conv.1,
             _ => return None,
         };
 
+        log.recv_status = recv_status;
         log.time_status = time_status;
         log.week = week;
         log.ms = ms;
@@ -112,6 +122,7 @@ named!(parse_bestxyz(&[u8]) -> BestXYZLog,
         gal_beidou_sig: le_u8 >>
         gps_glonass_sig: le_u8 >>
         (BestXYZLog {
+            recv_status: ReceiverStatusFlags::empty(),
             time_status: 0,
             week: 0,
             ms: 0,

--- a/apis/novatel-oem6-api/src/messages/logs/mod.rs
+++ b/apis/novatel-oem6-api/src/messages/logs/mod.rs
@@ -36,17 +36,26 @@ pub enum Log {
 
 impl Log {
     /// Convert a raw data buffer into a useable struct
-    pub fn new(id: MessageID, time_status: u8, week: u16, ms: i32, raw: Vec<u8>) -> Option<Log> {
+    pub fn new(
+        id: MessageID,
+        recv_status: ReceiverStatusFlags,
+        time_status: u8,
+        week: u16,
+        ms: i32,
+        raw: Vec<u8>,
+    ) -> Option<Log> {
         match id {
-            MessageID::BestXYZ => match BestXYZLog::new(time_status, week, ms, raw) {
+            MessageID::BestXYZ => match BestXYZLog::new(recv_status, time_status, week, ms, raw) {
                 Some(log) => Some(Log::BestXYZ(log)),
                 _ => None,
             },
-            MessageID::RxStatusEvent => match RxStatusEventLog::new(raw) {
-                Some(log) => Some(Log::RxStatusEvent(log)),
-                _ => None,
-            },
-            MessageID::Version => match VersionLog::new(raw) {
+            MessageID::RxStatusEvent => {
+                match RxStatusEventLog::new(recv_status, time_status, week, ms, raw) {
+                    Some(log) => Some(Log::RxStatusEvent(log)),
+                    _ => None,
+                }
+            }
+            MessageID::Version => match VersionLog::new(recv_status, time_status, week, ms, raw) {
                 Some(log) => Some(Log::Version(log)),
                 _ => None,
             },

--- a/apis/novatel-oem6-api/src/messages/logs/rxstatusevent.rs
+++ b/apis/novatel-oem6-api/src/messages/logs/rxstatusevent.rs
@@ -15,10 +15,19 @@
 //
 
 use nom::*;
+use super::*;
 
 /// Event/error log message
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct RxStatusEventLog {
+    /// Current status of receiver
+    pub recv_status: ReceiverStatusFlags,
+    /// Validity of the time information
+    pub time_status: u8,
+    /// GPS reference week
+    pub week: u16,
+    /// Milliseconds into GPS reference week
+    pub ms: i32,
     /// Status word which generated the event
     pub word: u32,
     /// Location of the bit in the status word
@@ -31,11 +40,24 @@ pub struct RxStatusEventLog {
 
 impl RxStatusEventLog {
     /// Convert a raw data buffer into a useable struct
-    pub fn new(raw: Vec<u8>) -> Option<Self> {
-        match parse_rxstatusevent(&raw) {
-            Ok(conv) => Some(conv.1),
-            _ => None,
-        }
+    pub fn new(
+        recv_status: ReceiverStatusFlags,
+        time_status: u8,
+        week: u16,
+        ms: i32,
+        raw: Vec<u8>,
+    ) -> Option<Self> {
+        let mut log = match parse_rxstatusevent(&raw) {
+            Ok(conv) => conv.1,
+            _ => return None,
+        };
+
+        log.recv_status = recv_status;
+        log.time_status = time_status;
+        log.week = week;
+        log.ms = ms;
+
+        Some(log)
     }
 }
 
@@ -46,6 +68,10 @@ named!(parse_rxstatusevent(&[u8]) -> RxStatusEventLog,
         event: le_u32 >>
         description: take!(32) >>
         (RxStatusEventLog {
+            recv_status: ReceiverStatusFlags::empty(),
+            time_status: 0,
+            week: 0,
+            ms: 0,
             word,
             bit,
             event,

--- a/apis/novatel-oem6-api/src/messages/logs/version.rs
+++ b/apis/novatel-oem6-api/src/messages/logs/version.rs
@@ -15,12 +15,21 @@
 //
 
 use nom::*;
+use super::*;
 
 const COMPONENT_SIZE: usize = 108;
 
 /// Log message containing version information
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct VersionLog {
+    /// Current status of receiver
+    pub recv_status: ReceiverStatusFlags,
+    /// Validity of the time information
+    pub time_status: u8,
+    /// GPS reference week
+    pub week: u16,
+    /// Milliseconds into GPS reference week
+    pub ms: i32,
     /// Number of components present in this structure
     pub num_components: u32,
     /// Version information for each component present in the system
@@ -29,10 +38,20 @@ pub struct VersionLog {
 
 impl VersionLog {
     /// Convert a raw data buffer into a useable struct
-    pub fn new(mut raw: Vec<u8>) -> Option<Self> {
+    pub fn new(
+        recv_status: ReceiverStatusFlags,
+        time_status: u8,
+        week: u16,
+        ms: i32,
+        mut raw: Vec<u8>,
+    ) -> Option<Self> {
         let raw_comp = raw.split_off(4);
 
         let mut log = VersionLog {
+            recv_status,
+            time_status,
+            week,
+            ms,
             num_components: {
                 match le_u32(&raw) {
                     Ok(v) => v.1,

--- a/apis/novatel-oem6-api/src/oem6.rs
+++ b/apis/novatel-oem6-api/src/oem6.rs
@@ -76,6 +76,9 @@ pub fn read_thread(
 
     loop {
         {
+            // Give any writes the chance to grab the lock first
+            ::std::thread::sleep(Duration::from_millis(1));
+
             // Take the stream connection mutex
             // If the lock() call fails, it means that a different thread poisoned
             // the mutex. We want to maintain our ability to read messages from the
@@ -85,7 +88,7 @@ pub fn read_thread(
             let conn = rx_conn.lock().unwrap_or_else(|err| err.into_inner());
 
             // Read SYNC bytes
-            let mut message = match conn.read(3, Duration::from_millis(500)) {
+            let mut message = match conn.read(3, Duration::from_millis(250)) {
                 Ok(v) => v,
                 Err(err) => match err {
                     #[cfg(test)]

--- a/apis/novatel-oem6-api/src/oem6.rs
+++ b/apis/novatel-oem6-api/src/oem6.rs
@@ -685,7 +685,14 @@ impl OEM6 {
                 continue;
             }
 
-            match Log::new(hdr.msg_id, hdr.time_status, hdr.week, hdr.ms, body) {
+            match Log::new(
+                hdr.msg_id,
+                hdr.recv_status,
+                hdr.time_status,
+                hdr.week,
+                hdr.ms,
+                body,
+            ) {
                 Some(v) => return Ok(v),
                 None => {
                     continue;

--- a/apis/novatel-oem6-api/src/tests/errors.rs
+++ b/apis/novatel-oem6-api/src/tests/errors.rs
@@ -15,6 +15,7 @@
 //
 
 use super::*;
+use messages::ReceiverStatusFlags;
 
 #[test]
 fn test_request_errors() {
@@ -76,6 +77,18 @@ fn test_get_error() {
     let oem = mock_new!(mock);
 
     let expected: Log = Log::RxStatusEvent(RxStatusEventLog {
+        recv_status: ReceiverStatusFlags::ANTENNA_NOT_POWERED
+            | ReceiverStatusFlags::ANTENNA_SHORTENED
+            | ReceiverStatusFlags::INS_RESET
+            | ReceiverStatusFlags::GPS_ALMANAC_INVALID
+            | ReceiverStatusFlags::CLOCK_STEERING_DISABLED
+            | ReceiverStatusFlags::CLOCK_MODEL_INVALID
+            | ReceiverStatusFlags::SOFTWARE_RESOURCE_WARNING
+            | ReceiverStatusFlags::AUX3_STATUS_EVENT
+            | ReceiverStatusFlags::AUX1_STATUS_EVENT,
+        time_status: 130,
+        week: 45230,
+        ms: 6230,
         word: 1,
         bit: 19,
         event: 1,

--- a/apis/novatel-oem6-api/src/tests/position.rs
+++ b/apis/novatel-oem6-api/src/tests/position.rs
@@ -15,6 +15,7 @@
 //
 
 use super::*;
+use messages::ReceiverStatusFlags;
 
 #[test]
 fn test_request_position_ontime() {
@@ -123,6 +124,8 @@ fn test_get_position() {
     let oem = mock_new!(mock);
 
     let expected: Log = Log::BestXYZ(BestXYZLog {
+        recv_status: ReceiverStatusFlags::CLOCK_MODEL_INVALID
+            | ReceiverStatusFlags::POSITION_SOLUTION_INVALID,
         time_status: 120,
         week: 3025,
         ms: 164195000,

--- a/apis/novatel-oem6-api/src/tests/version.rs
+++ b/apis/novatel-oem6-api/src/tests/version.rs
@@ -21,6 +21,7 @@
 
 use super::*;
 use messages::commands::ResponseID;
+use messages::ReceiverStatusFlags;
 
 #[test]
 fn test_request_version_good() {
@@ -131,6 +132,11 @@ fn test_get_version() {
     let oem = mock_new!(mock);
 
     let expected: Log = Log::Version(VersionLog {
+        recv_status: ReceiverStatusFlags::CLOCK_MODEL_INVALID
+            | ReceiverStatusFlags::POSITION_SOLUTION_INVALID,
+        time_status: 120,
+        week: 3025,
+        ms: 164191800,
         num_components: 1,
         components: vec![
             Component {

--- a/services/novatel-oem6-service/src/objects.rs
+++ b/services/novatel-oem6-service/src/objects.rs
@@ -339,6 +339,20 @@ graphql_object!(LockInfo: () | &self | {
     }
 });
 
+/// Response field for 'power' query
+#[derive(GraphQLEnum, Clone, Eq, PartialEq, Debug)]
+pub enum PowerState {
+    On,
+    Off,
+}
+
+/// Response fields for 'power' query
+#[derive(GraphQLObject)]
+pub struct GetPowerResponse {
+    pub state: PowerState,
+    pub uptime: i32,
+}
+
 pub struct SystemStatus {
     pub status: ReceiverStatusFlags,
     pub errors: Vec<String>,

--- a/services/novatel-oem6-service/src/objects.rs
+++ b/services/novatel-oem6-service/src/objects.rs
@@ -15,7 +15,7 @@
 //
 
 use juniper::FieldResult;
-use novatel_oem6_api::Component;
+use novatel_oem6_api::{Component, ReceiverStatusFlags};
 
 /// Common response fields structure for requests
 /// which don't return any specific data
@@ -336,6 +336,21 @@ graphql_object!(LockInfo: () | &self | {
 
     field velocity() -> FieldResult<Vec<f64>> {
         Ok(self.velocity.to_vec())
+    }
+});
+
+pub struct SystemStatus {
+    pub status: ReceiverStatusFlags,
+    pub errors: Vec<String>,
+}
+
+graphql_object!(SystemStatus: () | &self | {
+    field status() -> FieldResult<Vec<String>> {
+        Ok(self.status.to_vec())
+    }
+    
+    field errors() -> FieldResult<Vec<String>> {
+        Ok(self.errors.clone())
     }
 });
 

--- a/services/novatel-oem6-service/src/schema.rs
+++ b/services/novatel-oem6-service/src/schema.rs
@@ -69,9 +69,11 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
         }
     }
 
-    // Get the current power state and uptime of the system
+    // Get the current power state of the system
     //
-    // TODO: Figure out what to do with uptime. It isn't returned by the device at all...
+    // Note: `uptime` is included as an available field in order to conform to
+    //       the Kubos Service Outline, but cannot be implemented for this device,
+    //       so the value will be 1 if the device is on and 0 if the device is off
     //
     // {
     //     power {
@@ -79,9 +81,9 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
     //         uptime: Int
     //     }
     // }
-    field power(&executor) -> FieldResult<String>
+    field power(&executor) -> FieldResult<GetPowerResponse>
     {
-        Ok(String::from("Not Implemented"))
+        Ok(executor.context().subsystem().get_power()?)
     }
 
     // Get the current configuration of the system

--- a/services/novatel-oem6-service/src/schema.rs
+++ b/services/novatel-oem6-service/src/schema.rs
@@ -109,11 +109,15 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
         Ok(executor.context().subsystem().get_test_results()?)
     }
 
-    // TODO: Check for system errors
-    // Stretch goal: Implement RXSTATUS
-    field system_status(&executor) -> FieldResult<String>
+    // Get the current system status and errors
+    //
+    // systemStatus {
+    //    errors: Vec<String>,
+    //    status: Vec<String>
+    // }
+    field system_status(&executor) -> FieldResult<SystemStatus>
     {
-        Ok(String::from("Not Implemented"))
+        Ok(executor.context().subsystem().get_system_status()?)
     }
 
     // Get current status of position information gathering

--- a/services/novatel-oem6-service/src/tests/schema/mutations/noop.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mutations/noop.rs
@@ -89,7 +89,7 @@ fn noop_no_log() {
 
     let expected = json!({
             "noop": {
-                "errors": "timed out waiting on channel",
+                "errors": "Failed to receive version info - timed out waiting on channel",
                 "success": false
             }
     });

--- a/services/novatel-oem6-service/src/tests/schema/mutations/test_hardware.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mutations/test_hardware.rs
@@ -150,7 +150,7 @@ fn test_hardware_integration_no_log() {
 
     let expected = json!({
             "testHardware": {
-                "errors": "timed out waiting on channel",
+                "errors": "Failed to receive version info - timed out waiting on channel",
                 "success": false,
                 "telemetryDebug": null,
             }

--- a/services/novatel-oem6-service/src/tests/schema/queries/power.rs
+++ b/services/novatel-oem6-service/src/tests/schema/queries/power.rs
@@ -17,17 +17,54 @@
 use super::*;
 
 #[test]
-fn get_power() {
+fn get_power_on() {
     let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    let mut output = LOG_RESPONSE_GOOD.to_vec();
+    output.extend_from_slice(&VERSION_LOG);
+    mock.read.set_output(output);
 
     let service = service_new!(mock);
 
     let query = r#"{
-            power
+            power{
+                state,
+                uptime
+            }
         }"#;
 
     let expected = json!({
-            "power": "Not Implemented"
+            "power": {
+                "state": "ON",
+                "uptime": 1
+            }
+    });
+
+    assert_eq!(service.process(query.to_owned()), wrap!(expected));
+}
+
+#[test]
+fn get_power_off() {
+    let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    let service = service_new!(mock);
+
+    let query = r#"{
+            power{
+                state,
+                uptime
+            }
+        }"#;
+
+    let expected = json!({
+            "power": {
+                "state": "OFF",
+                "uptime": 0
+            }
     });
 
     assert_eq!(service.process(query.to_owned()), wrap!(expected));

--- a/services/novatel-oem6-service/src/tests/schema/queries/system_status.rs
+++ b/services/novatel-oem6-service/src/tests/schema/queries/system_status.rs
@@ -17,17 +17,112 @@
 use super::*;
 
 #[test]
-fn get_system_status() {
+fn get_system_status_good() {
     let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    let mut output = LOG_RESPONSE_GOOD.to_vec();
+    output.extend_from_slice(&VERSION_LOG);
+    mock.read.set_output(output);
 
     let service = service_new!(mock);
 
     let query = r#"{
-            power
+            systemStatus {
+                errors,
+                status
+            }
         }"#;
 
     let expected = json!({
-            "power": "Not Implemented"
+            "systemStatus": {
+                "errors": [],
+                "status": ["POSITION_SOLUTION_INVALID", "CLOCK_MODEL_INVALID"]
+            }
+    });
+
+    assert_eq!(service.process(query.to_owned()), wrap!(expected));
+}
+
+#[test]
+fn get_system_status_good_with_error() {
+    let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    let mut output = ERROR_LOG.to_vec();
+    output.extend_from_slice(&LOG_RESPONSE_GOOD);
+    output.extend_from_slice(&VERSION_LOG);
+    mock.read.set_output(output);
+
+    let service = service_new!(mock);
+
+    let query = r#"{
+            systemStatus {
+                errors,
+                status
+            }
+        }"#;
+
+    let expected = json!({
+            "systemStatus": {
+                "errors": ["RxStatusEvent(1, 19, 1): No Valid Position Calculated"],
+                "status": ["POSITION_SOLUTION_INVALID", "CLOCK_MODEL_INVALID"]
+            }
+    });
+
+    assert_eq!(service.process(query.to_owned()), wrap!(expected));
+}
+
+#[test]
+fn get_system_status_bad() {
+    let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    mock.read.set_output(LOG_RESPONSE_GOOD.to_vec());
+
+    let service = service_new!(mock);
+
+    let query = r#"{
+            systemStatus {
+                errors,
+                status
+            }
+        }"#;
+
+    let expected = json!({
+            "systemStatus": {
+                "errors": ["System Status: Failed to receive version info - timed out waiting on channel"],
+                "status": [
+                           "ERROR_PRESENT", 
+                           "TEMPERATURE_WARNING", 
+                           "VOLTAGE_SUPPLY_WARNING", 
+                           "ANTENNA_NOT_POWERED", 
+                           "LNA_FAILURE", 
+                           "ANTENNA_OPEN", 
+                           "ANTENNA_SHORTENED", 
+                           "CPU_OVERLOAD", 
+                           "COM1_BUFFER_OVERRUN", 
+                           "COM2_BUFFER_OVERRUN", 
+                           "COM3_BUFFER_OVERRUN", 
+                           "LINK_OVERRUN", 
+                           "AUX_TRANSMIT_OVERRUN", 
+                           "AGC_OUT_OF_RANGE", 
+                           "INS_RESET", 
+                           "GPS_ALMANAC_INVALID", 
+                           "POSITION_SOLUTION_INVALID", 
+                           "POSITION_FIXED", 
+                           "CLOCK_STEERING_DISABLED", 
+                           "CLOCK_MODEL_INVALID", 
+                           "EXTERNAL_OSCILLATOR_LOCKED", 
+                           "SOFTWARE_RESOURCE_WARNING", 
+                           "AUX3_STATUS_EVENT", 
+                           "AUX2_STATUS_EVENT", 
+                           "AUX1_STATUS_EVENT"
+                           ]
+            }
     });
 
     assert_eq!(service.process(query.to_owned()), wrap!(expected));

--- a/services/novatel-oem6-service/src/tests/schema/queries/test_results.rs
+++ b/services/novatel-oem6-service/src/tests/schema/queries/test_results.rs
@@ -144,7 +144,7 @@ fn test_results_no_log() {
 
     let expected = json!({
             "testResults": {
-                "errors": "timed out waiting on channel",
+                "errors": "Failed to receive version info - timed out waiting on channel",
                 "success": false,
                 "telemetryDebug": null,
             }


### PR DESCRIPTION
Adding queries:
- `power`
- `systemStatus`

Additional work:
- Converted the message header `recv_status` field from a raw u32 into bit fields
- Added system time, time status, and receiver status to all log messages in the API. They're not all used for each log within the service, but they're useful fields to have in general
- There a several functions which get and use the VersionInfo log. Changed the code to make one central `get_version_log()` function