### PR TITLE
OEM6 Service: Phase 5

### DIFF
--- a/services/kubos-service/src/service.rs
+++ b/services/kubos-service/src/service.rs
@@ -20,7 +20,7 @@ use std::net::{SocketAddr, UdpSocket};
 use std::cell::RefCell;
 use serde_json;
 use config::Config;
-use juniper::{execute, Context as JuniperContext, GraphQLType, RootNode, Value, Variables};
+use juniper::{execute, Context as JuniperContext, GraphQLType, RootNode, Variables};
 
 const FIONREAD: u16 = 0x541B;
 ioctl!(bad read udp_bytes_available with FIONREAD; usize);
@@ -182,16 +182,12 @@ where
             &self.context,
         ) {
             Ok((val, errs)) => {
-                let msg = match val {
-                    Value::Null => "".to_string(),
-                    _ => serde_json::to_string(&val).unwrap(),
-                };
                 let errs_msg: String = errs.into_iter()
                     .map(|x| serde_json::to_string(&x).unwrap())
                     .collect();
 
                 json!({
-                    "msg": msg,
+                    "msg": val,
                     "errs": errs_msg})
                     .to_string()
             }

--- a/services/novatel-oem6-service/Cargo.toml
+++ b/services/novatel-oem6-service/Cargo.toml
@@ -10,6 +10,4 @@ kubos-service = { path = "../kubos-service" }
 novatel-oem6-api = { path = "../../apis/novatel-oem6-api" }
 
 [dev-dependencies]
-serde = "1.0"
-serde_derive = "1.0"
 serde_json = "1.0.10"

--- a/services/novatel-oem6-service/src/main.rs
+++ b/services/novatel-oem6-service/src/main.rs
@@ -15,7 +15,7 @@
 //
 
 #![deny(missing_docs)]
-//#![deny(warnings)]
+#![deny(warnings)]
 
 //! Kubos Service for interacting with a [NovAtel OEM6 High Precision GNSS Receiver](https://www.novatel.com/products/gnss-receivers/oem-receiver-boards/oem6-receivers/)
 //!
@@ -23,7 +23,7 @@
 //!
 //! The service can be configured in the `/home/system/etc/config.toml` with the following fields:
 //! ```
-//! [novatel-oem6-service]
+//! [novatel-oem6-service.addr]
 //! ip = "127.0.0.1"
 //! port = 8082
 //! ```
@@ -43,7 +43,187 @@
 //! # Available Fields
 //!
 //! ```json
-//! TODO
+//! query {
+//!     ack,
+//!     config,
+//!     errors,
+//!     lockInfo {
+//!         position,
+//!         time {
+//!             ms,
+//!             week
+//!         },
+//!         velocity
+//!     },
+//!     lockStatus {
+//!         positionStatus,
+//!         positionType,
+//!         time {
+//!             ms,
+//!             week
+//!         },
+//!         timeStatus,
+//!         velocityStatus,
+//!         velocityType
+//!     },
+//!     power{
+//!         state,
+//!         uptime
+//!     },
+//!     systemStatus {
+//!         errors,
+//!         status
+//!     },
+//!     telemetry{
+//!         debug {
+//!             components {
+//!                 bootVersion,
+//!                 compType,
+//!                 compileDate,
+//!                 compileTime,
+//!                 hwVersion,
+//!                 model,
+//!                 serialNum,
+//!                 swVersion,
+//!             },
+//!             numComponents
+//!         },
+//!         nominal{
+//!             lockInfo {
+//!                 position,
+//!                 time {
+//!                     ms,
+//!                     week
+//!                 },
+//!                 velocity
+//!             },
+//!             lockStatus {
+//!                 positionStatus,
+//!                 positionType,
+//!                 time {
+//!                     ms,
+//!                     week
+//!                 },
+//!                 timeStatus,
+//!                 velocityStatus,
+//!                 velocityType
+//!             },
+//!             systemStatus {
+//!                 errors,
+//!                 status
+//!             }
+//!         }
+//!     },
+//!     testResults {
+//!         errors,
+//!         success,
+//!         telemetryDebug {
+//!             components {
+//!                 bootVersion,
+//!                 compType,
+//!                 compileDate,
+//!                 compileTime,
+//!                 hwVersion,
+//!                 model,
+//!                 serialNum,
+//!                 swVersion,
+//!             },
+//!             numComponents
+//!         },
+//!         telemetryNominal{
+//!             lockInfo {
+//!                 position,
+//!                 time {
+//!                     ms,
+//!                     week
+//!                 },
+//!                 velocity
+//!             },
+//!             lockStatus {
+//!                 positionStatus,
+//!                 positionType,
+//!                 time {
+//!                     ms,
+//!                     week
+//!                 },
+//!                 timeStatus,
+//!                 velocityStatus,
+//!                 velocityType
+//!             },
+//!             systemStatus {
+//!                 errors,
+//!                 status
+//!             }
+//!         }
+//!     }
+//! }
+//!
+//! mutation {
+//!     configureHardware(config: [{option: ConfigOption, hold: Boolean, interval: Float, offset: Float},...]) {
+//!         config,
+//!         errors,
+//!         success
+//!     },
+//!     controlPower,
+//!     errors,
+//!     issueRawCommand(command: String){
+//!         errors,
+//!         success
+//!     },
+//!     noop {
+//!         errors,
+//!         success
+//!     },
+//!     testHardware(test: TestType) {
+//!         ... on IntegrationTestResults {
+//!             errors,
+//!             success,
+//!             telemetryDebug {
+//!                 components {
+//!                     bootVersion,
+//!                     compType,
+//!                     compileDate,
+//!                     compileTime,
+//!                     hwVersion,
+//!                     model,
+//!                     serialNum,
+//!                     swVersion,
+//!                 },
+//!                 numComponents
+//!             },
+//!             telemetryNominal{
+//!                 lockInfo {
+//!                     position,
+//!                     time {
+//!                         ms,
+//!                         week
+//!                     },
+//!                     velocity
+//!                 },
+//!                 lockStatus {
+//!                     positionStatus,
+//!                     positionType,
+//!                     time {
+//!                         ms,
+//!                         week
+//!                     },
+//!                     timeStatus,
+//!                     velocityStatus,
+//!                     velocityType
+//!                 },
+//!                 systemStatus {
+//!                     errors,
+//!                     status
+//!                 }
+//!             }
+//!         }
+//!         ... on HardwareTestResults {
+//!             data,
+//!             errors,
+//!             success
+//!         }
+//!     }
+//! }
 //! ```
 //!
 

--- a/services/novatel-oem6-service/src/main.rs
+++ b/services/novatel-oem6-service/src/main.rs
@@ -22,19 +22,27 @@
 //! # Configuration
 //!
 //! The service can be configured in the `/home/system/etc/config.toml` with the following fields:
-//! ```
+//!
+//! - `bus` - Specifies the UART bus the OEM6 is connected to
+//! - `ip` - Specifies the service's IP address
+//! - `port` - Specifies the port on which the service will be listening for UDP packets
+//!
+//! For example:
+//!
+//! ```toml
+//! [novatel-oem6-service]
+//! bus = "/dev/ttyS4"
+//!
 //! [novatel-oem6-service.addr]
 //! ip = "127.0.0.1"
 //! port = 8082
 //! ```
 //!
-//! Where `ip` specifies the service's IP address, and `port` specifies the port which UDP requests should be sent to.
-//!
 //! # Starting the Service
 //!
 //! The service should be started automatically by its init script, but may also be started manually:
 //!
-//! ```
+//! ```toml
 //! $ novatel-oem6-service
 //! Kubos OEM6 service started
 //! Listening on: 10.63.1.20:8082
@@ -251,8 +259,6 @@ use novatel_oem6_api::OEMResult;
 use schema::{MutationRoot, QueryRoot};
 use std::sync::Arc;
 
-// TODO: CHANGE THE UART BUS TO UART4!!!
-
 fn main() -> OEMResult<()> {
     Service::new(
         Config::new("novatel-oem6-service"),
@@ -263,3 +269,19 @@ fn main() -> OEMResult<()> {
 
     Ok(())
 }
+
+/* TODO: Use once master has been merged into main service PR
+fn main() -> OEMResult<()> {
+    let config = Config::new("novatel-oem6-service");
+    let bus = config
+        .get("bus")
+        .expect("No OEM6 device path found in config");
+    let bus = bus.as_str()?;
+
+    let subsystem = Subsystem::new(bus, Arc::new(LockData::new()))?;
+
+    Service::new(config, subsystem, QueryRoot, MutationRoot).start();
+
+    Ok(())
+}
+*/

--- a/services/novatel-oem6-service/src/schema.rs
+++ b/services/novatel-oem6-service/src/schema.rs
@@ -155,17 +155,31 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
         Ok(executor.context().subsystem().get_lock_info()?)
     }
 
-    // TODO:
-    // Nominal - 
-    // - System status
-    // - Lock status
-    // - Lock info
-    // - Power status
-    // Debug -
-    // - Maybe - System config info (LOGLIST?)
-    field telemetry(&executor) -> FieldResult<String>
+    // Get current telemetry information for the system
+    //
+    // telemetry{
+    //     debug {
+    //         components: [{
+    //             bootVersion: String,
+    //             compType: Int,
+    //             compileDate: String,
+    //             compileTime: String, 
+    //             hwVersion: String,
+    //             model: String,
+    //             serialNum: String,
+    //             swVersion: String,
+    //         }],
+    //         numComponents: Int
+    //     },
+    //     nominal{
+    //         lockInfo {...},
+    //         lockStatus {...},
+    //         systemStatus: Vec<String>
+    //     }
+    // }
+    field telemetry(&executor) -> FieldResult<Telemetry>
     {
-        Ok(String::from("Not Implemented"))
+        Ok(executor.context().subsystem().get_telemetry()?)
     }
 });
 

