### PR TITLE
Adding OEM6 bus configuration

### DIFF
--- a/services/novatel-oem6-service/src/main.rs
+++ b/services/novatel-oem6-service/src/main.rs
@@ -260,23 +260,11 @@ use schema::{MutationRoot, QueryRoot};
 use std::sync::Arc;
 
 fn main() -> OEMResult<()> {
-    Service::new(
-        Config::new("novatel-oem6-service"),
-        Subsystem::new("/dev/ttyS5", Arc::new(LockData::new()))?,
-        QueryRoot,
-        MutationRoot,
-    ).start();
-
-    Ok(())
-}
-
-/* TODO: Use once master has been merged into main service PR
-fn main() -> OEMResult<()> {
     let config = Config::new("novatel-oem6-service");
     let bus = config
         .get("bus")
-        .expect("No OEM6 device path found in config");
-    let bus = bus.as_str()?;
+        .expect("No 'bus' value found in 'novatel-oem6-service' section of config");
+    let bus = bus.as_str().unwrap();
 
     let subsystem = Subsystem::new(bus, Arc::new(LockData::new()))?;
 
@@ -284,4 +272,3 @@ fn main() -> OEMResult<()> {
 
     Ok(())
 }
-*/

--- a/services/novatel-oem6-service/src/model.rs
+++ b/services/novatel-oem6-service/src/model.rs
@@ -73,10 +73,6 @@ pub fn log_thread(
             .expect("Underlying read thread no longer communicating")
         {
             BestXYZ(log) => {
-                // TODO: Do we want to only update our stored values if
-                // both position and velocity are valid? The alternative
-                // would be to just update which ever one is valid and
-                // ignore the other
                 if log.pos_status == 0 && log.vel_status == 0 {
                     data.update_info(LockInfo {
                         time: OEMTime {

--- a/services/novatel-oem6-service/src/model.rs
+++ b/services/novatel-oem6-service/src/model.rs
@@ -133,7 +133,7 @@ pub struct Subsystem {
 }
 
 impl Subsystem {
-    pub fn new(bus: &'static str, data: Arc<LockData>) -> OEMResult<Subsystem> {
+    pub fn new(bus: &str, data: Arc<LockData>) -> OEMResult<Subsystem> {
         let (log_send, log_recv) = sync_channel(5);
         let (response_send, response_recv) = sync_channel(5);
 

--- a/services/novatel-oem6-service/src/tests/schema/mutations/test_hardware.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mutations/test_hardware.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-// TODO: Add telemetryNominal results
-
 use super::*;
 
 #[test]

--- a/services/novatel-oem6-service/src/tests/schema/queries/test_results.rs
+++ b/services/novatel-oem6-service/src/tests/schema/queries/test_results.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-// TODO: Add telemetryNominal results
-
 use super::*;
 
 #[test]


### PR DESCRIPTION
Hard coding things is bad. Pulling the bus device (ex. "/dev/ttyS4") from the master config.toml file