### PR TITLE
[WIP] Move to KISS framed UDP packets in Serial wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ name = "backtrace"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -19,10 +19,10 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.17"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -32,7 +32,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -47,7 +47,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -88,22 +88,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "diesel"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_derives 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsqlite3-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "failure"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang-nursery/failure#fa39406f6eea8fc5885f1d47001bbc5d813c25d7"
+source = "git+https://github.com/rust-lang-nursery/failure#6706772ff04bcb633fb2a6056060bfd63df3568f"
 dependencies = [
  "display_derive 1.0.0 (git+https://github.com/withoutboats/display_derive)",
  "failure_derive 1.0.0 (git+https://github.com/rust-lang-nursery/failure)",
@@ -169,11 +169,11 @@ dependencies = [
 [[package]]
 name = "failure_derive"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang-nursery/failure#fa39406f6eea8fc5885f1d47001bbc5d813c25d7"
+source = "git+https://github.com/rust-lang-nursery/failure#6706772ff04bcb633fb2a6056060bfd63df3568f"
 dependencies = [
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -276,13 +276,12 @@ dependencies = [
 
 [[package]]
 name = "isatty"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -336,8 +335,8 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_codegen 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -352,12 +351,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "kubos-app"
+version = "0.1.0"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kubos-service 0.1.0",
+ "kubos-system 0.1.0",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kubos-app-service"
+version = "0.1.0"
+dependencies = [
+ "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kubos-app 0.1.0",
+ "kubos-service 0.1.0",
+ "kubos-system 0.1.0",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -375,15 +391,33 @@ dependencies = [
  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "kubos-system"
+version = "0.1.0"
+dependencies = [
+ "kubos-service 0.1.0",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kubos-telemetry"
+version = "0.1.0"
+dependencies = [
+ "diesel 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -444,9 +478,9 @@ dependencies = [
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
  "mai400-api 0.1.0",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -473,7 +507,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -548,7 +582,7 @@ name = "ordermap"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -563,7 +597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.2.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -571,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -584,18 +618,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -628,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -663,27 +697,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.59"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.59"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -769,7 +803,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "isatty 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -787,21 +821,21 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.12.15"
+version = "0.13.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -824,12 +858,12 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -842,10 +876,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "telemetry-service"
 version = "0.1.0"
 dependencies = [
- "diesel 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kubos-telemetry 0.1.0",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -870,7 +905,7 @@ name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -880,7 +915,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -889,7 +924,7 @@ name = "toml"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -897,9 +932,9 @@ name = "udp-client"
 version = "0.1.0"
 dependencies = [
  "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -955,6 +990,15 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "uuid"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,11 +1023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,17 +1034,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbdd17cd962b570302f5297aea8648d5923e22e555c2ed2d8b2e34eca646bf6d"
-"checksum backtrace-sys 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0a44ce0e3758d8eb359302c71415dac06b4cfdc3ae50b2a53776d097b168770b"
+"checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bda13183df33055cbb84b847becce220d392df502ebe7a4a78d7021771ed94d0"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
-"checksum bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1d50c876fb7545f5f289cd8b2aee3f359d073ae819eed5d6373638e2c61e59"
-"checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
+"checksum bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd32989a66957d3f0cba6588f15d4281a733f4e9ffc43fcd2385f57d3bf99ff"
+"checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
 "checksum crc16 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "11a65c4797332f3e3a5945e0377875afc79b1bdc87082a4f98ac1ef15b47e2dd"
-"checksum diesel 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24815a0c2094f2c8dafe74ab3b9e975892f44acbb94b4d4b4898025a7615efa4"
-"checksum diesel_derives 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6471a2b637b414d3ee1504cf230409a550381c79204282f8fe06c527e4ae56be"
+"checksum diesel 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9db28a518f3e0c61bdb0044d9a8b2b369373c090c19fec07e49e3b8511dcffa"
+"checksum diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03bcaf77491f53e400d5ee3bdd57142ea4e1c47fe9217b3361ff9a76ca0e3d37"
 "checksum display_derive 1.0.0 (git+https://github.com/withoutboats/display_derive)" = "<none>"
 "checksum double 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "21d9ba47ea688a92ebe3bb1c19424b51a33fc1b72e719d6d90b7f93d9decfbf9"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -1025,12 +1064,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum ioctl-rs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum isatty 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a118a53ba42790ef25c82bb481ecf36e2da892646cccd361e69a6bb881e19398"
+"checksum isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6c324313540cd4d7ba008d43dc6606a32a5579f13cc17b2804c13096f0a5c522"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc520ae5efce621611ad03aa0ad6ebec0aabc60efa1e47df7d835609c079dd31"
 "checksum juniper_codegen 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2605e2fd568ff0ad62e2e6ca985950bbe53708c0e75b08d4fc640f05a564c9e"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazysort 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "183ec8cdfed14090d032b5498f10a38b91a56dff39573cc75e5c72c2c3de900a"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
 "checksum libsqlite3-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e9eb7b8e152b6a01be6a4a2917248381875758250dc3df5d46caf9250341dda"
@@ -1046,19 +1084,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
-"checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
-"checksum proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a45f2f0ae0b5757f6fe9e68745ba25f5246aea3598984ed81d013865873c1f84"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
+"checksum proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1fa93823f53cfd0f5ac117b189aed6cfdfb2cfc0a9d82e956dd7927595ed7d46"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
-"checksum quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e53eeda07ddbd8b057dde66d9beded11d0dfda13f0db0769e6b71d6bcf2074e"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "0a12d51a5b5fd700e6c757f15877685bfa04fd7eb60c108f01d045cafa0073c2"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum resize-slice 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a3cb2f74a9891e76958b9e0ccd269a25b466c3ae3bb3efd71db157248308c4a"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
-"checksum serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "2a4d976362a13caad61c38cf841401d2d4d480496a9391c3842c288b01f9de95"
-"checksum serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "94bb618afe46430c6b089e9b111dc5b2fcd3e26a268da0993f6d16bea51c6021"
-"checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
+"checksum serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)" = "fba5be06346c5200249c8c8ca4ccba4a09e8747c71c16e420bd359a0db4d8f91"
+"checksum serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)" = "79e4620ba6fbe051fc7506fab6f84205823564d55da18d55b695160fb3479cd8"
+"checksum serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "93aee34bb692dde91e602871bc792dd319e489c7308cdbbe5f27cf27c64280f5"
 "checksum serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
 "checksum serial-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
 "checksum serial-unix 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
@@ -1070,11 +1108,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum slog-stream 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3fac4af71007ddb7338f771e059a46051f18d1454d8ac556f234a0573e719daa"
 "checksum slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97c05b8ebc34ddd6b967994d5c6e9852fa92f8b82b3858c39451f97346dcce5"
-"checksum syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99d991a9e7c33123925e511baab68f7ec25c3795962fe326a2395e5a42a614f0"
+"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
+"checksum syn 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfd71b2be5a58ee30a6f8ea355ba8290d397131c00dfa55c3d34e6e13db5101"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
-"checksum synstructure 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "010366096045d8250555904c58da03377289e7f4b2ce7a5b1027e2b532f41000"
+"checksum synstructure 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "98cad891cd238c98e1f0aec9f7c0f620aa696e4e5f7daba56ac67b5e86a6b049"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
@@ -1089,10 +1127,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
+"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 "apis/novatel-oem6-api",
 "apis/nsl-duplex-d2",
 "apis/rust-radio-api",
+"apis/system-api",
 "apis/telemetry-api",
 "examples/rust-service/extern-lib",
 "examples/rust-service/service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 "apis/novatel-oem6-api",
 "apis/nsl-duplex-d2",
 "apis/rust-radio-api",
+"apis/telemetry-api",
 "examples/rust-service/extern-lib",
 "examples/rust-service/service",
 "examples/udp-service-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+"apis/app-api",
 "apis/adcs-api",
 "apis/isis-ants-api",
 "apis/isis-imtq-api",
@@ -15,6 +16,7 @@ members = [
 "examples/udp-service-client",
 "hal/rust-hal/rust-uart",
 "kubos-build-helper",
+"services/app-service",
 "services/comms-service",
 "services/kubos-service",
 "services/iobc-supervisor-service",

--- a/apis/app-api/Cargo.toml
+++ b/apis/app-api/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubos-app"
+version = "0.1.0"
+authors = ["Marshall Culpepper <marshall@kubos.com>"]
+
+[dependencies]
+getopts = "0.2"
+juniper =  "0.9.2"
+kubos-service = { path = "../../services/kubos-service" }
+kubos-system = { path = "../system-api" }
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+toml = "0.4"
+uuid = { version = "0.6", features = ["v4"] }

--- a/apis/app-api/src/lib.rs
+++ b/apis/app-api/src/lib.rs
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! A simple API to make standalone Rust applications with high-level hooks
+//! for mission life-cycle management
+//#![deny(missing_docs)]
+#![deny(warnings)]
+
+extern crate uuid;
+extern crate getopts;
+
+extern crate kubos_system;
+
+#[macro_use]
+extern crate serde_derive;
+extern crate toml;
+
+use std::env;
+
+use getopts::Options;
+
+pub mod registry;
+use self::registry::*;
+
+/// SystemState
+#[allow(dead_code)]
+pub struct SystemState {
+    initial_deploy: bool,
+    detumble: bool,
+    over_station: bool,
+    reboot: bool,
+    sys_update: bool
+}
+
+pub type App = registry::App;
+pub type RunLevel = registry::RunLevel;
+
+#[allow(dead_code)]
+pub struct Timer {
+    id: u32,
+    label: String,
+    executed: bool,
+    when: u32,
+    rel_system_time: u32,
+    app_uuid: String
+}
+
+/// AppHandler
+#[allow(unused_variables)]
+pub trait AppHandler {
+    /// Timer fired
+    fn on_timer(&self, timer: &Timer) {
+    }
+
+    ///
+    fn on_boot(&self) {
+    }
+
+    ///
+    fn on_command(&self) {
+    }
+
+    /// app process shutting down
+    fn on_shutdown(&self) {
+    }
+}
+
+#[macro_export]
+macro_rules! app_main {
+    ($handler:expr) => {{
+        let name: Option<&'static str> = option_env!("CARGO_PKG_NAME");
+        let version: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
+        let authors: Option<&'static str> = option_env!("CARGO_PKG_AUTHORS");
+
+         App::main(name.unwrap_or("Unknown"),
+                   version.unwrap_or("Unknown"),
+                   authors.unwrap_or("Unknown"),
+                   std::process::id(),
+                   $handler)
+    }};
+}
+
+impl App {
+    pub fn main(name: &str, version: &str, authors: &str, _pid: u32, handler: &AppHandler) {
+        let args: Vec<String> = env::args().collect();
+        let program = args[0].clone();
+
+        let mut opts = Options::new();
+        opts.optflag("M", "metadata", "print app metadata and immediately exit");
+        opts.optflag("h", "help", "print this help menu");
+
+        let matches = match opts.parse(&args[1..]) {
+            Ok(m) => m,
+            Err(f) => panic!(f.to_string())
+        };
+
+        if matches.opt_present("h") {
+            let brief = format!("Usage: {} [options]", program);
+            print!("{}", opts.usage(&brief));
+            return;
+        }
+
+        if matches.opt_present("M") {
+            println!("{}", toml::to_string(
+                &AppMetadata::new(name, version, authors)).unwrap());
+            return;
+        }
+
+        // TODO graphql client, update
+
+        let _uuid = env::var_os("KUBOS_APP_UUID");
+        let run_level = env::var_os("KUBOS_APP_RUN_LEVEL");
+
+        match run_level {
+            Some(level) => {
+                if &level == "OnBoot" {
+                    handler.on_boot();
+                } else {
+                    handler.on_command();
+                }
+            },
+            None => { handler.on_command(); },
+        }
+    }
+}

--- a/apis/app-api/src/lib.rs
+++ b/apis/app-api/src/lib.rs
@@ -119,8 +119,6 @@ impl App {
             return;
         }
 
-        // TODO graphql client, update
-
         let _uuid = env::var_os("KUBOS_APP_UUID");
         let run_level = env::var_os("KUBOS_APP_RUN_LEVEL");
 

--- a/apis/app-api/src/registry.rs
+++ b/apis/app-api/src/registry.rs
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::cell::RefCell;
+use std::fmt;
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use toml;
+use uuid::Uuid;
+
+pub const K_APPS_DIR: &'static str = "/home/system/kubos/apps";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AppMetadata {
+    pub name: String,
+    pub version: String,
+    pub author: String,
+}
+
+impl AppMetadata {
+    pub fn new(name: &str, version: &str, author: &str) -> AppMetadata {
+        AppMetadata {
+            name: name.to_string(),
+            version: version.to_string(),
+            author: author.to_string()
+        }
+    }
+}
+
+/// Kubos RunLevel struct
+#[derive(Clone,Debug,Deserialize,Serialize,PartialEq)]
+pub enum RunLevel {
+    OnBoot,
+    OnCommand
+}
+
+impl fmt::Display for RunLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RunLevel::OnBoot => write!(f, "OnBoot"),
+            RunLevel::OnCommand => write!(f, "OnCommand")
+        }
+    }
+}
+
+/// Kubos App struct
+#[derive(Clone,Debug,Deserialize,Serialize)]
+pub struct App {
+    pub uuid: String,
+    pub pid: u32,
+    pub path: String,
+    pub metadata: AppMetadata,
+}
+
+#[derive(Debug,Deserialize,Serialize)]
+pub struct AppRegistryEntry {
+    pub active: bool,
+    pub run_level: RunLevel,
+    pub app: App,
+}
+
+
+impl Clone for AppRegistryEntry {
+    fn clone(&self) -> AppRegistryEntry {
+        AppRegistryEntry {
+            app: self.app.clone(),
+            active: self.active,
+            run_level: self.run_level.clone()
+        }
+    }
+}
+
+impl AppRegistryEntry {
+    pub fn from_dir(dir: &str) -> Option<AppRegistryEntry> {
+        let app_toml: PathBuf = [dir, "app.toml"].iter().collect();
+        if !app_toml.exists() {
+            return None;
+        }
+
+        let mut f = fs::File::open(app_toml).unwrap();
+        let mut buffer = String::new();
+        if let Ok(_) = f.read_to_string(&mut buffer) {
+            if let Ok(entry) = toml::from_str::<AppRegistryEntry>(&buffer) {
+                return Some(entry);
+            }
+        }
+        return None;
+    }
+
+    pub fn save(&self) -> Result<bool, String> {
+        let mut app_toml = PathBuf::from(self.app.path.clone());
+        app_toml.set_file_name("app.toml");
+
+        match fs::File::create(app_toml) {
+            Ok(mut file) => match toml::to_string(&self) {
+                Ok(toml_str) => match file.write_all(&toml_str.into_bytes()) {
+                    Ok(_) => Ok(true),
+                    Err(err) => Err(format!("{}", err))
+                },
+                Err(err) => Err(format!("{}", err))
+            },
+            Err(err) => Err(format!("{}", err))
+        }
+
+        //let mut file = fs::File::create(app_toml).unwrap();
+        //let _result = file.write_all(&toml::to_string(&self).unwrap().into_bytes());
+    }
+}
+
+#[derive(Deserialize,Serialize)]
+pub struct AppRegistry {
+    pub entries: RefCell<Vec<AppRegistryEntry>>,
+    pub apps_dir: String
+}
+
+impl AppRegistry {
+    pub fn new_from_dir(apps_dir: &str) -> AppRegistry {
+        let registry = AppRegistry {
+            entries: RefCell::new(Vec::new()),
+            apps_dir: String::from(apps_dir)
+        };
+
+        if !Path::new(apps_dir).is_dir() {
+            return registry;
+        }
+
+        registry.entries.borrow_mut().extend(registry.discover_apps());
+        return registry;
+    }
+
+    pub fn new() -> AppRegistry {
+        Self::new_from_dir(K_APPS_DIR)
+    }
+
+    fn discover_apps(&self) -> Vec<AppRegistryEntry> {
+        let mut reg_entries: Vec<AppRegistryEntry> = Vec::new();
+
+        if let Ok(entries) = fs::read_dir(&self.apps_dir) {
+            for entry in entries {
+                if let Ok(entry) = entry {
+                    if let Ok(file_type) = entry.file_type() {
+                        if file_type.is_dir() && entry.file_name().to_str() != Some("active") {
+                            reg_entries.extend(self.discover_versions(entry.path()));
+                        }
+                    }
+                }
+            }
+        }
+
+        reg_entries
+    }
+
+    fn discover_versions(&self, app_dir: PathBuf) -> Vec<AppRegistryEntry> {
+        let mut reg_entries: Vec<AppRegistryEntry> = Vec::new();
+        if let Ok(versions) = fs::read_dir(app_dir) {
+            for version in versions {
+                if let Ok(version) = version {
+                    if let Ok(v_file_type) = version.file_type() {
+                        if v_file_type.is_dir() {
+                            let v_path = version.path();
+                            let version_path = v_path.to_str().expect("invalid version path");
+
+                            if let Some(entry) = AppRegistryEntry::from_dir(version_path) {
+                                reg_entries.push(entry);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        reg_entries
+    }
+
+    pub fn register(&self, path: &str) -> Result<AppRegistryEntry, String> {
+        let app_path = Path::new(path);
+        if !app_path.exists() {
+            return Err(format!("{} does not exist", path));
+        }
+
+        let app_metadata = Command::new(path)
+                                   .args(&["--metadata"])
+                                   .output()
+                                   .expect("Failed to get app metadata");
+
+        if !app_metadata.status.success() {
+            return Err("Bad exit code getting app metadata".to_string());
+        }
+
+        let metadata: AppMetadata =
+            toml::from_slice(app_metadata.stdout.as_slice()).unwrap();
+
+        let mut entries = self.entries.borrow_mut();
+        let mut app_uuid: Uuid = Uuid::new_v4();
+        for entry in entries.iter_mut() {
+            if entry.active && entry.app.metadata.name == metadata.name {
+                entry.active = false;
+                app_uuid = Uuid::parse_str(&entry.app.uuid).unwrap();
+                entry.save()?;
+                break;
+            }
+        }
+
+        let app_uuid_str = app_uuid.hyphenated().to_string();
+        let apps_dir = Path::new(&self.apps_dir);
+        if !apps_dir.exists() {
+            match fs::create_dir(apps_dir) {
+                Err(err) => { return Err(format!("Couldn't create apps dir {}: {:?}", apps_dir.display(), err)); },
+                Ok(_) => {}
+            }
+        }
+
+        assert!(apps_dir.exists());
+        let app_dir_path = format!("{}/{}/{}", self.apps_dir, app_uuid_str,
+                                   metadata.version.as_str());
+        let app_dir = Path::new(&app_dir_path);
+
+        if !app_dir.exists() {
+            match fs::create_dir_all(app_dir) {
+                Err(err) => { return Err(format!("Couldn't create app dir {}: {:?}", app_dir.display(), err)); },
+                Ok(_) => {}
+            }
+        }
+
+        let app_filename = app_path.file_name().expect("couldn't get app filename");
+
+        match fs::copy(path, app_dir.join(Path::new(app_filename))) {
+            Err(err) => { return Err(format!("Couldn't copy app binary: {:?}", err)); },
+            Ok(_) => {}
+        }
+
+        let active_dir = PathBuf::from(format!("{}/active", self.apps_dir));
+        if !active_dir.exists() {
+            match fs::create_dir_all(active_dir.clone()) {
+                Err(err) => { return Err(format!("Couldn't create 'active' dir {}: {:?}", active_dir.display(), err)); },
+                Ok(_) => {}
+            }
+        }
+
+        let active_symlink = active_dir.join(app_uuid_str.clone());
+
+        if active_symlink.exists() {
+            match fs::remove_file(active_symlink.clone()) {
+                Err(err) => { return Err(format!("Couldn't remove symlink {}: {:?}", active_symlink.display(), err)); },
+                Ok(_) => {}
+            }
+        }
+
+        match unix::fs::symlink(app_dir.to_str().expect("invalid app dir"),
+                                active_symlink.clone())
+        {
+            Err(err) => { return Err(format!("Couldn't symlink {} to {}: {:?}", active_symlink.display(), app_dir.display(), err)); },
+            Ok(_) => {}
+        }
+
+        let reg_entry = AppRegistryEntry {
+            app: App {
+                uuid: app_uuid_str.to_string(),
+                metadata: metadata,
+                pid: 0,
+                path: app_dir.join(Path::new(app_filename)).to_str().expect("invalid app dir").to_string(),
+            },
+            active: true,
+            run_level: RunLevel::OnCommand
+        };
+
+        entries.push(reg_entry);
+        entries[entries.len() - 1].save()?;
+        Ok(entries[entries.len() - 1].clone())
+    }
+
+    pub fn start_app(&self, app_uuid: &str, run_level: RunLevel) -> Result<u32, String>
+    {
+        let entries = self.entries.borrow();
+        let app: &App;
+
+        match entries.iter().find(|ref e| e.active && e.app.uuid == app_uuid) {
+            Some(entry) => { app = &entry.app; },
+            None => {
+                return Err(format!("Active app with UUID {} does not exist", app_uuid));
+            }
+        }
+
+        let app_path = PathBuf::from(&app.path);
+        if !app_path.exists() {
+            return Err(format!("{} does not exist", &app.path));
+        }
+
+        let child = Command::new(app_path)
+                            .env("KUBOS_APP_UUID", app.uuid.clone())
+                            .env("KUBOS_APP_RUN_LEVEL", format!("{}", run_level))
+                            .spawn()
+                            .expect("Failed to spawn app");
+
+        Ok(child.id())
+    }
+}

--- a/apis/app-api/tests/registry_test.rs
+++ b/apis/app-api/tests/registry_test.rs
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+extern crate kubos_app;
+extern crate toml;
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kubos_app::registry::*;
+
+fn setup_registry() -> PathBuf {
+    let mut registry_dir = env::temp_dir();
+    registry_dir.push("apps");
+    if registry_dir.exists() {
+        assert!(fs::remove_dir_all(registry_dir.clone()).is_ok());
+    }
+
+    assert!(fs::create_dir_all(registry_dir.clone()).is_ok());
+
+    registry_dir
+}
+
+#[test]
+fn default_apps_dir() {
+    let registry = AppRegistry::new();
+    assert_eq!(registry.apps_dir, K_APPS_DIR);
+}
+
+#[test]
+fn custom_apps_dir() {
+    let registry = AppRegistry::new_from_dir("/custom/dir");
+    assert_eq!(registry.apps_dir, String::from("/custom/dir"));
+}
+
+#[test]
+fn invalid_apps_dir_empty_reg() {
+    let registry = AppRegistry::new_from_dir("/i/dont/exist");
+    assert_eq!(registry.entries.borrow().len(), 0);
+}
+
+#[test]
+fn empty_apps_dir_empty_reg() {
+    let mut registry_dir = setup_registry();
+
+    let registry = AppRegistry::new_from_dir(registry_dir.to_str().unwrap());
+    assert_eq!(registry.entries.borrow().len(), 0);
+}
+
+#[test]
+fn serialize_entry() {
+    let dummy = AppRegistryEntry {
+        app: App {
+            uuid: String::from("a-b-c-d"),
+            metadata: AppMetadata {
+                name: String::from("dummy"),
+                version: String::from("0.0.1"),
+                author: String::from("noone"),
+            },
+            pid: 101,
+            path: String::from("/fake/path")
+        },
+        active: true,
+        run_level: RunLevel::OnCommand
+    };
+
+    let str = toml::to_string(&dummy).unwrap();
+    let parsed: AppRegistryEntry  = toml::from_str(&str).unwrap();
+
+    assert_eq!(parsed.active, dummy.active);
+    assert_eq!(parsed.run_level, dummy.run_level);
+    assert_eq!(parsed.app.uuid, dummy.app.uuid);
+    assert_eq!(parsed.app.pid, dummy.app.pid);
+    assert_eq!(parsed.app.path, dummy.app.path);
+    assert_eq!(parsed.app.metadata.name, dummy.app.metadata.name);
+    assert_eq!(parsed.app.metadata.version, dummy.app.metadata.version);
+    assert_eq!(parsed.app.metadata.author, dummy.app.metadata.author);
+}

--- a/apis/system-api/Cargo.toml
+++ b/apis/system-api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kubos-system"
+version = "0.1.0"
+authors = ["Marshall Culpepper <marshall@kubos.com>"]
+
+[dependencies]
+lazy_static = "1.0"
+kubos-service = { path = "../../services/kubos-service" }
+nix = "0.10.0"
+serde_json = "1.0"

--- a/apis/system-api/src/lib.rs
+++ b/apis/system-api/src/lib.rs
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![deny(warnings)]
+
+/// KubOS System level APIs
+#[macro_use]
+extern crate lazy_static;
+extern crate kubos_service;
+extern crate serde_json;
+
+use std::env;
+use std::error;
+use std::fmt;
+use std::mem;
+use std::net::UdpSocket;
+use std::process::Command;
+use std::str::FromStr;
+use std::time::Duration;
+
+pub const VAR_BOOT_COUNT: &'static str = "bootcount";
+pub const VAR_BOOT_LIMIT: &'static str = "bootlimit";
+pub const VAR_KUBOS_CURR_VERSION: &'static str = "kubos_curr_version";
+pub const VAR_KUBOS_PREV_VERSION: &'static str = "kubos_prev_version";
+pub const VAR_KUBOS_CURR_TRIED: &'static str = "kubos_curr_tried";
+pub const VAR_KUBOS_INITIAL_DEPLOY: &'static str = "kubos_initial_deploy";
+
+pub const SVC_APP: &'static str = "app-service";
+pub const SVC_GPS: &'static str = "gps-service";
+pub const SVC_TELEMETRY: &'static str = "telemetry-service";
+
+type Result<T> = std::result::Result<T, SystemError>;
+
+lazy_static! {
+    static ref FW_PRINTENV_PATH: &'static str = {
+        match env::var("KUBOS_PRINTENV") {
+            Ok(path) => unsafe {
+                let ret = mem::transmute(&path as &str);
+                mem::forget(path);
+                ret
+            },
+            _ => "/usr/sbin/fw_printenv"
+        }
+    };
+}
+
+#[derive(Debug)]
+pub enum SystemError {
+    Message(String),
+    JsonError(serde_json::Error),
+    IoError(std::io::Error),
+}
+
+impl fmt::Display for SystemError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SystemError::Message(ref s) => write!(f, "{}", s),
+            SystemError::JsonError(ref e) => e.fmt(f),
+            SystemError::IoError(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl error::Error for SystemError {
+    fn description(&self) -> &str {
+        match *self {
+            SystemError::Message(ref s) => s.as_str(),
+            SystemError::JsonError(ref e) => e.description(),
+            SystemError::IoError(ref e) => e.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            SystemError::Message(_) => None,
+            SystemError::JsonError(ref e) => Some(e),
+            SystemError::IoError(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<String> for SystemError {
+    fn from(err: String) -> SystemError {
+        SystemError::Message(err)
+    }
+}
+
+impl From<serde_json::Error> for SystemError {
+    fn from(err: serde_json::Error) -> SystemError {
+        SystemError::JsonError(err)
+    }
+}
+
+impl From<std::io::Error> for SystemError {
+    fn from(err: std::io::Error) -> SystemError {
+        SystemError::IoError(err)
+    }
+}
+
+fn get_boot_var(name: &str) -> Result<String> {
+    let output = Command::new(*FW_PRINTENV_PATH)
+                         .args(&["-n", name])
+                         .output()
+                         .expect(&format!("Failed to execute {}", *FW_PRINTENV_PATH));
+
+    if !output.status.success() {
+        Err(SystemError::Message(String::from("Var not found")))
+    } else {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+}
+
+macro_rules! u32_boot_var_getter {
+    ($fn:ident, $prop:expr) => {
+        pub fn $fn() -> Option<u32> {
+            match get_boot_var($prop) {
+                Ok(v) => match u32::from_str(&v) {
+                    Ok(val) => Some(val),
+                    Err(_) => None,
+                },
+                Err(_) => None
+            }
+        }
+    }
+}
+
+macro_rules! str_boot_var_getter {
+    ($fn:ident, $prop:expr) => {
+        pub fn $fn() -> Option<String> {
+            match get_boot_var($prop) {
+                Ok(v) => Some(v),
+                Err(_) => None
+            }
+        }
+    }
+}
+
+macro_rules! bool_boot_var_getter {
+    ($fn:ident, $prop:expr) => {
+        pub fn $fn() -> Option<bool> {
+            match get_boot_var($prop) {
+                Ok(v) => match v.to_lowercase().as_ref() {
+                    "t" | "true" | "on" | "1" | "y" | "yes" => Some(true),
+                    _ => Some(false)
+                },
+                Err(_) => None
+            }
+        }
+    }
+}
+
+u32_boot_var_getter!(boot_count, VAR_BOOT_COUNT);
+u32_boot_var_getter!(boot_limit, VAR_BOOT_LIMIT);
+str_boot_var_getter!(kubos_curr_version, VAR_KUBOS_CURR_VERSION);
+str_boot_var_getter!(kubos_prev_version, VAR_KUBOS_PREV_VERSION);
+u32_boot_var_getter!(kubos_curr_tried, VAR_KUBOS_CURR_TRIED);
+bool_boot_var_getter!(kubos_initial_deploy, VAR_KUBOS_INITIAL_DEPLOY);
+
+pub fn query(host_url: &str, query: &str, timeout: Option<Duration>)
+    -> Result<serde_json::Value>
+{
+    // TODO: make these return Results
+    let socket = UdpSocket::bind("0.0.0.0:0")?;
+    socket.connect(host_url)?;
+    socket.send(query.as_bytes())?;
+
+    // Wait for a response, but don't actually read it yet.
+    // If we don't get a reply within one second, the service probably
+    // isn't actually running.
+    socket.set_read_timeout(timeout).unwrap();
+
+    let mut buf = [0; 4096];
+    let (amt, _) = socket.recv_from(&mut buf)?;
+
+    let v: serde_json::Value = serde_json::from_slice(&buf[0..(amt)])?;
+
+    if v.is_array() {
+        let err = v.get(0).unwrap();
+        return Err(SystemError::Message(err["message"].as_str().unwrap().to_string()));
+    } else if v.get("errs").is_some() {
+        let errs: serde_json::Value = v.get("errs").unwrap().clone();
+        if errs.is_string() {
+            let errs_str = errs.as_str().unwrap();
+            if errs_str.len() > 0 {
+                return Err(SystemError::Message(errs_str.to_string()));
+            }
+        } else {
+            return Err(SystemError::Message(errs["message"].as_str().unwrap().to_string()));
+        }
+    }
+
+    Ok(v["msg"].clone())
+}

--- a/apis/system-api/tests/test_boot_vars.rs
+++ b/apis/system-api/tests/test_boot_vars.rs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![deny(warnings)]
+extern crate kubos_system;
+
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+
+const DUMMY_PRINTENV: &'static str = r#"
+#!/bin/bash
+[[ -n "${!2+set}" ]] || exit 1
+echo ${!2}
+"#;
+
+fn setup_dummy_printenv() -> String {
+    let mut bin_dest = env::temp_dir();
+    bin_dest.push("dummy-printenv");
+
+    let mut file = fs::File::create(bin_dest.clone()).unwrap();
+    file.write_all(DUMMY_PRINTENV.as_bytes()).expect("Failed to write dummy printenv");;
+
+    let mut perms = file.metadata().unwrap().permissions();
+    perms.set_mode(0o755);
+    file.set_permissions(perms).expect("Failed to change file permissions");
+
+    let bin_str = bin_dest.to_str().unwrap();
+    env::set_var("KUBOS_PRINTENV", bin_str);
+
+    String::from(bin_str)
+}
+
+#[test]
+fn u32_vars() {
+    setup_dummy_printenv();
+
+    env::set_var(kubos_system::VAR_BOOT_COUNT, "123");
+    assert_eq!(kubos_system::boot_count(), Some(123));
+
+    env::set_var(kubos_system::VAR_BOOT_COUNT, "");
+    assert_eq!(kubos_system::boot_count(), None);
+
+    // should be undefined so far..
+    assert_eq!(kubos_system::boot_limit(), None);
+
+    env::set_var(kubos_system::VAR_BOOT_LIMIT, "abc");
+    assert_eq!(kubos_system::boot_limit(), None);
+}
+
+#[test]
+fn bool_vars() {
+    setup_dummy_printenv();
+
+    assert_eq!(kubos_system::kubos_initial_deploy(), None);
+
+    env::set_var(kubos_system::VAR_KUBOS_INITIAL_DEPLOY, "0");
+    assert_eq!(kubos_system::kubos_initial_deploy(), Some(false));
+
+    env::set_var(kubos_system::VAR_KUBOS_INITIAL_DEPLOY, "1");
+    assert_eq!(kubos_system::kubos_initial_deploy(), Some(true));
+}
+
+#[test]
+fn str_vars() {
+    setup_dummy_printenv();
+
+    assert_eq!(kubos_system::kubos_curr_version(), None);
+
+    env::set_var(kubos_system::VAR_KUBOS_CURR_VERSION, "1.23");
+    assert_eq!(kubos_system::kubos_curr_version(), Some(String::from("1.23")));
+
+    env::set_var(kubos_system::VAR_KUBOS_CURR_VERSION, "");
+    assert_eq!(kubos_system::kubos_curr_version(), Some(String::from("")));
+}

--- a/apis/telemetry-api/Cargo.toml
+++ b/apis/telemetry-api/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "kubos-telemetry"
+version = "0.1.0"
+authors = ["Marshall Culpepper <marshall@kubos.com>"]
+
+[dependencies]
+diesel = { version = "1.0.0", features = ["sqlite"] }
+time = "0.1"

--- a/apis/telemetry-api/src/lib.rs
+++ b/apis/telemetry-api/src/lib.rs
@@ -13,8 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#[macro_use]
+extern crate diesel;
+extern crate time;
+
+use std::time::SystemTime;
+
+pub mod models;
+pub use models::*;
 
 use diesel::dsl::sql;
+use diesel::insert_into;
 use diesel::prelude::*;
 use diesel::sql_query;
 use diesel::sql_types::Bool;
@@ -74,10 +83,37 @@ impl Database {
                 ).execute(&self.connection)
                 {
                     Ok(_) => println!("Telemetry table created"),
-                    _ => panic!("Error creating table"),
+                    Err(err) => panic!("Error creating table: {:?}", err),
                 }
             }
         };
+    }
+
+    pub fn insert<'a>(&self, timestamp: i32,
+                             subsystem: &'a str,
+                             parameter: &'a str,
+                             value: &'a str) -> QueryResult<usize>
+    {
+        use self::telemetry;
+
+        let new_entry = NewEntry {
+            timestamp: timestamp,
+            subsystem: subsystem,
+            parameter: parameter,
+            value: value,
+        };
+
+        insert_into(telemetry::table)
+            .values(&new_entry)
+            .execute(&self.connection)
+    }
+
+    pub fn insert_systime<'a>(&self, subsystem: &'a str,
+                                     parameter: &'a str,
+                                     value: &'a str) -> QueryResult<usize>
+    {
+        let timestamp = time::now_utc().to_timespec().sec;
+        self.insert(timestamp as i32, subsystem, parameter, value)
     }
 }
 

--- a/apis/telemetry-api/src/models.rs
+++ b/apis/telemetry-api/src/models.rs
@@ -14,10 +14,21 @@
 // limitations under the License.
 //
 
+use super::telemetry;
+
 #[derive(Debug, Queryable)]
 pub struct Entry {
     pub timestamp: i32,
     pub subsystem: String,
     pub parameter: String,
     pub value: String,
+}
+
+#[derive(Insertable)]
+#[table_name="telemetry"]
+pub struct NewEntry<'a> {
+    pub timestamp: i32,
+    pub subsystem: &'a str,
+    pub parameter: &'a str,
+    pub value: &'a str,
 }

--- a/examples/udp-service-client/Cargo.toml
+++ b/examples/udp-service-client/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 authors = ["Catherine Garabedian <catherine@kubos.co>"]
 
 [dependencies]
+getopts = "0.2"
 nix = "0.10.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0.10"
 toml = "0.4"
+kubos-service = { path = "../../services/kubos-service" }

--- a/examples/udp-service-client/src/main.rs
+++ b/examples/udp-service-client/src/main.rs
@@ -16,147 +16,56 @@
 // Example client program for interacting with a Kubos Service using UDP
 //
 
-#[macro_use]
-extern crate nix;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate toml;
+extern crate getopts;
+extern crate kubos_service;
 
-use std::net::{SocketAddr, UdpSocket};
+use std::cell::RefCell;
 use std::env;
-use std::fs::File;
-use std::io::prelude::*;
-use std::os::unix::io::AsRawFd;
-use std::time::Duration;
+use std::net::SocketAddr;
+use std::str;
 
-const FIONREAD: u16 = 0x541B;
-ioctl!(bad read available with FIONREAD; usize);
+use kubos_service::{FrameHandler, KissUdpSocket};
+use getopts::Options;
 
-#[derive(Debug, Deserialize)]
-pub struct Address {
-    ip: String,
-    port: u16,
+struct Handler<'a> {
+    socket: RefCell<Option<KissUdpSocket<'a>>>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct Config {
-    host: Address,
-    service: Address,
-    query_file: String,
-}
-
-fn configure_client() -> (SocketAddr, SocketAddr, String) {
-    let args: Vec<String> = env::args().collect();
-
-    let config: Config = if args.len() == 2 {
-        let mut raw = String::new();
-        let filename = &args[1];
-        match File::open(filename)
-            .map(|mut f| f.read_to_string(&mut raw))
-            .map(|_| toml::from_str(&raw))
-        {
-            Ok(toml) => toml.unwrap(),
-            _ => {
-                panic!("Couldn't open config file");
-            }
-        }
-    } else {
-        panic!("No config file");
-    };
-
-    let listen_addr = format!("{}:{}", config.host.ip, config.host.port)
-        .parse::<SocketAddr>()
-        .unwrap();
-
-    let send_addr = format!("{}:{}", config.service.ip, config.service.port)
-        .parse::<SocketAddr>()
-        .unwrap();
-
-    let query: String = {
-        let mut raw = String::new();
-        match File::open(config.query_file).map(|mut f| f.read_to_string(&mut raw)) {
-            Ok(_) => raw,
-            _ => {
-                println!("Using default query");
-                "{ping}".to_owned()
-            }
-        }
-    };
-
-    (listen_addr, send_addr, query)
-}
-
-fn main() {
-    // Get the host IP, remote IP, and query string from the configuration file
-    let (client_addr, service_addr, query) = configure_client();
-
-    // Get a socket for the host IP
-    let socket = match UdpSocket::bind(client_addr) {
-        Ok(sock) => {
-            println!("Bound socket to {}", client_addr);
-            sock
-        }
-        Err(err) => {
-            println!("Could not bind: {}", err);
-            return;
-        }
-    };
-
-    // Send our query to the requested service IP
-    let result = socket.send_to(&query.as_bytes(), &service_addr);
-    match result {
-        Ok(amt) => println!("Sent {} bytes", amt),
-        Err(err) => {
-            println!("Write error: {}", err);
-            return;
+impl<'a> FrameHandler for Handler<'a> {
+    fn handle_frame(&self, socket: &KissUdpSocket, frame: &[u8], src_addr: SocketAddr) {
+        println!("{}", str::from_utf8(frame).unwrap());
+        let s = self.socket.borrow();
+        match *s {
+            Some(ref s) => { s.looping.replace(false); },
+            None => {},
         }
     }
+}
 
-    // Wait for a response, but don't actually read it yet.
-    // If we don't get a reply within one second, the service probably
-    // isn't actually running.
-    socket.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
-    let mut buf: [u8; 1] = [0];
-    let result = socket.peek_from(&mut buf);
-    if let Err(err) = result {
-        println!("Read error: {}", err);
+pub fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 3 {
+        eprintln!("Usage: {} [dest] [graphql-query]", args[0]);
         return;
     }
 
-    // Get the number of bytes in the response so we know how big to make our buffer
-    let mut len: usize = 0;
-    unsafe {
-        match available(socket.as_raw_fd(), &mut len) {
-            Ok(_) => {}
-            Err(err) => {
-                println!("Failed to read bytes available: {}", err);
-                return;
-            }
-        }
-    }
+    let mut handler = Handler {
+        socket: RefCell::new(None)
+    };
 
-    // Allocate the buffer and read the response
-    let mut buf = vec![0u8; len].into_boxed_slice();
-    let result = socket.recv_from(&mut buf);
-    match result {
-        Ok((amt, src)) => {
-            println!("Received {} bytes from {}", amt, src);
-            let mut v: serde_json::Value = serde_json::from_slice(&buf[0..(amt)]).unwrap();
-            // If there's  'msg' field in the returned JSON, then our query went (atleast mostly) successfully.
-            // Extract the query response JSON from the field
-            match serde_json::from_value::<String>(v["msg"].clone()) {
-                Ok(msg) => {
-                    v = serde_json::from_str(&msg).unwrap_or_default();
-                }
-                // Otherwise, we'll just print the raw returned JSON
-                _ => println!("Errors returned from query"),
-            }
-            println!("{}", serde_json::to_string_pretty(&v).unwrap());
-        }
-        Err(err) => {
-            println!("Read error: {}", err);
-            return;
-        }
+    handler.socket.replace(
+        KissUdpSocket::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap(), &handler)
+    );
+
+    let s = handler.socket.borrow();
+    match *s {
+        Some(ref sock) => {
+            let dest = args[1].parse::<SocketAddr>().unwrap();
+            let query = &args[2];
+            sock.send_to(query.as_bytes(), dest);
+            sock.recv_loop();
+        },
+        None => {}
     }
 }

--- a/services/app-service/Cargo.toml
+++ b/services/app-service/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kubos-app-service"
+version = "0.1.0"
+authors = ["Marshall Culpepper <marshall@kubos.com>"]
+
+[dependencies]
+juniper =  "0.9.2"
+kubos-app = { path = "../../apis/app-api" }
+kubos-service = { path = "../kubos-service" }
+
+[dev-dependencies]
+kubos-system = { path = "../../apis/system-api" }
+serde_json = "1.0"

--- a/services/app-service/src/main.rs
+++ b/services/app-service/src/main.rs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![deny(warnings)]
+
+#[macro_use]
+extern crate juniper;
+extern crate kubos_app;
+extern crate kubos_service;
+
+use kubos_app::registry::AppRegistry;
+use kubos_service::{Config, Service};
+
+mod schema;
+
+fn main() {
+    let config = Config::new("app-service");
+    let registry = {
+        match config.get("registry-dir") {
+            Some(dir) => AppRegistry::new_from_dir(dir.as_str().unwrap()),
+            None => AppRegistry::new(),
+        }
+    };
+
+    Service::new(config,
+                 registry,
+                 schema::QueryRoot,
+                 schema::MutationRoot).start();
+}

--- a/services/app-service/src/schema.rs
+++ b/services/app-service/src/schema.rs
@@ -121,7 +121,19 @@ graphql_object!(MutationRoot : Context as "Mutation" |&self| {
         }
     }
 
-    field start_app(&executor, app_uuid: String, run_level: String) -> FieldResult<f64>
+    field uninstall(&executor, uuid: String, version: String) -> FieldResult<bool>
+        as "Uninstall App"
+    {
+        match executor.context().subsystem().uninstall(&uuid, &version) {
+            Ok(v) => Ok(v),
+            Err(msg) => {
+                println!("{}", msg);
+                Err(FieldError::new(msg, juniper::Value::null()))
+            }
+        }
+    }
+
+    field start_app(&executor, uuid: String, run_level: String) -> FieldResult<f64>
         as "Start App"
     {
         let run_level_o = {
@@ -131,7 +143,7 @@ graphql_object!(MutationRoot : Context as "Mutation" |&self| {
             }
         };
 
-        match executor.context().subsystem().start_app(&app_uuid, run_level_o) {
+        match executor.context().subsystem().start_app(&uuid, run_level_o) {
             Ok(pid) => Ok(f64::from(pid)),
             Err(err) => Err(FieldError::new(err, juniper::Value::null()))
         }

--- a/services/app-service/src/schema.rs
+++ b/services/app-service/src/schema.rs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+extern crate juniper;
+extern crate kubos_service;
+
+use juniper::{FieldError, FieldResult};
+use kubos_app::registry::{self, AppRegistry, RunLevel};
+
+type Context = kubos_service::Context<AppRegistry>;
+
+pub struct KApp(pub registry::App);
+
+graphql_object!(KApp: () as "App" |&self| {
+    description: "Kubos Application"
+
+    field uuid() -> FieldResult<&String>
+        as "UUID"
+    {
+        Ok(&(self.0.uuid))
+    }
+
+    field name() -> FieldResult<&String>
+        as "Name"
+    {
+        Ok(&self.0.metadata.name)
+    }
+
+    field version() -> FieldResult<&String>
+        as "Version"
+    {
+        Ok(&self.0.metadata.version)
+    }
+
+    field author() -> FieldResult<&String>
+        as "Author"
+    {
+        Ok(&self.0.metadata.author)
+    }
+
+    field pid() -> FieldResult<f64>
+        as "Process ID"
+    {
+        Ok(f64::from(self.0.pid))
+    }
+
+    field path() -> FieldResult<&String>
+        as "Absolute Path"
+    {
+        Ok(&self.0.path)
+    }
+});
+
+pub struct KAppRegistryEntry(pub registry::AppRegistryEntry);
+
+graphql_object!(KAppRegistryEntry: () as "AppRegistryEntry" |&self| {
+    field app() -> FieldResult<KApp>
+        as "App"
+    {
+        Ok(KApp(self.0.app.clone()))
+    }
+
+    field active() -> FieldResult<bool>
+        as "Active"
+    {
+        Ok(self.0.active)
+    }
+
+    field run_level() -> FieldResult<String>
+        as "Run Level"
+    {
+        Ok(String::from(format!("{}", self.0.run_level)))
+    }
+});
+
+
+///
+pub struct QueryRoot;
+
+/// Base GraphQL query model
+graphql_object!(QueryRoot : Context as "Query" |&self| {
+    field apps(&executor) -> FieldResult<Vec<KAppRegistryEntry>>
+        as "Kubos Apps Query"
+    {
+        let mut entries: Vec<KAppRegistryEntry> = Vec::new();
+        for entry in executor.context().subsystem().entries.borrow().iter() {
+            entries.push(KAppRegistryEntry(entry.clone()));
+        }
+        Ok(entries)
+    }
+});
+
+///
+pub struct MutationRoot;
+
+/// Base GraphQL mutation model
+graphql_object!(MutationRoot : Context as "Mutation" |&self| {
+
+    field register(&executor, path: String) -> FieldResult<KAppRegistryEntry>
+        as "Register App"
+    {
+        let registry = executor.context().subsystem();
+        match registry.register(&path) {
+            Ok(entry) => Ok(KAppRegistryEntry(entry)),
+            Err(e) => {
+                println!("Register error: {}", e);
+                Err(FieldError::new(e, juniper::Value::null()))
+            }
+        }
+    }
+
+    field start_app(&executor, app_uuid: String, run_level: String) -> FieldResult<f64>
+        as "Start App"
+    {
+        let run_level_o = {
+            match run_level.as_ref() {
+                "OnBoot" => RunLevel::OnBoot,
+                _ => RunLevel::OnCommand
+            }
+        };
+
+        match executor.context().subsystem().start_app(&app_uuid, run_level_o) {
+            Ok(pid) => Ok(f64::from(pid)),
+            Err(err) => Err(FieldError::new(err, juniper::Value::null()))
+        }
+    }
+});

--- a/services/app-service/tests/config.toml
+++ b/services/app-service/tests/config.toml
@@ -1,0 +1,6 @@
+[app-service]
+registry-dir = "/tmp/apps"
+
+[app-service.addr]
+ip = "0.0.0.0"
+port = 9999

--- a/services/app-service/tests/test_discover.rs
+++ b/services/app-service/tests/test_discover.rs
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![deny(warnings)]
+extern crate kubos_app;
+extern crate kubos_system;
+#[macro_use]
+extern crate serde_json;
+
+use std::panic;
+use std::time::Duration;
+
+mod utils;
+use utils::*;
+
+#[test]
+fn discover_app() {
+    let mut fixture = AppServiceFixture::setup();
+    fixture.install_dummy_app();
+    fixture.start_service();
+
+    let result = panic::catch_unwind(|| {
+        let apps_query = "{ apps { active, runLevel, app { uuid, name, version, author } } }";
+        let result = kubos_system::query("localhost:9999", &apps_query,
+                                        Some(Duration::from_secs(5)));
+        assert!(result.is_ok());
+
+        let apps = &result.unwrap()["apps"];
+        assert!(apps.is_array());
+        assert_eq!(apps.as_array().unwrap().len(), 1);
+
+        let v = &apps.as_array().unwrap()[0];
+        assert_eq!(v["active"], json!(true));
+        assert_eq!(v["runLevel"], json!("OnBoot"));
+        assert!(v["app"].is_object());
+        assert_eq!(v["app"]["uuid"], json!("a-b-c-d-e"));
+        assert_eq!(v["app"]["name"], json!("dummy"));
+        assert_eq!(v["app"]["version"], json!("0.0.1"));
+        assert_eq!(v["app"]["author"], json!("user"));
+    });
+
+    fixture.teardown();
+    assert!(result.is_ok());
+}

--- a/services/app-service/tests/test_register.rs
+++ b/services/app-service/tests/test_register.rs
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+extern crate kubos_app;
+extern crate kubos_system;
+#[macro_use]
+extern crate serde_json;
+
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::panic;
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::time::Duration;
+use std::{thread, thread::JoinHandle};
+
+const DUMMY_APP_SRC: &'static str = r#"
+#!/bin/bash
+if [ "$1" = "--metadata" ]; then
+    echo name = \"dummy\"
+    echo version = \"0.0.1\"
+    echo author = \"user\"
+else
+    echo uuid = \"$KUBOS_APP_UUID\"
+    echo run_level = \"$KUBOS_APP_RUN_LEVEL\"
+fi
+"#;
+
+const DUMMY_APP_TOML: &'static str = r#"
+active = true
+run_level = "OnBoot"
+
+[app]
+uuid = "a-b-c-d-e"
+pid = 0
+path = "{}/a-b-c-d-e/0.0.1/dummy-app"
+
+[app.metadata]
+name = "dummy"
+version = "0.0.1"
+author = "user"
+"#;
+
+struct AppServiceFixture {
+    registry_dir: PathBuf,
+    config_toml: PathBuf,
+    join_handle: Option<JoinHandle<()>>,
+    sender: Option<Sender<bool>>
+}
+
+impl AppServiceFixture {
+    fn setup() -> Self {
+        let mut registry_dir = env::temp_dir();
+        registry_dir.push("apps");
+
+        if !registry_dir.exists() {
+            assert!(fs::create_dir_all(registry_dir.clone()).is_ok());
+        }
+
+        let mut config_toml = env::temp_dir();
+        config_toml.push("config.toml");
+
+        let mut toml = fs::File::create(config_toml.clone()).unwrap();
+        toml.write_all(format!(r#"
+            [app-service]
+            registry-dir = "{}"
+            [app-service.addr]
+            ip = "0.0.0.0"
+            port = 9999"#, registry_dir.to_str().unwrap()).as_bytes())
+            .expect("Failed to write config.toml");
+
+        Self {
+            registry_dir: registry_dir,
+            config_toml: config_toml.clone(),
+            join_handle: None,
+            sender: None
+        }
+    }
+
+    fn start_service(&mut self)
+    {
+        let mut app_service = env::current_exe().unwrap();
+        app_service.pop();
+        app_service.set_file_name("kubos-app-service");
+
+        let (tx, rx): (Sender<bool>, Receiver<bool>) = channel();
+        let config_toml = self.config_toml.clone();
+
+        let handle = thread::spawn(move || {
+            let mut service_proc = Command::new(app_service)
+                .arg("-c")
+                .arg(config_toml.to_str().unwrap())
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap();
+
+            let mut run = true;
+            while run {
+                thread::sleep(Duration::from_millis(100));
+                if let Ok(_) = rx.try_recv() {
+                    service_proc.kill().unwrap();
+                    run = false;
+                }
+            }
+        });
+
+        // Give the process a bit to actually start
+        thread::sleep(Duration::from_millis(100));
+        self.join_handle = Some(handle);
+        self.sender = Some(tx);
+    }
+
+    fn setup_dummy_bin(&self, bin_dest: &Path) {
+        let mut file = fs::File::create(bin_dest.clone()).unwrap();
+        if !file.write_all(DUMMY_APP_SRC.as_bytes()).is_ok() {
+            panic!("failed to write app script");
+        }
+
+        let mut perms = file.metadata().unwrap().permissions();
+        perms.set_mode(0o755);
+
+        if !file.set_permissions(perms).is_ok() {
+            panic!("failed to change permissions of app script");
+        }
+    }
+
+    fn setup_dummy_toml(&self, toml_dest: &Path) {
+        let mut file = fs::File::create(toml_dest.clone()).unwrap();
+        if !file.write_all(DUMMY_APP_TOML.as_bytes()).is_ok() {
+            panic!("failed to write app TOML");
+        }
+    }
+
+    fn teardown(&mut self) {
+        if self.sender.is_some() {
+            self.sender.take().unwrap().send(true).unwrap();
+        }
+        if self.join_handle.is_some() {
+            self.join_handle.take().unwrap().join().unwrap();
+        }
+
+        if self.registry_dir.exists() {
+            assert!(fs::remove_dir_all(self.registry_dir.clone()).is_ok());
+        }
+
+    }
+}
+
+
+#[test]
+fn register_app() {
+    let mut fixture = AppServiceFixture::setup();
+    let mut app_bin = env::temp_dir();
+    app_bin.push("dummy-app");
+
+    fixture.setup_dummy_bin(&app_bin);
+
+    let register_query = format!(r#"mutation {{
+        register(path: "{}") {{
+            active, runLevel, app {{
+                uuid, name, version, author, pid, path
+            }}
+        }}
+    }}"#, app_bin.to_str().unwrap());
+
+    let apps_query = r#"{ apps { active, runLevel, app {
+        uuid, name, version, author, pid, path
+    } } }"#;
+
+    fn assert_expected(v: &serde_json::Value) {
+        assert_eq!(v["active"], json!(true));
+        assert_eq!(v["runLevel"], json!("OnCommand"));
+        assert!(v["app"].is_object());
+        assert_eq!(v["app"]["name"], json!("dummy"));
+        assert_eq!(v["app"]["version"], json!("0.0.1"));
+        assert_eq!(v["app"]["author"], json!("user"));
+    }
+
+    fixture.start_service();
+
+    let result = panic::catch_unwind(|| {
+        println!("{}", register_query);
+        let result = kubos_system::query("localhost:9999", &register_query,
+                                        Some(Duration::from_secs(2)));
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert_expected(&result.unwrap()["register"]);
+
+        let result = kubos_system::query("localhost:9999", &apps_query,
+                                        Some(Duration::from_secs(5)));
+        assert!(result.is_ok());
+        assert_expected(&result.unwrap()["apps"][0]);
+
+        /*let start_result = registry.start_app(&entry.app.uuid, RunLevel::OnBoot);
+        assert!(start_result.is_ok(), format!("error starting app: {}", start_result.unwrap_err()));
+        assert!(start_result.unwrap() > 0); // pid*/
+    });
+    fixture.teardown();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn discover_app() {
+    let mut fixture = AppServiceFixture::setup();
+    let mut parent_dir = fixture.registry_dir.clone();
+    parent_dir.push("a-b-c-d-e");
+    parent_dir.push("0.0.1");
+    assert!(fs::create_dir_all(parent_dir.clone()).is_ok());
+
+    let mut app_bin = parent_dir.clone();
+    app_bin.push("dummy-app");
+
+    fixture.setup_dummy_bin(&app_bin);
+
+    let mut app_toml = parent_dir.clone();
+    app_toml.push("app.toml");
+
+    fixture.setup_dummy_toml(&app_toml);
+    fixture.start_service();
+
+    let result = panic::catch_unwind(|| {
+        let apps_query = "{ apps { active, runLevel, app { uuid, name, version, author } } }";
+        let result = kubos_system::query("localhost:9999", &apps_query,
+                                        Some(Duration::from_secs(5)));
+        assert!(result.is_ok());
+
+        let apps = &result.unwrap()["apps"];
+        assert!(apps.is_array());
+        assert_eq!(apps.as_array().unwrap().len(), 1);
+
+        let v = &apps.as_array().unwrap()[0];
+        assert_eq!(v["active"], json!(true));
+        assert_eq!(v["runLevel"], json!("OnBoot"));
+        assert!(v["app"].is_object());
+        assert_eq!(v["app"]["uuid"], json!("a-b-c-d-e"));
+        assert_eq!(v["app"]["name"], json!("dummy"));
+        assert_eq!(v["app"]["version"], json!("0.0.1"));
+        assert_eq!(v["app"]["author"], json!("user"));
+    });
+
+    fixture.teardown();
+    assert!(result.is_ok());
+}

--- a/services/app-service/tests/test_register.rs
+++ b/services/app-service/tests/test_register.rs
@@ -13,155 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![deny(warnings)]
 extern crate kubos_app;
 extern crate kubos_system;
 #[macro_use]
 extern crate serde_json;
 
-use std::env;
-use std::fs;
-use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::panic;
-use std::process::{Command, Stdio};
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::{env, panic};
 use std::time::Duration;
-use std::{thread, thread::JoinHandle};
 
-const DUMMY_APP_SRC: &'static str = r#"
-#!/bin/bash
-if [ "$1" = "--metadata" ]; then
-    echo name = \"dummy\"
-    echo version = \"0.0.1\"
-    echo author = \"user\"
-else
-    echo uuid = \"$KUBOS_APP_UUID\"
-    echo run_level = \"$KUBOS_APP_RUN_LEVEL\"
-fi
-"#;
-
-const DUMMY_APP_TOML: &'static str = r#"
-active = true
-run_level = "OnBoot"
-
-[app]
-uuid = "a-b-c-d-e"
-pid = 0
-path = "{}/a-b-c-d-e/0.0.1/dummy-app"
-
-[app.metadata]
-name = "dummy"
-version = "0.0.1"
-author = "user"
-"#;
-
-struct AppServiceFixture {
-    registry_dir: PathBuf,
-    config_toml: PathBuf,
-    join_handle: Option<JoinHandle<()>>,
-    sender: Option<Sender<bool>>
-}
-
-impl AppServiceFixture {
-    fn setup() -> Self {
-        let mut registry_dir = env::temp_dir();
-        registry_dir.push("apps");
-
-        if !registry_dir.exists() {
-            assert!(fs::create_dir_all(registry_dir.clone()).is_ok());
-        }
-
-        let mut config_toml = env::temp_dir();
-        config_toml.push("config.toml");
-
-        let mut toml = fs::File::create(config_toml.clone()).unwrap();
-        toml.write_all(format!(r#"
-            [app-service]
-            registry-dir = "{}"
-            [app-service.addr]
-            ip = "0.0.0.0"
-            port = 9999"#, registry_dir.to_str().unwrap()).as_bytes())
-            .expect("Failed to write config.toml");
-
-        Self {
-            registry_dir: registry_dir,
-            config_toml: config_toml.clone(),
-            join_handle: None,
-            sender: None
-        }
-    }
-
-    fn start_service(&mut self)
-    {
-        let mut app_service = env::current_exe().unwrap();
-        app_service.pop();
-        app_service.set_file_name("kubos-app-service");
-
-        let (tx, rx): (Sender<bool>, Receiver<bool>) = channel();
-        let config_toml = self.config_toml.clone();
-
-        let handle = thread::spawn(move || {
-            let mut service_proc = Command::new(app_service)
-                .arg("-c")
-                .arg(config_toml.to_str().unwrap())
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()
-                .unwrap();
-
-            let mut run = true;
-            while run {
-                thread::sleep(Duration::from_millis(100));
-                if let Ok(_) = rx.try_recv() {
-                    service_proc.kill().unwrap();
-                    run = false;
-                }
-            }
-        });
-
-        // Give the process a bit to actually start
-        thread::sleep(Duration::from_millis(100));
-        self.join_handle = Some(handle);
-        self.sender = Some(tx);
-    }
-
-    fn setup_dummy_bin(&self, bin_dest: &Path) {
-        let mut file = fs::File::create(bin_dest.clone()).unwrap();
-        if !file.write_all(DUMMY_APP_SRC.as_bytes()).is_ok() {
-            panic!("failed to write app script");
-        }
-
-        let mut perms = file.metadata().unwrap().permissions();
-        perms.set_mode(0o755);
-
-        if !file.set_permissions(perms).is_ok() {
-            panic!("failed to change permissions of app script");
-        }
-    }
-
-    fn setup_dummy_toml(&self, toml_dest: &Path) {
-        let mut file = fs::File::create(toml_dest.clone()).unwrap();
-        if !file.write_all(DUMMY_APP_TOML.as_bytes()).is_ok() {
-            panic!("failed to write app TOML");
-        }
-    }
-
-    fn teardown(&mut self) {
-        if self.sender.is_some() {
-            self.sender.take().unwrap().send(true).unwrap();
-        }
-        if self.join_handle.is_some() {
-            self.join_handle.take().unwrap().join().unwrap();
-        }
-
-        if self.registry_dir.exists() {
-            assert!(fs::remove_dir_all(self.registry_dir.clone()).is_ok());
-        }
-
-    }
-}
-
+mod utils;
+use utils::*;
 
 #[test]
 fn register_app() {
@@ -210,49 +72,6 @@ fn register_app() {
         assert!(start_result.is_ok(), format!("error starting app: {}", start_result.unwrap_err()));
         assert!(start_result.unwrap() > 0); // pid*/
     });
-    fixture.teardown();
-    assert!(result.is_ok());
-}
-
-#[test]
-fn discover_app() {
-    let mut fixture = AppServiceFixture::setup();
-    let mut parent_dir = fixture.registry_dir.clone();
-    parent_dir.push("a-b-c-d-e");
-    parent_dir.push("0.0.1");
-    assert!(fs::create_dir_all(parent_dir.clone()).is_ok());
-
-    let mut app_bin = parent_dir.clone();
-    app_bin.push("dummy-app");
-
-    fixture.setup_dummy_bin(&app_bin);
-
-    let mut app_toml = parent_dir.clone();
-    app_toml.push("app.toml");
-
-    fixture.setup_dummy_toml(&app_toml);
-    fixture.start_service();
-
-    let result = panic::catch_unwind(|| {
-        let apps_query = "{ apps { active, runLevel, app { uuid, name, version, author } } }";
-        let result = kubos_system::query("localhost:9999", &apps_query,
-                                        Some(Duration::from_secs(5)));
-        assert!(result.is_ok());
-
-        let apps = &result.unwrap()["apps"];
-        assert!(apps.is_array());
-        assert_eq!(apps.as_array().unwrap().len(), 1);
-
-        let v = &apps.as_array().unwrap()[0];
-        assert_eq!(v["active"], json!(true));
-        assert_eq!(v["runLevel"], json!("OnBoot"));
-        assert!(v["app"].is_object());
-        assert_eq!(v["app"]["uuid"], json!("a-b-c-d-e"));
-        assert_eq!(v["app"]["name"], json!("dummy"));
-        assert_eq!(v["app"]["version"], json!("0.0.1"));
-        assert_eq!(v["app"]["author"], json!("user"));
-    });
-
     fixture.teardown();
     assert!(result.is_ok());
 }

--- a/services/app-service/tests/test_uninstall.rs
+++ b/services/app-service/tests/test_uninstall.rs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![deny(warnings)]
+extern crate kubos_app;
+extern crate kubos_system;
+//#[macro_use]
+extern crate serde_json;
+
+use std::panic;
+use std::time::Duration;
+
+mod utils;
+use utils::*;
+
+const UNINSTALL_QUERY: &'static str = r#"mutation {
+    uninstall(uuid: "a-b-c-d-e", version: "0.0.1")
+}"#;
+const APPS_QUERY: &'static str = "{ apps { active } }";
+
+#[test]
+fn uninstall_app() {
+    let mut fixture = AppServiceFixture::setup();
+    fixture.install_dummy_app();
+    fixture.start_service();
+
+    let result = panic::catch_unwind(|| {
+        let result = kubos_system::query("localhost:9999", UNINSTALL_QUERY,
+                                         Some(Duration::from_secs(5)));
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert!(result.unwrap()["uninstall"].as_bool().unwrap());
+
+        let result = kubos_system::query("localhost:9999", APPS_QUERY,
+                                         Some(Duration::from_secs(1)));
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert_eq!(result.unwrap()["apps"].as_array().expect("Not an array").len(), 0);
+    });
+
+    fixture.teardown();
+    assert!(result.is_ok());
+}

--- a/services/app-service/tests/utils/mod.rs
+++ b/services/app-service/tests/utils/mod.rs
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![allow(dead_code)]
+use std::{env, fs};
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::{thread, thread::JoinHandle};
+use std::time::Duration;
+
+const DUMMY_APP_SRC: &'static str = r#"
+#!/bin/bash
+if [ "$1" = "--metadata" ]; then
+    echo name = \"dummy\"
+    echo version = \"0.0.1\"
+    echo author = \"user\"
+else
+    echo uuid = \"$KUBOS_APP_UUID\"
+    echo run_level = \"$KUBOS_APP_RUN_LEVEL\"
+fi
+"#;
+
+const DUMMY_APP_TOML: &'static str = r#"
+active = true
+run_level = "OnBoot"
+
+[app]
+uuid = "a-b-c-d-e"
+pid = 0
+path = "{}/a-b-c-d-e/0.0.1/dummy-app"
+
+[app.metadata]
+name = "dummy"
+version = "0.0.1"
+author = "user"
+"#;
+
+pub struct AppServiceFixture {
+    pub registry_dir: PathBuf,
+    config_toml: PathBuf,
+    join_handle: Option<JoinHandle<()>>,
+    sender: Option<Sender<bool>>
+}
+
+impl AppServiceFixture {
+    pub fn setup() -> Self {
+        let mut registry_dir = env::temp_dir();
+        registry_dir.push("apps");
+
+        if !registry_dir.exists() {
+            assert!(fs::create_dir_all(registry_dir.clone()).is_ok());
+        }
+
+        let mut config_toml = env::temp_dir();
+        config_toml.push("config.toml");
+
+        let mut toml = fs::File::create(config_toml.clone()).unwrap();
+        toml.write_all(format!(r#"
+            [app-service]
+            registry-dir = "{}"
+            [app-service.addr]
+            ip = "0.0.0.0"
+            port = 9999"#, registry_dir.to_str().unwrap()).as_bytes())
+            .expect("Failed to write config.toml");
+
+        Self {
+            registry_dir: registry_dir,
+            config_toml: config_toml.clone(),
+            join_handle: None,
+            sender: None
+        }
+    }
+
+    pub fn start_service(&mut self)
+    {
+        let mut app_service = env::current_exe().unwrap();
+        app_service.pop();
+        app_service.set_file_name("kubos-app-service");
+
+        let (tx, rx): (Sender<bool>, Receiver<bool>) = channel();
+        let config_toml = self.config_toml.clone();
+
+        let handle = thread::spawn(move || {
+            let mut service_proc = Command::new(app_service)
+                .arg("-c")
+                .arg(config_toml.to_str().unwrap())
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap();
+
+            let mut run = true;
+            while run {
+                thread::sleep(Duration::from_millis(100));
+                if let Ok(_) = rx.try_recv() {
+                    service_proc.kill().unwrap();
+                    run = false;
+                }
+            }
+        });
+
+        // Give the process a bit to actually start
+        thread::sleep(Duration::from_millis(100));
+        self.join_handle = Some(handle);
+        self.sender = Some(tx);
+    }
+
+    pub fn install_dummy_app(&self) {
+        let mut parent_dir = self.registry_dir.clone();
+        parent_dir.push("a-b-c-d-e");
+        parent_dir.push("0.0.1");
+        assert!(fs::create_dir_all(parent_dir.clone()).is_ok());
+
+        let mut app_bin = parent_dir.clone();
+        app_bin.push("dummy-app");
+
+        self.setup_dummy_bin(&app_bin);
+
+        let mut app_toml = parent_dir.clone();
+        app_toml.push("app.toml");
+
+        self.setup_dummy_toml(&app_toml);
+    }
+
+    pub fn setup_dummy_bin(&self, bin_dest: &Path) {
+        let mut file = fs::File::create(bin_dest.clone()).unwrap();
+        if !file.write_all(DUMMY_APP_SRC.as_bytes()).is_ok() {
+            panic!("failed to write app script");
+        }
+
+        let mut perms = file.metadata().unwrap().permissions();
+        perms.set_mode(0o755);
+
+        if !file.set_permissions(perms).is_ok() {
+            panic!("failed to change permissions of app script");
+        }
+    }
+
+    pub fn setup_dummy_toml(&self, toml_dest: &Path) {
+        let mut file = fs::File::create(toml_dest.clone()).unwrap();
+        if !file.write_all(format!(r#"
+            active = true
+            run_level = "OnBoot"
+
+            [app]
+            uuid = "a-b-c-d-e"
+            pid = 0
+            path = "{}/a-b-c-d-e/0.0.1/dummy-app"
+
+            [app.metadata]
+            name = "dummy"
+            version = "0.0.1"
+            author = "user"
+            "#, self.registry_dir.to_str().unwrap()).as_bytes()).is_ok()
+        {
+            panic!("failed to write app TOML");
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        if self.sender.is_some() {
+            self.sender.take().unwrap().send(true).unwrap();
+        }
+        if self.join_handle.is_some() {
+            self.join_handle.take().unwrap().join().unwrap();
+        }
+
+        if self.registry_dir.exists() {
+            assert!(fs::remove_dir_all(self.registry_dir.clone()).is_ok());
+        }
+
+    }
+}

--- a/services/kubos-service/Cargo.toml
+++ b/services/kubos-service/Cargo.toml
@@ -10,7 +10,6 @@ serde_json = "1.0"
 juniper = "0.9"
 getopts = "0.2"
 toml = "0.4"
-nix = "0.10.0"
 
 [dev-dependencies]
 failure = { git = "https://github.com/rust-lang-nursery/failure" }

--- a/services/kubos-service/src/config.rs
+++ b/services/kubos-service/src/config.rs
@@ -58,10 +58,23 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Creates and parses configuration data. Service name is used
-    /// as a key in the config file.
+    /// Creates and parses configuration data from the system configuration
+    /// file or the path passed as the '-c' or '--config' option to this
+    /// executable.
+    ///
+    /// # Arguments
+    /// `name` - Service name used as a key in the config file
     pub fn new(name: &str) -> Self {
-        parse_config(name, get_config_path()).unwrap_or(Config::default())
+        Self::new_from_path(name, get_config_path())
+    }
+
+    /// Creates and parses configuration data from the passed in configuration
+    /// path.
+    /// # Arguments
+    /// `name` - Service name used as a key in the config file
+    /// `path` - Path to configuration file
+    pub fn new_from_path(name: &str, path: String) -> Self {
+        parse_config(name, path).unwrap_or(Config::default())
     }
 
     /// Returns the configured hosturl string in the following

--- a/services/kubos-service/src/kiss.rs
+++ b/services/kubos-service/src/kiss.rs
@@ -1,0 +1,261 @@
+//
+// Copyright (C) 2018 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::cell::RefCell;
+use std::io;
+use std::net::{SocketAddr, UdpSocket};
+
+///Frame delimiter code, used to represent start and end of frames.
+pub const FEND: u8 = 0xC0;
+
+///Frame escape code, used to escape FESC and FEND codes if they are found in byte stream
+pub const FESC: u8 = 0xDB;
+
+///Escaped FEND value
+pub const TFEND: u8 = 0xDC;
+
+///Escaped FESC value
+pub const TFESC: u8 = 0xDD;
+
+pub trait FrameHandler {
+    fn handle_frame(&self, socket: &KissUdpSocket, frame: &[u8], src_addr: SocketAddr) { }
+}
+
+pub struct KissUdpSocket<'a> {
+    pub addr: SocketAddr,
+    socket: UdpSocket,
+    // TODO: implement a per-client frame
+    current_frame: RefCell<Vec<u8>>,
+    handler: &'a FrameHandler,
+    pub looping: RefCell<bool>,
+}
+
+impl<'a> KissUdpSocket<'a> {
+    pub fn bind(addr: SocketAddr, handler: &'a FrameHandler) -> Option<Self> {
+        match UdpSocket::bind(&addr) {
+            Ok(socket) => {
+                //println!("Listening on {}", addr);
+                Some(Self {
+                    addr: addr,
+                    socket: socket,
+                    current_frame: RefCell::new(Vec::new()),
+                    handler: handler,
+                    looping: RefCell::new(false),
+                })
+            },
+            Err(_) => None
+        }
+    }
+
+    pub fn handle(&self, chunk: &[u8], src_addr: SocketAddr) {
+        //println!("Received {} bytes", chunk.len());
+        let mut current_frame = self.current_frame.borrow_mut();
+        current_frame.extend(chunk);
+
+        let mut begin: usize = 0;
+        let mut state = State::OutsideFrame;
+
+        #[derive(PartialEq)]
+        enum State {
+            OutsideFrame,
+            InsideFrame,
+        }
+
+        for index in 0..current_frame.len() {
+            match current_frame[index] {
+                FEND => match state {
+                    State::OutsideFrame => {
+                        state = State::InsideFrame;
+                        begin = index;
+                        continue;
+                    },
+                    _ => {
+                        if state == State::InsideFrame {
+                            self.handle_frame(&current_frame[begin..index+1], src_addr);
+                            current_frame.drain(..index+1);
+                        }
+                        state = State::OutsideFrame;
+                        continue;
+                    },
+                },
+                _ => {},
+            }
+        }
+    }
+
+    fn handle_frame(&self, frame: &[u8], src_addr: SocketAddr) {
+        match self.decode(frame) {
+            Ok(decoded) => {
+                self.handler.handle_frame(&self, &decoded, src_addr);
+            },
+            Err(e) => { eprintln!("Warning, handed invalid frame: {:?}", e); }
+        }
+    }
+
+    fn escape(&self, buf: &[u8]) -> Vec<u8> {
+        let mut new_buf = vec![];
+        for (_, e) in buf.iter().enumerate() {
+            match e {
+                0xC0 => {
+                    new_buf.push(0xDB);
+                    new_buf.push(0xDC);
+                }
+                0xDB => {
+                    new_buf.push(0xDB);
+                    new_buf.push(0xDD);
+                }
+                _ => new_buf.push(*e),
+            };
+        }
+        new_buf
+    }
+
+    fn unescape(&self, buf: &[u8]) -> (Vec<u8>, bool) {
+        let mut new_buf = vec![];
+
+        let mut i = 0;
+        while i < buf.len() {
+            let e = buf[i];
+            match e {
+                0xDB => {
+                    new_buf.push(match buf.get(i + 1) {
+                        Some(0xDC) => 0xC0,
+                        Some(0xDD) => 0xDB,
+                        _ => {
+                            return (vec![], false);
+                        }
+                    });
+                    i += 1;
+                }
+                _ => new_buf.push(e),
+            }
+            i += 1;
+        }
+
+        (new_buf, true)
+    }
+
+    pub fn encode(&self, frame: &[u8]) -> Result<Vec<u8>, String> {
+        let mut buff = vec![0xC0, 0x00];
+
+        buff.extend(self.escape(frame).iter().clone());
+        buff.push(0xC0);
+
+        Ok(buff)
+    }
+
+    pub fn decode(&self, chunk: &[u8]) -> Result<Vec<u8>, String> {
+        let mut frame = vec![];
+        let mut index_l = 0;
+        let mut valid = false;
+
+        while !valid {
+            frame.clear();
+            let mut index_a = 0;
+            let mut index_b;
+
+            // Search for first full kiss frame
+            for (i, e) in chunk.iter().skip(index_l).enumerate() {
+                if *e == 0xC0 {
+                    if chunk[i + 1] == 0x00 {
+                        index_a = i + index_l + 1;
+                        break;
+                    }
+                }
+            }
+            if index_a == 0 {
+                return Err(String::from("Kiss frame start not found"));
+            }
+
+            index_b = 0;
+            // Search for end sequence?
+            for (i, e) in chunk.iter().skip(index_a).enumerate() {
+                if *e == 0xC0 {
+                    index_b = i + index_a + 1;
+                    break;
+                }
+            }
+            if index_b == 0 {
+                return Err(String::from("Kiss frame end not found"));
+            }
+
+            // Extract the frame payload
+            frame.extend(chunk[index_a + 1..index_b - 1].iter().clone());
+            index_l = index_b;
+
+            // Unescape KISS control characters
+            let (un_frame, check) = self.unescape(&frame);
+            valid = check;
+            frame = un_frame;
+        }
+
+        Ok(frame)
+    }
+
+    pub fn send_to(&self, frame: &[u8], dest: SocketAddr) -> Result<usize, io::Error> {
+        let encoded = match self.encode(frame) {
+            Ok(e) => e,
+            Err(msg) => return Err(io::Error::new(io::ErrorKind::Other, msg))
+        };
+
+        let chunk_iter = encoded.chunks(1024);
+        let mut total_written = 0;
+
+        for chunk in chunk_iter {
+            let mut chunk_written = 0;
+            let mut start = 0;
+            'chunk_loop: loop {
+                match self.socket.send_to(&chunk[start..], &dest) {
+                    Ok(written) => {
+                        //println!("Wrote {} bytes", written);
+                        total_written += written;
+                        chunk_written += written;
+                        start += written;
+                    },
+                    Err(err) => {
+                        return Err(err);
+                    }
+                }
+
+                if chunk_written >= chunk.len() {
+                    break 'chunk_loop;
+                }
+            }
+        }
+        Ok(total_written)
+    }
+
+    pub fn recv_loop(&self) {
+        let mut buf = [0; 4096];
+        *self.looping.borrow_mut() = true;
+        while *self.looping.borrow() {
+            // Wait for an incoming message
+            match self.socket.recv_from(&mut buf) {
+                Ok((size, peer)) => {
+                    self.handle(&buf[0..size], peer);
+                },
+                Err(e) => {
+                    eprintln!("Error receiving data: {:?}", e);
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+
+
+

--- a/services/kubos-service/src/lib.rs
+++ b/services/kubos-service/src/lib.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-#![deny(missing_docs)]
-#![deny(warnings)]
+//#![deny(missing_docs)]
+//#![deny(warnings)]
 
 //! A collection of structures and functions used to create hardware services
 //! in the Kubos Linux ecosystem.
@@ -110,8 +110,6 @@
 extern crate failure;
 extern crate getopts;
 extern crate juniper;
-//#[macro_use]
-//extern crate nix;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -122,6 +120,8 @@ extern crate toml;
 mod config;
 mod macros;
 mod service;
+mod kiss;
 
 pub use config::Config;
 pub use service::{Context, Service};
+pub use kiss::{FrameHandler, KissUdpSocket};

--- a/services/kubos-service/src/lib.rs
+++ b/services/kubos-service/src/lib.rs
@@ -110,8 +110,8 @@
 extern crate failure;
 extern crate getopts;
 extern crate juniper;
-#[macro_use]
-extern crate nix;
+//#[macro_use]
+//extern crate nix;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/services/telemetry-service/Cargo.toml
+++ b/services/telemetry-service/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Ryan Plauche <ryan@kubos.co>"]
 diesel = { version = "1.0.0", features = ["sqlite"] }
 juniper =  "0.9.2"
 kubos-service = { path = "../kubos-service" }
+kubos-telemetry = { path = "../../apis/telemetry-api" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/services/telemetry-service/src/main.rs
+++ b/services/telemetry-service/src/main.rs
@@ -137,18 +137,16 @@
 //!   }
 //! }
 //! ```
-
-#[macro_use]
 extern crate diesel;
+
 #[macro_use]
 extern crate juniper;
 extern crate kubos_service;
+extern crate kubos_telemetry;
 
-mod db;
-mod models;
 mod schema;
 
-use db::Database;
+use kubos_telemetry::Database;
 use kubos_service::{Config, Service};
 use schema::{MutationRoot, QueryRoot};
 


### PR DESCRIPTION
This is a proof of concept that changes the UDP protocol used by GraphQL based Services to KISS-based framing of all requests and results. Without this change, all GraphQL requests and responses were required to be contained within a single UDP packet, which can be constrained in different clients and operating systems.

In order to test this, I built the `kubos-app-service` and the example `udp-service-client`, and sent a request for the App Service's GraphQL schema, which resulted in a little over 3KB of response data:

```
$ ./udp-client 127.0.0.1:8083 "{ __schema { types { name, fields { name, type { name, kind } } } } }"
{"errs":"","msg":{"__schema":{"types":[{"fields":null,"name":"Boolean"},{"fields":[{"name":"name","type":{"kind":"NON_NULL","name":null}},{"name":"description","type":{"kind":"SCALAR","name":"String"}},{"name":"type","type":{"kind":"NON_NULL","name":null}},{"name":"defaultValue","type":{"kind":"SCALAR","name":"String"}}],"name":"__InputValue"},{"fields":null,"name":"String"},{"fields":[{"name":"name","type":{"kind":"NON_NULL","name":null}},{"name":"description","type":{"kind":"SCALAR","name":"String"}},{"name":"args","type":{"kind":"NON_NULL","name":null}},{"name":"type","type":{"kind":"NON_NULL","name":null}},{"name":"isDeprecated","type":{"kind":"NON_NULL","name":null}},{"name":"deprecationReason","type":{"kind":"SCALAR","name":"String"}}],"name":"__Field"},{"fields":[{"name":"register","type":{"kind":"NON_NULL","name":null}},{"name":"uninstall","type":{"kind":"NON_NULL","name":null}},{"name":"startApp","type":{"kind":"NON_NULL","name":null}}],"name":"Mutation"},{"fields":[{"name":"uuid","type":{"kind":"NON_NULL","name":null}},{"name":"name","type":{"kind":"NON_NULL","name":null}},{"name":"version","type":{"kind":"NON_NULL","name":null}},{"name":"author","type":{"kind":"NON_NULL","name":null}},{"name":"pid","type":{"kind":"NON_NULL","name":null}},{"name":"path","type":{"kind":"NON_NULL","name":null}}],"name":"App"},{"fields":null,"name":"__TypeKind"},{"fields":[{"name":"name","type":{"kind":"SCALAR","name":"String"}},{"name":"description","type":{"kind":"SCALAR","name":"String"}},{"name":"kind","type":{"kind":"NON_NULL","name":null}},{"name":"fields","type":{"kind":"LIST","name":null}},{"name":"ofType","type":{"kind":"OBJECT","name":"__Type"}},{"name":"inputFields","type":{"kind":"LIST","name":null}},{"name":"interfaces","type":{"kind":"LIST","name":null}},{"name":"possibleTypes","type":{"kind":"LIST","name":null}},{"name":"enumValues","type":{"kind":"LIST","name":null}}],"name":"__Type"},{"fields":[{"name":"app","type":{"kind":"NON_NULL","name":null}},{"name":"active","type":{"kind":"NON_NULL","name":null}},{"name":"runLevel","type":{"kind":"NON_NULL","name":null}}],"name":"AppRegistryEntry"},{"fields":null,"name":"Float"},{"fields":[{"name":"types","type":{"kind":"NON_NULL","name":null}},{"name":"queryType","type":{"kind":"NON_NULL","name":null}},{"name":"mutationType","type":{"kind":"OBJECT","name":"__Type"}},{"name":"subscriptionType","type":{"kind":"OBJECT","name":"__Type"}},{"name":"directives","type":{"kind":"NON_NULL","name":null}}],"name":"__Schema"},{"fields":[{"name":"apps","type":{"kind":"NON_NULL","name":null}}],"name":"Query"},{"fields":[{"name":"name","type":{"kind":"NON_NULL","name":null}},{"name":"description","type":{"kind":"SCALAR","name":"String"}},{"name":"isDeprecated","type":{"kind":"NON_NULL","name":null}},{"name":"deprecationReason","type":{"kind":"SCALAR","name":"String"}}],"name":"__EnumValue"},{"fields":null,"name":"__DirectiveLocation"},{"fields":[{"name":"name","type":{"kind":"NON_NULL","name":null}},{"name":"description","type":{"kind":"SCALAR","name":"String"}},{"name":"locations","type":{"kind":"NON_NULL","name":null}},{"name":"args","type":{"kind":"NON_NULL","name":null}}],"name":"__Directive"}]}}}
```

Before this change, the response would be cut off at 1024 bytes which is presumably some kind of buffer size in the operating system, because it occurred in both `nc` and `udp-service-client`