--- a/services/novatel-oem6-service/src/schema.rs
+++ b/services/novatel-oem6-service/src/schema.rs
@@ -88,7 +88,7 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
 
     // Get the current configuration of the system
     //
-    // TODO: Return the version log info? Stretch goal: implement the LOGLIST command
+    // Stretch goal: implement the LOGLIST command
     //
     // {
     //     config: "Not Implemented"
@@ -113,9 +113,11 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
 
     // Get the current system status and errors
     //
-    // systemStatus {
-    //    errors: Vec<String>,
-    //    status: Vec<String>
+    // {
+    //     systemStatus {
+    //        errors: Vec<String>,
+    //        status: Vec<String>
+    //     }
     // }
     field system_status(&executor) -> FieldResult<SystemStatus>
     {
@@ -124,16 +126,18 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
 
     // Get current status of position information gathering
     //
-    // lockStatus {
-    //     positionStatus: SolutionStatus,
-    // 	   positionType: PosVelType,
-    // 	   time {
-    //         ms: Int,
-    // 		   week: Int
-    // 	   },
-    //     timeStatus: RefTimeStatus,
-    //     velocityStatus: SolutionStatus,
-    // 	   velocityType: PosVelType
+    // {
+    //     lockStatus {
+    //         positionStatus: SolutionStatus,
+    //           positionType: PosVelType,
+    //           time {
+    //             ms: Int,
+    //               week: Int
+    //           },
+    //         timeStatus: RefTimeStatus,
+    //         velocityStatus: SolutionStatus,
+    //           velocityType: PosVelType
+    //     }
     // }
     field lock_status(&executor) -> FieldResult<LockStatus>
     {
@@ -142,13 +146,15 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
 
     // Get the last known good position information
     //
-    // lockInfo {
-    // 	position: Vec<Float>,
-    // 	time {
-    // 		ms: Int,
-    // 		week: Int
-    // 	},
-    // 	velocity: Vec<Float>
+    // {
+    //     lockInfo {
+    //        position: Vec<Float>,
+    //        time {
+    //            ms: Int,
+    //            week: Int
+    //        },
+    //        velocity: Vec<Float>
+    //     }
     // }
     field lock_info(&executor) -> FieldResult<LockInfo>
     {
@@ -157,24 +163,26 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
 
     // Get current telemetry information for the system
     //
-    // telemetry{
-    //     debug {
-    //         components: [{
-    //             bootVersion: String,
-    //             compType: Int,
-    //             compileDate: String,
-    //             compileTime: String, 
-    //             hwVersion: String,
-    //             model: String,
-    //             serialNum: String,
-    //             swVersion: String,
-    //         }],
-    //         numComponents: Int
-    //     },
-    //     nominal{
-    //         lockInfo {...},
-    //         lockStatus {...},
-    //         systemStatus: Vec<String>
+    // {
+    //     telemetry{
+    //         debug {
+    //             components: [{
+    //                 bootVersion: String,
+    //                 compType: Int,
+    //                 compileDate: String,
+    //                 compileTime: String, 
+    //                 hwVersion: String,
+    //                 model: String,
+    //                 serialNum: String,
+    //                 swVersion: String,
+    //             }],
+    //             numComponents: Int
+    //         },
+    //         nominal{
+    //             lockInfo {...},
+    //             lockStatus {...},
+    //             systemStatus: Vec<String>
+    //         }
     //     }
     // }
     field telemetry(&executor) -> FieldResult<Telemetry>

--- a/services/novatel-oem6-service/src/tests/mod.rs
+++ b/services/novatel-oem6-service/src/tests/mod.rs
@@ -74,7 +74,6 @@ macro_rules! service_new {
             QueryRoot,
             MutationRoot,
         )
-
     }};
 }
 

