### PR TITLE
Adding Rust doc generation to gendocs.py

### DIFF
--- a/docs/services/core-services.rst
+++ b/docs/services/core-services.rst
@@ -5,7 +5,7 @@ The core services are all the services that provide critical flight software cap
 
 Upcoming services are:
 
- - Telmetry Database Service
+ - `Telmetry Database Service <../rust-docs/telemetry_service/index.html>`_
  - Communication Service
  - Shell Service
  - File Service

--- a/docs/services/core-services.rst
+++ b/docs/services/core-services.rst
@@ -5,7 +5,11 @@ The core services are all the services that provide critical flight software cap
 
 Upcoming services are:
 
- - `Telmetry Database Service <../rust-docs/telemetry_service/index.html>`_
+ - |telem-db|
  - Communication Service
  - Shell Service
  - File Service
+ 
+ .. |telem-db| raw:: html
+ 
+    <a href="../rust-docs/telemetry_service/index.html" target="_blank">Telemetry Database Service</a>

--- a/tools/gendocs.py
+++ b/tools/gendocs.py
@@ -3,6 +3,7 @@ import argparse
 import subprocess
 import os
 import shutil
+from distutils import dir_util
 
 GENERATE_XML = """
 (cat {0};
@@ -47,9 +48,10 @@ def main():
         gendocs_xml(dir, "docs/Doxyfile", args.version, doc_dir)
 
     subprocess.call("sphinx-build docs/ html/", shell=True)
-
     shutil.rmtree("./xml")
-
+    
+    subprocess.call("cargo kubos -c doc -t x86-linux-native -- --no-deps", shell=True)
+    dir_util.copy_tree("target/x86_64-unknown-linux-gnu/doc", "html/sdk-docs/rust")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Our new Rust crates have lots of documentation which should be included in our official docs. This PR starts to integrate them by using Rust's doc gen (via `cargo kubos -c doc` to handle our custom C/Rust combo crates) and then copying the resulting HTML files into our usual `html` output folder.

Our existing docs are then able to reference them using relative links. An example has been included in this PR.

For an example doc link: http://docs.kubos.co/beta/services/core-services.html
To look at all the Rust docs: http://docs.kubos.co/beta/rust-docs/telemetry_service/index.html

Notes: 
- I looked at [Doxidize](https://github.com/steveklabnik/doxidize), but was unable to get it to quickly work. It's a very new tool, so might still be good to return to at some point.
- There isn't currently a way to generate a master index.html file for all of the Rust crates, so we can't just have one easy pointer to the Rust docs. [There's an open feature request for it, though](https://github.com/rust-lang/rust/issues/16103)