--- a/services/novatel-oem6-service/src/tests/schema/mod.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mod.rs
@@ -20,15 +20,14 @@ use super::*;
 use kubos_service::{Config, Service};
 use model::*;
 use schema::*;
-use serde_json;
 use std::sync::mpsc::sync_channel;
 
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                        "msg": serde_json::to_string(&$result).unwrap(),
-                        "errs": ""
-                }).to_string()
+                    "msg": $result,
+                    "errs": ""
+            }).to_string()
     }};
 }
 

--- a/services/novatel-oem6-service/src/tests/schema/mod.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mod.rs
@@ -26,9 +26,9 @@ use std::sync::mpsc::sync_channel;
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                "msg": serde_json::to_string(&$result).unwrap(),
-                "errs": ""
-        }).to_string()
+                        "msg": serde_json::to_string(&$result).unwrap(),
+                        "errs": ""
+                }).to_string()
     }};
 }
 

--- a/services/novatel-oem6-service/src/tests/schema/mutations/test_hardware.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mutations/test_hardware.rs
@@ -47,6 +47,31 @@ fn test_hardware_integration_good() {
                             swVersion,
                         },
                         numComponents
+                    },
+                    telemetryNominal{
+                        lockInfo {
+                            position,
+                            time {
+                                ms,
+                                week
+                            },
+                            velocity
+                        },
+                        lockStatus {
+                            positionStatus,
+                            positionType,
+                            time {
+                                ms,
+                                week
+                            },
+                            timeStatus,
+                            velocityStatus,
+                            velocityType
+                        },
+                        systemStatus {
+                            errors,
+                            status
+                        }
                     }
                 }
             }
@@ -68,6 +93,31 @@ fn test_hardware_integration_good() {
                         "swVersion": "OEM060600RN0000",   
                     }],
                     "numComponents": 1
+                },
+                "telemetryNominal": {
+                    "lockInfo": {
+                        "position": [0.0, 0.0, 0.0],
+                        "time": {
+                            "ms": 0,
+                            "week": 0,
+                        },
+                        "velocity": [0.0, 0.0, 0.0],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "positionType": "NONE",
+                        "time": {
+                            "ms": 0,
+                        	"week": 0
+                        },
+                        "timeStatus": "UNKNOWN",
+                        "velocityStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "velocityType": "NONE"
+                    },
+                    "systemStatus": {
+                        "errors": [],
+                        "status": ["POSITION_SOLUTION_INVALID", "CLOCK_MODEL_INVALID"]
+                    }
                 }
             }
     });
@@ -100,6 +150,31 @@ fn test_hardware_integration_no_response() {
                             swVersion,
                         },
                         numComponents
+                    },
+                    telemetryNominal{
+                        lockInfo {
+                            position,
+                            time {
+                                ms,
+                                week
+                            },
+                            velocity
+                        },
+                        lockStatus {
+                            positionStatus,
+                            positionType,
+                            time {
+                                ms,
+                                week
+                            },
+                            timeStatus,
+                            velocityStatus,
+                            velocityType
+                        },
+                        systemStatus {
+                            errors,
+                            status
+                        }
                     }
                 }
             }
@@ -107,9 +182,60 @@ fn test_hardware_integration_no_response() {
 
     let expected = json!({
             "testHardware": {
-                "errors": "Failed to get command response",
+                "errors": "Get Telemetry: Failed to get command response",
                 "success": false,
                 "telemetryDebug": null,
+                "telemetryNominal": {
+                    "lockInfo": {
+                        "position": [0.0, 0.0, 0.0],
+                        "time": {
+                            "ms": 0,
+                            "week": 0,
+                        },
+                        "velocity": [0.0, 0.0, 0.0],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "positionType": "NONE",
+                        "time": {
+                            "ms": 0,
+                        	"week": 0
+                        },
+                        "timeStatus": "UNKNOWN",
+                        "velocityStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "velocityType": "NONE"
+                    },
+                    "systemStatus": {
+                        "errors": ["Get Telemetry: Failed to get command response"],
+                        "status": [
+                           "ERROR_PRESENT", 
+                           "TEMPERATURE_WARNING", 
+                           "VOLTAGE_SUPPLY_WARNING", 
+                           "ANTENNA_NOT_POWERED", 
+                           "LNA_FAILURE", 
+                           "ANTENNA_OPEN", 
+                           "ANTENNA_SHORTENED", 
+                           "CPU_OVERLOAD", 
+                           "COM1_BUFFER_OVERRUN", 
+                           "COM2_BUFFER_OVERRUN", 
+                           "COM3_BUFFER_OVERRUN", 
+                           "LINK_OVERRUN", 
+                           "AUX_TRANSMIT_OVERRUN", 
+                           "AGC_OUT_OF_RANGE", 
+                           "INS_RESET", 
+                           "GPS_ALMANAC_INVALID", 
+                           "POSITION_SOLUTION_INVALID", 
+                           "POSITION_FIXED", 
+                           "CLOCK_STEERING_DISABLED", 
+                           "CLOCK_MODEL_INVALID", 
+                           "EXTERNAL_OSCILLATOR_LOCKED", 
+                           "SOFTWARE_RESOURCE_WARNING", 
+                           "AUX3_STATUS_EVENT", 
+                           "AUX2_STATUS_EVENT", 
+                           "AUX1_STATUS_EVENT"
+                           ]
+                    }
+                }
             }
     });
 
@@ -143,6 +269,31 @@ fn test_hardware_integration_no_log() {
                             swVersion,
                         },
                         numComponents
+                    },
+                    telemetryNominal{
+                        lockInfo {
+                            position,
+                            time {
+                                ms,
+                                week
+                            },
+                            velocity
+                        },
+                        lockStatus {
+                            positionStatus,
+                            positionType,
+                            time {
+                                ms,
+                                week
+                            },
+                            timeStatus,
+                            velocityStatus,
+                            velocityType
+                        },
+                        systemStatus {
+                            errors,
+                            status
+                        }
                     }
                 }
             }
@@ -150,9 +301,60 @@ fn test_hardware_integration_no_log() {
 
     let expected = json!({
             "testHardware": {
-                "errors": "Failed to receive version info - timed out waiting on channel",
+                "errors": "Get Telemetry: Failed to receive version info - timed out waiting on channel",
                 "success": false,
                 "telemetryDebug": null,
+                "telemetryNominal": {
+                    "lockInfo": {
+                        "position": [0.0, 0.0, 0.0],
+                        "time": {
+                            "ms": 0,
+                            "week": 0,
+                        },
+                        "velocity": [0.0, 0.0, 0.0],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "positionType": "NONE",
+                        "time": {
+                            "ms": 0,
+                        	"week": 0
+                        },
+                        "timeStatus": "UNKNOWN",
+                        "velocityStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "velocityType": "NONE"
+                    },
+                    "systemStatus": {
+                        "errors": ["Get Telemetry: Failed to receive version info - timed out waiting on channel"],
+                        "status": [
+                           "ERROR_PRESENT", 
+                           "TEMPERATURE_WARNING", 
+                           "VOLTAGE_SUPPLY_WARNING", 
+                           "ANTENNA_NOT_POWERED", 
+                           "LNA_FAILURE", 
+                           "ANTENNA_OPEN", 
+                           "ANTENNA_SHORTENED", 
+                           "CPU_OVERLOAD", 
+                           "COM1_BUFFER_OVERRUN", 
+                           "COM2_BUFFER_OVERRUN", 
+                           "COM3_BUFFER_OVERRUN", 
+                           "LINK_OVERRUN", 
+                           "AUX_TRANSMIT_OVERRUN", 
+                           "AGC_OUT_OF_RANGE", 
+                           "INS_RESET", 
+                           "GPS_ALMANAC_INVALID", 
+                           "POSITION_SOLUTION_INVALID", 
+                           "POSITION_FIXED", 
+                           "CLOCK_STEERING_DISABLED", 
+                           "CLOCK_MODEL_INVALID", 
+                           "EXTERNAL_OSCILLATOR_LOCKED", 
+                           "SOFTWARE_RESOURCE_WARNING", 
+                           "AUX3_STATUS_EVENT", 
+                           "AUX2_STATUS_EVENT", 
+                           "AUX1_STATUS_EVENT"
+                           ]
+                    }
+                }
             }
     });
 

--- a/services/novatel-oem6-service/src/tests/schema/queries/telemetry.rs
+++ b/services/novatel-oem6-service/src/tests/schema/queries/telemetry.rs
@@ -17,17 +17,342 @@
 use super::*;
 
 #[test]
-fn get_telemetry() {
+fn get_telemetry_nominal() {
     let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    let mut output = POSITION_LOG_GOOD.to_vec();
+    output.extend_from_slice(&LOG_RESPONSE_GOOD.to_vec());
+    output.extend_from_slice(&VERSION_LOG);
+    mock.read.set_output(output);
 
     let service = service_new!(mock);
 
     let query = r#"{
-            telemetry
+            telemetry{
+                nominal{
+                    lockInfo {
+                        position,
+                        time {
+                            ms,
+                            week
+                        },
+                        velocity
+                    },
+                    lockStatus {
+                        positionStatus,
+                        positionType,
+                        time {
+                            ms,
+                            week
+                        },
+                        timeStatus,
+                        velocityStatus,
+                        velocityType
+                    },
+                    systemStatus {
+                        errors,
+                        status
+                    }
+                }
+            }
         }"#;
 
     let expected = json!({
-            "telemetry": "Not Implemented"
+            "telemetry": {
+                "nominal": {
+                    "lockInfo": {
+                        "position": [1.1, 2.2, 3.3],
+                        "time": {
+                            "ms": 164195000,
+                        	"week": 3025
+                        },
+                        "velocity": [4.4, 5.5, 6.6],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "SOL_COMPUTED",
+                        "positionType": "PSRDIFF",
+                        "time": {
+                            "ms": 164195000,
+                        	"week": 3025
+                        },
+                        "timeStatus": "FINE_STEERING",
+                        "velocityStatus": "SOL_COMPUTED",
+                        "velocityType": "PSRDIFF"
+                    },
+                    "systemStatus": {
+                        "errors": [],
+                        "status": ["POSITION_SOLUTION_INVALID", "CLOCK_MODEL_INVALID"]
+                    }
+                }
+            }
+    });
+
+    assert_eq!(service.process(query.to_owned()), wrap!(expected));
+}
+
+#[test]
+fn get_telemetry_debug() {
+    let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    let mut output = LOG_RESPONSE_GOOD.to_vec();
+    output.extend_from_slice(&VERSION_LOG);
+    mock.read.set_output(output);
+
+    let service = service_new!(mock);
+
+    let query = r#"{
+            telemetry{
+                debug {
+                    components {
+                        bootVersion,
+                        compType,
+                        compileDate,
+                        compileTime, 
+                        hwVersion,
+                        model,
+                        serialNum,
+                        swVersion,
+                    },
+                    numComponents
+                }
+            }
+        }"#;
+
+    let expected = json!({
+            "telemetry": {
+                "debug": {
+                    "components": [{
+                        "bootVersion": "OEM060201RB0000",
+                        "compType": 1,
+                        "compileDate": "2015/Jan/28",
+                        "compileTime": "15:27:29",
+                        "hwVersion": "OEM615-2.00",
+                        "model": "G1SB0GTT0",
+                        "serialNum": "BJYA15120038H",
+                        "swVersion": "OEM060600RN0000",   
+                    }],
+                    "numComponents": 1
+                }
+            }
+    });
+
+    assert_eq!(service.process(query.to_owned()), wrap!(expected));
+}
+
+#[test]
+fn get_telemetry_both() {
+    let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    let mut output = POSITION_LOG_GOOD.to_vec();
+    output.extend_from_slice(&LOG_RESPONSE_GOOD.to_vec());
+    output.extend_from_slice(&VERSION_LOG);
+    mock.read.set_output(output);
+
+    let service = service_new!(mock);
+
+    let query = r#"{
+            telemetry{
+                debug {
+                    components {
+                        bootVersion,
+                        compType,
+                        compileDate,
+                        compileTime, 
+                        hwVersion,
+                        model,
+                        serialNum,
+                        swVersion,
+                    },
+                    numComponents
+                },
+                nominal{
+                    lockInfo {
+                        position,
+                        time {
+                            ms,
+                            week
+                        },
+                        velocity
+                    },
+                    lockStatus {
+                        positionStatus,
+                        positionType,
+                        time {
+                            ms,
+                            week
+                        },
+                        timeStatus,
+                        velocityStatus,
+                        velocityType
+                    },
+                    systemStatus {
+                        errors,
+                        status
+                    }
+                }
+            }
+        }"#;
+
+    let expected = json!({
+            "telemetry": {
+                "debug": {
+                    "components": [{
+                        "bootVersion": "OEM060201RB0000",
+                        "compType": 1,
+                        "compileDate": "2015/Jan/28",
+                        "compileTime": "15:27:29",
+                        "hwVersion": "OEM615-2.00",
+                        "model": "G1SB0GTT0",
+                        "serialNum": "BJYA15120038H",
+                        "swVersion": "OEM060600RN0000",   
+                    }],
+                    "numComponents": 1
+                },
+                "nominal": {
+                    "lockInfo": {
+                        "position": [1.1, 2.2, 3.3],
+                        "time": {
+                            "ms": 164195000,
+                        	"week": 3025
+                        },
+                        "velocity": [4.4, 5.5, 6.6],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "SOL_COMPUTED",
+                        "positionType": "PSRDIFF",
+                        "time": {
+                            "ms": 164195000,
+                        	"week": 3025
+                        },
+                        "timeStatus": "FINE_STEERING",
+                        "velocityStatus": "SOL_COMPUTED",
+                        "velocityType": "PSRDIFF"
+                    },
+                    "systemStatus": {
+                        "errors": [],
+                        "status": ["POSITION_SOLUTION_INVALID", "CLOCK_MODEL_INVALID"]
+                    }
+                }
+            }
+    });
+
+    assert_eq!(service.process(query.to_owned()), wrap!(expected));
+}
+
+#[test]
+fn get_telemetry_empty() {
+    let mut mock = MockStream::default();
+
+    mock.write.set_input(LOG_VERSION_COMMAND.to_vec());
+
+    mock.read.set_output(LOG_RESPONSE_GOOD.to_vec());
+
+    let service = service_new!(mock);
+
+    let query = r#"{
+            telemetry{
+                debug {
+                    components {
+                        bootVersion,
+                        compType,
+                        compileDate,
+                        compileTime, 
+                        hwVersion,
+                        model,
+                        serialNum,
+                        swVersion,
+                    },
+                    numComponents
+                },
+                nominal{
+                    lockInfo {
+                        position,
+                        time {
+                            ms,
+                            week
+                        },
+                        velocity
+                    },
+                    lockStatus {
+                        positionStatus,
+                        positionType,
+                        time {
+                            ms,
+                            week
+                        },
+                        timeStatus,
+                        velocityStatus,
+                        velocityType
+                    },
+                    systemStatus {
+                        errors,
+                        status
+                    }
+                }
+            }
+        }"#;
+
+    let expected = json!({
+            "telemetry": {
+                "debug":null,
+                "nominal": {
+                    "lockInfo": {
+                        "position": [0.0, 0.0, 0.0],
+                        "time": {
+                            "ms": 0,
+                            "week": 0,
+                        },
+                        "velocity": [0.0, 0.0, 0.0],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "positionType": "NONE",
+                        "time": {
+                            "ms": 0,
+                        	"week": 0
+                        },
+                        "timeStatus": "UNKNOWN",
+                        "velocityStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "velocityType": "NONE"
+                    },
+                    "systemStatus": {
+                        "errors": ["Get Telemetry: Failed to receive version info - timed out waiting on channel"],
+                        "status": [
+                           "ERROR_PRESENT", 
+                           "TEMPERATURE_WARNING", 
+                           "VOLTAGE_SUPPLY_WARNING", 
+                           "ANTENNA_NOT_POWERED", 
+                           "LNA_FAILURE", 
+                           "ANTENNA_OPEN", 
+                           "ANTENNA_SHORTENED", 
+                           "CPU_OVERLOAD", 
+                           "COM1_BUFFER_OVERRUN", 
+                           "COM2_BUFFER_OVERRUN", 
+                           "COM3_BUFFER_OVERRUN", 
+                           "LINK_OVERRUN", 
+                           "AUX_TRANSMIT_OVERRUN", 
+                           "AGC_OUT_OF_RANGE", 
+                           "INS_RESET", 
+                           "GPS_ALMANAC_INVALID", 
+                           "POSITION_SOLUTION_INVALID", 
+                           "POSITION_FIXED", 
+                           "CLOCK_STEERING_DISABLED", 
+                           "CLOCK_MODEL_INVALID", 
+                           "EXTERNAL_OSCILLATOR_LOCKED", 
+                           "SOFTWARE_RESOURCE_WARNING", 
+                           "AUX3_STATUS_EVENT", 
+                           "AUX2_STATUS_EVENT", 
+                           "AUX1_STATUS_EVENT"
+                           ]
+                    }
+                }
+            }
     });
 
     assert_eq!(service.process(query.to_owned()), wrap!(expected));

--- a/services/novatel-oem6-service/src/tests/schema/queries/test_results.rs
+++ b/services/novatel-oem6-service/src/tests/schema/queries/test_results.rs
@@ -46,6 +46,31 @@ fn test_results_good() {
                         swVersion,
                     },
                     numComponents
+                },
+                telemetryNominal{
+                    lockInfo {
+                        position,
+                        time {
+                            ms,
+                            week
+                        },
+                        velocity
+                    },
+                    lockStatus {
+                        positionStatus,
+                        positionType,
+                        time {
+                            ms,
+                            week
+                        },
+                        timeStatus,
+                        velocityStatus,
+                        velocityType
+                    },
+                    systemStatus {
+                        errors,
+                        status
+                    }
                 }
             }
         }"#;
@@ -66,6 +91,31 @@ fn test_results_good() {
                         "swVersion": "OEM060600RN0000",   
                     }],
                     "numComponents": 1
+                },
+                "telemetryNominal": {
+                    "lockInfo": {
+                        "position": [0.0, 0.0, 0.0],
+                        "time": {
+                            "ms": 0,
+                            "week": 0,
+                        },
+                        "velocity": [0.0, 0.0, 0.0],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "positionType": "NONE",
+                        "time": {
+                            "ms": 0,
+                        	"week": 0
+                        },
+                        "timeStatus": "UNKNOWN",
+                        "velocityStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "velocityType": "NONE"
+                    },
+                    "systemStatus": {
+                        "errors": [],
+                        "status": ["POSITION_SOLUTION_INVALID", "CLOCK_MODEL_INVALID"]
+                    }
                 }
             }
     });
@@ -97,15 +147,91 @@ fn test_results_no_response() {
                         swVersion,
                     },
                     numComponents
+                },
+                telemetryNominal{
+                    lockInfo {
+                        position,
+                        time {
+                            ms,
+                            week
+                        },
+                        velocity
+                    },
+                    lockStatus {
+                        positionStatus,
+                        positionType,
+                        time {
+                            ms,
+                            week
+                        },
+                        timeStatus,
+                        velocityStatus,
+                        velocityType
+                    },
+                    systemStatus {
+                        errors,
+                        status
+                    }
                 }
             }
         }"#;
 
     let expected = json!({
             "testResults": {
-                "errors": "Failed to get command response",
+                "errors": "Get Telemetry: Failed to get command response",
                 "success": false,
                 "telemetryDebug": null,
+                "telemetryNominal": {
+                    "lockInfo": {
+                        "position": [0.0, 0.0, 0.0],
+                        "time": {
+                            "ms": 0,
+                            "week": 0,
+                        },
+                        "velocity": [0.0, 0.0, 0.0],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "positionType": "NONE",
+                        "time": {
+                            "ms": 0,
+                        	"week": 0
+                        },
+                        "timeStatus": "UNKNOWN",
+                        "velocityStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "velocityType": "NONE"
+                    },
+                    "systemStatus": {
+                        "errors": ["Get Telemetry: Failed to get command response"],
+                        "status": [
+                           "ERROR_PRESENT", 
+                           "TEMPERATURE_WARNING", 
+                           "VOLTAGE_SUPPLY_WARNING", 
+                           "ANTENNA_NOT_POWERED", 
+                           "LNA_FAILURE", 
+                           "ANTENNA_OPEN", 
+                           "ANTENNA_SHORTENED", 
+                           "CPU_OVERLOAD", 
+                           "COM1_BUFFER_OVERRUN", 
+                           "COM2_BUFFER_OVERRUN", 
+                           "COM3_BUFFER_OVERRUN", 
+                           "LINK_OVERRUN", 
+                           "AUX_TRANSMIT_OVERRUN", 
+                           "AGC_OUT_OF_RANGE", 
+                           "INS_RESET", 
+                           "GPS_ALMANAC_INVALID", 
+                           "POSITION_SOLUTION_INVALID", 
+                           "POSITION_FIXED", 
+                           "CLOCK_STEERING_DISABLED", 
+                           "CLOCK_MODEL_INVALID", 
+                           "EXTERNAL_OSCILLATOR_LOCKED", 
+                           "SOFTWARE_RESOURCE_WARNING", 
+                           "AUX3_STATUS_EVENT", 
+                           "AUX2_STATUS_EVENT", 
+                           "AUX1_STATUS_EVENT"
+                           ]
+                    }
+                }
             }
     });
 
@@ -138,15 +264,91 @@ fn test_results_no_log() {
                         swVersion,
                     },
                     numComponents
+                },
+                telemetryNominal{
+                    lockInfo {
+                        position,
+                        time {
+                            ms,
+                            week
+                        },
+                        velocity
+                    },
+                    lockStatus {
+                        positionStatus,
+                        positionType,
+                        time {
+                            ms,
+                            week
+                        },
+                        timeStatus,
+                        velocityStatus,
+                        velocityType
+                    },
+                    systemStatus {
+                        errors,
+                        status
+                    }
                 }
             }
         }"#;
 
     let expected = json!({
             "testResults": {
-                "errors": "Failed to receive version info - timed out waiting on channel",
+                "errors": "Get Telemetry: Failed to receive version info - timed out waiting on channel",
                 "success": false,
                 "telemetryDebug": null,
+                "telemetryNominal": {
+                    "lockInfo": {
+                        "position": [0.0, 0.0, 0.0],
+                        "time": {
+                            "ms": 0,
+                            "week": 0,
+                        },
+                        "velocity": [0.0, 0.0, 0.0],
+                    },
+                    "lockStatus": {
+                        "positionStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "positionType": "NONE",
+                        "time": {
+                            "ms": 0,
+                        	"week": 0
+                        },
+                        "timeStatus": "UNKNOWN",
+                        "velocityStatus": "INSUFFICIENT_OBSERVATIONS",
+                        "velocityType": "NONE"
+                    },
+                    "systemStatus": {
+                        "errors": ["Get Telemetry: Failed to receive version info - timed out waiting on channel"],
+                        "status": [
+                           "ERROR_PRESENT", 
+                           "TEMPERATURE_WARNING", 
+                           "VOLTAGE_SUPPLY_WARNING", 
+                           "ANTENNA_NOT_POWERED", 
+                           "LNA_FAILURE", 
+                           "ANTENNA_OPEN", 
+                           "ANTENNA_SHORTENED", 
+                           "CPU_OVERLOAD", 
+                           "COM1_BUFFER_OVERRUN", 
+                           "COM2_BUFFER_OVERRUN", 
+                           "COM3_BUFFER_OVERRUN", 
+                           "LINK_OVERRUN", 
+                           "AUX_TRANSMIT_OVERRUN", 
+                           "AGC_OUT_OF_RANGE", 
+                           "INS_RESET", 
+                           "GPS_ALMANAC_INVALID", 
+                           "POSITION_SOLUTION_INVALID", 
+                           "POSITION_FIXED", 
+                           "CLOCK_STEERING_DISABLED", 
+                           "CLOCK_MODEL_INVALID", 
+                           "EXTERNAL_OSCILLATOR_LOCKED", 
+                           "SOFTWARE_RESOURCE_WARNING", 
+                           "AUX3_STATUS_EVENT", 
+                           "AUX2_STATUS_EVENT", 
+                           "AUX1_STATUS_EVENT"
+                           ]
+                    }
+                }
             }
     });
 


### PR DESCRIPTION
- Adding `telemetry` query.
- Under the covers, adding nominal telemetry, which is also returned by `testHardware(INTEGRATION)` and `testResults`
- Adding full schema to main doc