### PR TITLE
Cleaning up formatting

### DIFF
--- a/apis/isis-ants-api/src/ants.rs
+++ b/apis/isis-ants-api/src/ants.rs
@@ -72,10 +72,8 @@ impl AntS {
         ant_count: u8,
         timeout: u32,
     ) -> AntSResult<Self> {
-
-        match unsafe {
-            ffi::k_ants_init(convert_bus(bus), primary, secondary, ant_count, timeout)
-        } {
+        match unsafe { ffi::k_ants_init(convert_bus(bus), primary, secondary, ant_count, timeout) }
+        {
             ffi::KANTSStatus::AntsOK => {
                 if timeout > 0 {
                     match unsafe { ffi::k_ants_watchdog_start() } {
@@ -90,8 +88,6 @@ impl AntS {
             ffi::KANTSStatus::AntsErrorConfig => Err(AntsError::ConfigError.into()),
             _ => Err(AntsError::GenericError.into()),
         }
-
-
     }
 
     /// Configure the system to send future commands to the requested microcontroller
@@ -311,7 +307,6 @@ impl AntS {
     ///
     /// [`AntsError`]: enum.AntsError.html
     pub fn get_deploy(&self) -> AntSResult<DeployStatus> {
-
         let mut status: [u8; 2] = [0; 2];
 
         match unsafe { ffi::k_ants_get_deploy_status(status.as_mut_ptr()) } {
@@ -346,7 +341,6 @@ impl AntS {
     ///
     /// [`AntsError`]: enum.AntsError.html
     pub fn get_uptime(&self) -> AntSResult<u32> {
-
         let mut uptime = 0;
 
         match unsafe { ffi::k_ants_get_uptime(&mut uptime) } {
@@ -382,7 +376,6 @@ impl AntS {
     ///
     /// [`AntsError`]: enum.AntsError.html
     pub fn get_system_telemetry(&self) -> AntSResult<AntsTelemetry> {
-
         let mut c_telem = ffi::AntsTelemetry {
             raw_temp: 0,
             deploy_status: 0,
@@ -424,7 +417,6 @@ impl AntS {
     ///
     /// [`AntsError`]: enum.AntsError.html
     pub fn get_activation_count(&self, antenna: KANTSAnt) -> AntSResult<u8> {
-
         let mut count: u8 = 0;
 
         match unsafe { ffi::k_ants_get_activation_count(convert_antenna(antenna), &mut count) } {
@@ -461,7 +453,6 @@ impl AntS {
     ///
     /// [`AntsError`]: enum.AntsError.html
     pub fn get_activation_time(&self, antenna: KANTSAnt) -> AntSResult<u16> {
-
         let mut time: u16 = 0;
 
         match unsafe { ffi::k_ants_get_activation_time(convert_antenna(antenna), &mut time) } {
@@ -582,7 +573,6 @@ impl AntS {
     ///
     /// [`AntsError`]: enum.AntsError.html
     pub fn passthrough(&self, tx: &[u8], rx: &mut [u8]) -> AntSResult<()> {
-
         let tx_len: u8 = tx.len() as u8;
         let rx_len: u8 = rx.len() as u8;
 

--- a/apis/isis-ants-api/src/lib.rs
+++ b/apis/isis-ants-api/src/lib.rs
@@ -59,7 +59,7 @@ extern crate failure;
 extern crate nom;
 
 pub use ants::*;
-pub use parse::{KI2CNum, KANTSAnt, KANTSController, AntsTelemetry, DeployStatus};
+pub use parse::{AntsTelemetry, DeployStatus, KANTSAnt, KANTSController, KI2CNum};
 
 mod ants;
 mod ffi;

--- a/apis/isis-ants-api/src/parse.rs
+++ b/apis/isis-ants-api/src/parse.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-use ffi;
 use ants::*;
+use ffi;
 use std::mem::transmute;
 
 /// I<sup>2</sup>C bus which will be used for communication
@@ -100,7 +100,7 @@ pub struct DeployStatus {
     pub ant_4_active: bool,
 }
 
-named!(parse_status<&[u8], DeployStatus>, 
+named!(parse_status<&[u8], DeployStatus>,
 	do_parse!(
 		bits: bits!(
 				tuple!(
@@ -146,7 +146,6 @@ named!(parse_status<&[u8], DeployStatus>,
 impl AntsTelemetry {
     #[doc(hidden)]
     pub fn new(c_telem: ffi::AntsTelemetry) -> Result<AntsTelemetry, AntsError> {
-
         let raw_status: [u8; 2] = unsafe { transmute(c_telem.deploy_status) };
 
         let status = DeployStatus::new(&raw_status)?;

--- a/apis/isis-imtq-api/src/imtq.rs
+++ b/apis/isis-imtq-api/src/imtq.rs
@@ -157,8 +157,8 @@ impl<T: ImtqFFI> Drop for Imtq<T> {
 
 #[cfg(test)]
 mod tests {
-    use double;
     use super::*;
+    use double;
 
     mock_trait!(
         MockImtq,

--- a/apis/isis-iobc-supervisor/src/lib.rs
+++ b/apis/isis-iobc-supervisor/src/lib.rs
@@ -188,53 +188,53 @@ mod tests {
     #[test]
     fn test_convert_version() {
         let raw: ffi::supervisor_version = ffi::supervisor_version([
-                // dummy (u8)
-                0,
-                // spi_command_status (u8)
-                1,
-                // index_of_subsystem (u8)
-                2,
-                // major_version (u8)
-                3,
-                // minor version (u8)
-                4,
-                // patch version (u8)
-                5,
-                // git_head_version (u32)
-                6,
-                7,
-                8,
-                9,
-                // serial_number (u16)
-                10,
-                11,
-                // compile_information (i8 * 19)
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                // clock_speed (u8)
-                31,
-                // code_type (i8)
-                32,
-                // crc8 (u8)
-                33,
-            ]);
+            // dummy (u8)
+            0,
+            // spi_command_status (u8)
+            1,
+            // index_of_subsystem (u8)
+            2,
+            // major_version (u8)
+            3,
+            // minor version (u8)
+            4,
+            // patch version (u8)
+            5,
+            // git_head_version (u32)
+            6,
+            7,
+            8,
+            9,
+            // serial_number (u16)
+            10,
+            11,
+            // compile_information (i8 * 19)
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            // clock_speed (u8)
+            31,
+            // code_type (i8)
+            32,
+            // crc8 (u8)
+            33,
+        ]);
 
         let version = convert_raw_version(raw);
 
@@ -258,62 +258,62 @@ mod tests {
     #[test]
     fn test_convert_housekeeping() {
         let raw: ffi::supervisor_housekeeping = ffi::supervisor_housekeeping([
-                // dummy (u8), spi_command_status (u8), enable_status (u8)
-                0,
-                1,
-                // enable_status (u8) is a bitfield in the C structure
-                // power_obc : 1
-                // power_rtc : 1
-                // supervisor_mode : 1
-                // padding : 2
-                // busy_rtc : 1
-                // power_off_rtc : 1
-                // padding: 1
-                // Using 34 gives us -
-                // 0 0 1 0 0 0 1 0
-                // which results in alternating 1/0 field values
-                34,
-                // super_uptime (u32)
-                3,
-                2,
-                1,
-                0,
-                // iobc_uptime (u32)
-                4,
-                3,
-                2,
-                1,
-                // iobc_reset_count (u32)
-                5,
-                4,
-                3,
-                2,
-                // adc_data (u16 * 10)
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                // adc_update_flag (u8)
-                12,
-                // crc8
-                13,
-            ]);
+            // dummy (u8), spi_command_status (u8), enable_status (u8)
+            0,
+            1,
+            // enable_status (u8) is a bitfield in the C structure
+            // power_obc : 1
+            // power_rtc : 1
+            // supervisor_mode : 1
+            // padding : 2
+            // busy_rtc : 1
+            // power_off_rtc : 1
+            // padding: 1
+            // Using 34 gives us -
+            // 0 0 1 0 0 0 1 0
+            // which results in alternating 1/0 field values
+            34,
+            // super_uptime (u32)
+            3,
+            2,
+            1,
+            0,
+            // iobc_uptime (u32)
+            4,
+            3,
+            2,
+            1,
+            // iobc_reset_count (u32)
+            5,
+            4,
+            3,
+            2,
+            // adc_data (u16 * 10)
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            // adc_update_flag (u8)
+            12,
+            // crc8
+            13,
+        ]);
 
         let housekeeping = convert_raw_housekeeping(raw);
 

--- a/apis/isis-iobc-supervisor/src/lib.rs
+++ b/apis/isis-iobc-supervisor/src/lib.rs
@@ -96,7 +96,9 @@ fn convert_raw_version(raw: ffi::supervisor_version) -> SupervisorVersion {
         minor_version: raw.0[4] as u8,
         patch_version: raw.0[5] as u8,
         git_head_version: {
-            (raw.0[6] as u32) | (raw.0[7] as u32) << 8 | (raw.0[8] as u32) << 16
+            (raw.0[6] as u32)
+                | (raw.0[7] as u32) << 8
+                | (raw.0[8] as u32) << 16
                 | (raw.0[9] as u32) << 24
         },
         serial_number: { (raw.0[10] as u16) | (raw.0[11] as u16) << 8 },
@@ -141,15 +143,21 @@ fn convert_raw_housekeeping(raw: ffi::supervisor_housekeeping) -> SupervisorHous
             power_off_rtc: ((raw.0[2] as u8) & 0x40) >> 6,
         },
         supervisor_uptime: {
-            (raw.0[3] as u32) | (raw.0[4] as u32) << 8 | (raw.0[5] as u32) << 16
+            (raw.0[3] as u32)
+                | (raw.0[4] as u32) << 8
+                | (raw.0[5] as u32) << 16
                 | (raw.0[6] as u32) << 24
         },
         iobc_uptime: {
-            (raw.0[7] as u32) | (raw.0[8] as u32) << 8 | (raw.0[9] as u32) << 16
+            (raw.0[7] as u32)
+                | (raw.0[8] as u32) << 8
+                | (raw.0[9] as u32) << 16
                 | (raw.0[10] as u32) << 24
         },
         iobc_reset_count: {
-            (raw.0[11] as u32) | (raw.0[12] as u32) << 8 | (raw.0[13] as u32) << 16
+            (raw.0[11] as u32)
+                | (raw.0[12] as u32) << 8
+                | (raw.0[13] as u32) << 16
                 | (raw.0[14] as u32) << 24
         },
         adc_data: {

--- a/apis/mai400-api/examples/mai-test.rs
+++ b/apis/mai400-api/examples/mai-test.rs
@@ -1,8 +1,8 @@
 extern crate mai400_api;
 
 use mai400_api::*;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 

--- a/apis/novatel-oem6-api/examples/gps-test.rs
+++ b/apis/novatel-oem6-api/examples/gps-test.rs
@@ -17,9 +17,9 @@
 extern crate novatel_oem6_api;
 
 use novatel_oem6_api::*;
+use std::sync::mpsc::sync_channel;
 use std::thread;
 use std::time::Duration;
-use std::sync::mpsc::sync_channel;
 
 fn get_version(oem: &OEM6) -> OEMResult<()> {
     // Send the request for info

--- a/apis/novatel-oem6-api/src/lib.rs
+++ b/apis/novatel-oem6-api/src/lib.rs
@@ -85,9 +85,9 @@ mod oem6;
 #[cfg(test)]
 mod tests;
 
-pub use messages::MessageID;
 pub use messages::commands::ResponseID;
 pub use messages::logs::*;
+pub use messages::MessageID;
 pub use messages::ReceiverStatusFlags;
 pub use oem6::*;
 pub use rust_uart::{mock, Connection, UartError};

--- a/apis/novatel-oem6-api/src/messages/logs/best_xyz.rs
+++ b/apis/novatel-oem6-api/src/messages/logs/best_xyz.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-use nom::*;
 use super::*;
+use nom::*;
 
 /// Log message containing position information
 #[derive(Clone, Default, Debug, PartialEq)]

--- a/apis/novatel-oem6-api/src/messages/logs/rxstatusevent.rs
+++ b/apis/novatel-oem6-api/src/messages/logs/rxstatusevent.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-use nom::*;
 use super::*;
+use nom::*;
 
 /// Event/error log message
 #[derive(Clone, Default, Debug, PartialEq)]

--- a/apis/novatel-oem6-api/src/messages/logs/version.rs
+++ b/apis/novatel-oem6-api/src/messages/logs/version.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-use nom::*;
 use super::*;
+use nom::*;
 
 const COMPONENT_SIZE: usize = 108;
 

--- a/apis/novatel-oem6-api/src/tests/version.rs
+++ b/apis/novatel-oem6-api/src/tests/version.rs
@@ -138,18 +138,16 @@ fn test_get_version() {
         week: 3025,
         ms: 164191800,
         num_components: 1,
-        components: vec![
-            Component {
-                comp_type: 1,
-                model: "G1SB0GTT0".to_owned(),
-                serial_num: "BJYA15120038H".to_owned(),
-                hw_version: "OEM615-2.00".to_owned(),
-                sw_version: "OEM060600RN0000".to_owned(),
-                boot_version: "OEM060201RB0000".to_owned(),
-                compile_date: "2015/Jan/28".to_owned(),
-                compile_time: "15:27:29".to_owned(),
-            },
-        ],
+        components: vec![Component {
+            comp_type: 1,
+            model: "G1SB0GTT0".to_owned(),
+            serial_num: "BJYA15120038H".to_owned(),
+            hw_version: "OEM615-2.00".to_owned(),
+            sw_version: "OEM060600RN0000".to_owned(),
+            boot_version: "OEM060201RB0000".to_owned(),
+            compile_date: "2015/Jan/28".to_owned(),
+            compile_time: "15:27:29".to_owned(),
+        }],
     });
 
     assert_eq!(oem.get_log().unwrap(), expected);

--- a/apis/nsl-duplex-d2/src/duplex_d2.rs
+++ b/apis/nsl-duplex-d2/src/duplex_d2.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+use messages::{parse_ack_or_nak, parse_u32, File, GeoRecord, Message, StateOfHealth};
 use radio_api::{Connection, RadioResult};
-use messages::{parse_ack_or_nak, File, GeoRecord, Message, StateOfHealth, parse_u32};
 
 /// Structure for interacting with Duplex-D2 Radio API
 pub struct DuplexD2 {
@@ -113,8 +113,8 @@ impl DuplexD2 {
 #[cfg(test)]
 mod tests {
 
-    use radio_api::{Connection, RadioResult, Stream};
     use super::*;
+    use radio_api::{Connection, RadioResult, Stream};
 
     struct TestStream {
         data: Vec<u8>,

--- a/apis/nsl-duplex-d2/src/lib.rs
+++ b/apis/nsl-duplex-d2/src/lib.rs
@@ -27,12 +27,12 @@ extern crate serial;
 #[macro_use]
 extern crate nom;
 
-mod messages;
 mod duplex_d2;
+mod messages;
 mod serial_comm;
 
 pub use duplex_d2::DuplexD2;
-pub use serial_comm::serial_connection;
 pub use messages::File;
-pub use messages::StateOfHealth;
 pub use messages::GeoRecord;
+pub use messages::StateOfHealth;
+pub use serial_comm::serial_connection;

--- a/apis/nsl-duplex-d2/src/messages/file.rs
+++ b/apis/nsl-duplex-d2/src/messages/file.rs
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-use nom::{IResult, be_u16};
-use std::str::FromStr;
-use std::io::Write;
 use crc16;
+use nom::{be_u16, IResult};
+use std::io::Write;
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq)]
 /// Structure for files

--- a/apis/nsl-duplex-d2/src/messages/geo_record.rs
+++ b/apis/nsl-duplex-d2/src/messages/geo_record.rs
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-use nom::{float, multispace, Err, ErrorKind, IResult};
-use nom::simple_errors::Context;
-use std::str::from_utf8;
 use chrono::{DateTime, NaiveDateTime, Utc};
+use nom::simple_errors::Context;
+use nom::{float, multispace, Err, ErrorKind, IResult};
+use std::str::from_utf8;
 
 #[derive(Debug, PartialEq)]
 /// Struct for storing geo-records.

--- a/apis/nsl-duplex-d2/src/messages/mod.rs
+++ b/apis/nsl-duplex-d2/src/messages/mod.rs
@@ -17,16 +17,16 @@
 //! This module contains structs and parsers for messages received on
 //! serial connection.
 
-use nom::{IResult, be_u32};
+use nom::{be_u32, IResult};
 
 mod file;
-mod state_of_health;
 mod geo_record;
+mod state_of_health;
 
 pub use messages::file::File;
 pub type Message = File;
-pub use messages::state_of_health::StateOfHealth;
 pub use messages::geo_record::GeoRecord;
+pub use messages::state_of_health::StateOfHealth;
 
 /// Parse 4 byte integer
 pub fn parse_u32(input: &[u8]) -> IResult<&[u8], u32> {

--- a/apis/nsl-duplex-d2/src/messages/state_of_health.rs
+++ b/apis/nsl-duplex-d2/src/messages/state_of_health.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use nom::{IResult, be_u32, be_u8};
+use nom::{be_u32, be_u8, IResult};
 
 #[derive(Debug, PartialEq)]
 /// Struct for storing state of health records

--- a/apis/nsl-duplex-d2/src/serial_comm.rs
+++ b/apis/nsl-duplex-d2/src/serial_comm.rs
@@ -15,9 +15,9 @@
  */
 
 use radio_api::{Connection, RadioResult, Stream};
+use serial;
 use std::io;
 use std::time::Duration;
-use serial;
 
 /// Connection for communicating with actual
 /// Duplex-D2 hardware
@@ -37,8 +37,8 @@ impl Stream for SerialStream {
 }
 
 fn serial_send(data: &[u8]) -> io::Result<()> {
-    use std::io::prelude::*;
     use serial::prelude::*;
+    use std::io::prelude::*;
 
     let mut port = try!(serial::open("/dev/ttyUSB0"));
     let settings: serial::PortSettings = serial::PortSettings {
@@ -67,8 +67,8 @@ fn serial_send(data: &[u8]) -> io::Result<()> {
 }
 
 fn serial_receive() -> io::Result<Vec<u8>> {
-    use std::io::prelude::*;
     use serial::prelude::*;
+    use std::io::prelude::*;
 
     let mut ret_msg: Vec<u8> = Vec::new();
     let mut port = try!(serial::open("/dev/ttyUSB0"));

--- a/apis/rust-radio-api/src/lib.rs
+++ b/apis/rust-radio-api/src/lib.rs
@@ -22,8 +22,8 @@
 extern crate failure;
 extern crate nom;
 
-use std::cell::RefCell;
 use nom::IResult;
+use std::cell::RefCell;
 
 use failure::Error;
 

--- a/examples/rust-c-service/service/src/schema.rs
+++ b/examples/rust-c-service/service/src/schema.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 //
 
-use model::{CalibrateThermometer, ResetUptime, SetPower, Subsystem};
-use kubos_service;
 use juniper::FieldResult;
+use kubos_service;
+use model::{CalibrateThermometer, ResetUptime, SetPower, Subsystem};
 
 type Context = kubos_service::Context<Subsystem>;
 

--- a/examples/rust-service/src/schema.rs
+++ b/examples/rust-service/src/schema.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 //
 
-use model::{CalibrateThermometer, ResetUptime, SetPower, Subsystem};
-use kubos_service;
 use juniper::FieldResult;
+use kubos_service;
+use model::{CalibrateThermometer, ResetUptime, SetPower, Subsystem};
 
 type Context = kubos_service::Context<Subsystem>;
 

--- a/examples/udp-service-client/src/main.rs
+++ b/examples/udp-service-client/src/main.rs
@@ -23,10 +23,10 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate toml;
 
-use std::net::{SocketAddr, UdpSocket};
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
+use std::net::{SocketAddr, UdpSocket};
 use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 

--- a/services/comms-service/src/main.rs
+++ b/services/comms-service/src/main.rs
@@ -1,7 +1,7 @@
 extern crate nsl_duplex_d2;
 
-use nsl_duplex_d2::DuplexD2;
 use nsl_duplex_d2::serial_connection;
+use nsl_duplex_d2::DuplexD2;
 use nsl_duplex_d2::File;
 
 fn main() {

--- a/services/iobc-supervisor-service/src/model.rs
+++ b/services/iobc-supervisor-service/src/model.rs
@@ -35,9 +35,7 @@ impl Supervisor {
     }
 
     pub fn version(&self) -> Result<SupervisorVersion, String> {
-        Ok(SupervisorVersion(
-            isis_iobc_supervisor::supervisor_version()?,
-        ))
+        Ok(SupervisorVersion(isis_iobc_supervisor::supervisor_version()?))
     }
 
     pub fn housekeeping(&self) -> Result<SupervisorHousekeeping, String> {

--- a/services/iobc-supervisor-service/src/model.rs
+++ b/services/iobc-supervisor-service/src/model.rs
@@ -35,7 +35,9 @@ impl Supervisor {
     }
 
     pub fn version(&self) -> Result<SupervisorVersion, String> {
-        Ok(SupervisorVersion(isis_iobc_supervisor::supervisor_version()?))
+        Ok(SupervisorVersion(
+            isis_iobc_supervisor::supervisor_version()?
+        ))
     }
 
     pub fn housekeeping(&self) -> Result<SupervisorHousekeeping, String> {

--- a/services/iobc-supervisor-service/src/schema.rs
+++ b/services/iobc-supervisor-service/src/schema.rs
@@ -16,9 +16,9 @@
 
 extern crate isis_iobc_supervisor;
 
-use model::{Supervisor, SupervisorEnableStatus, SupervisorHousekeeping, SupervisorVersion};
 use juniper::FieldResult;
 use kubos_service;
+use model::{Supervisor, SupervisorEnableStatus, SupervisorHousekeeping, SupervisorVersion};
 
 type Context = kubos_service::Context<Supervisor>;
 

--- a/services/kubos-service/src/config.rs
+++ b/services/kubos-service/src/config.rs
@@ -16,11 +16,11 @@
 
 use getopts::Options;
 use std::env;
-use toml;
 use std::fs::File;
-use std::io::prelude::*;
-use toml::Value;
 use std::io;
+use std::io::prelude::*;
+use toml;
+use toml::Value;
 
 static PATH: &str = "/home/system/etc/config.toml";
 static IP: &str = "127.0.0.1";

--- a/services/kubos-service/src/macros.rs
+++ b/services/kubos-service/src/macros.rs
@@ -59,7 +59,9 @@
 ///
 #[macro_export]
 macro_rules! process_errors {
-    ($err:ident) => (process_errors!($err, ", "));
+    ($err:ident) => {
+        process_errors!($err, ", ")
+    };
     ($err:ident, $delim:expr) => {{
         {
             let mut results = String::new();
@@ -100,10 +102,10 @@ macro_rules! process_errors {
 #[macro_export]
 macro_rules! push_err {
     ($master:expr, $err:expr) => {{
-            if let Ok(mut master_vec) = $master.try_borrow_mut() {
-                master_vec.push($err);
-            }
-        }}
+        if let Ok(mut master_vec) = $master.try_borrow_mut() {
+            master_vec.push($err);
+        }
+    }};
 }
 
 /// Execute a function and return `Result<func_data, String>`
@@ -165,8 +167,8 @@ macro_rules! push_err {
 #[macro_export]
 macro_rules! run {
     ($func:expr) => {{
-            $func.map_err(|err| process_errors!(err))
-        }};
+        $func.map_err(|err| process_errors!(err))
+    }};
     ($func:expr, $master:expr) => {{
         {
             let result = run!($func);
@@ -181,8 +183,17 @@ macro_rules! run {
                 // and then add the file and line number where said function was
                 // called from
                 let mut name = stringify!($func).split('(').next().unwrap();
-                name = name.split(&[':','.'][..]).last().unwrap();
-                push_err!($master, format!("{} ({}:{}): {}", name, file!(), line!(), result.clone().unwrap_err()));
+                name = name.split(&[':', '.'][..]).last().unwrap();
+                push_err!(
+                    $master,
+                    format!(
+                        "{} ({}:{}): {}",
+                        name,
+                        file!(),
+                        line!(),
+                        result.clone().unwrap_err()
+                    )
+                );
             }
 
             result

--- a/services/kubos-service/src/macros.rs
+++ b/services/kubos-service/src/macros.rs
@@ -300,7 +300,7 @@ mod tests {
 
         assert_eq!(result, Err("TopError: top, RootError: root".to_owned()));
         assert_eq!(
-            vec!["test_func (services/kubos-service/src/macros.rs:288): TopError: top, RootError: root".to_owned()],
+            vec!["test_func (services/kubos-service/src/macros.rs:299): TopError: top, RootError: root".to_owned()],
             master_err.borrow().clone()
         );
     }

--- a/services/kubos-service/src/service.rs
+++ b/services/kubos-service/src/service.rs
@@ -14,13 +14,13 @@
 // limitations under the License.
 //
 
-use std::collections::HashMap;
-use std::os::unix::io::AsRawFd;
-use std::net::{SocketAddr, UdpSocket};
-use std::cell::RefCell;
-use serde_json;
 use config::Config;
 use juniper::{execute, Context as JuniperContext, GraphQLType, RootNode, Variables};
+use serde_json;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::net::{SocketAddr, UdpSocket};
+use std::os::unix::io::AsRawFd;
 
 const FIONREAD: u16 = 0x541B;
 ioctl!(bad read udp_bytes_available with FIONREAD; usize);

--- a/services/mai400-service/src/tests/mod.rs
+++ b/services/mai400-service/src/tests/mod.rs
@@ -39,9 +39,11 @@ macro_rules! service_new {
 
         let (sender, receiver) = channel();
 
-        let mai = MAI400 { conn: Arc::new(Mutex::new(Connection {
-            stream: Box::new($mock),
-        })) };
+        let mai = MAI400 {
+            conn: Arc::new(Mutex::new(Connection {
+                stream: Box::new($mock),
+            })),
+        };
 
         // We don't actually want to do anything with this thread, the channel
         // sender just needs to live through the lifetime of each test
@@ -76,9 +78,11 @@ macro_rules! service_new_with_read {
 
         let (sender, receiver) = channel();
 
-        let mai = MAI400 { conn: Arc::new(Mutex::new(Connection {
-            stream: Box::new($mock),
-        })) };
+        let mai = MAI400 {
+            conn: Arc::new(Mutex::new(Connection {
+                stream: Box::new($mock),
+            })),
+        };
 
         let mai_ref = mai.clone();
         let data_ref = $data.clone();

--- a/services/mai400-service/src/tests/schema.rs
+++ b/services/mai400-service/src/tests/schema.rs
@@ -27,9 +27,9 @@ use tests::test_data::*;
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                    "msg": $result,
-                    "errs": ""
-            }).to_string()
+                                "msg": $result,
+                                "errs": ""
+                        }).to_string()
     }};
 }
 

--- a/services/mai400-service/src/tests/schema.rs
+++ b/services/mai400-service/src/tests/schema.rs
@@ -27,9 +27,9 @@ use tests::test_data::*;
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                                "msg": $result,
-                                "errs": ""
-                        }).to_string()
+                                    "msg": $result,
+                                    "errs": ""
+                            }).to_string()
     }};
 }
 

--- a/services/novatel-oem6-service/src/tests/schema/mod.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mod.rs
@@ -25,9 +25,9 @@ use std::sync::mpsc::sync_channel;
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                    "msg": $result,
-                    "errs": ""
-            }).to_string()
+                                "msg": $result,
+                                "errs": ""
+                        }).to_string()
     }};
 }
 

--- a/services/novatel-oem6-service/src/tests/schema/mod.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mod.rs
@@ -25,9 +25,9 @@ use std::sync::mpsc::sync_channel;
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                                "msg": $result,
-                                "errs": ""
-                        }).to_string()
+                                    "msg": $result,
+                                    "errs": ""
+                            }).to_string()
     }};
 }
 

--- a/test/integration/linux/isis-ants/src/main.rs
+++ b/test/integration/linux/isis-ants/src/main.rs
@@ -21,17 +21,16 @@ extern crate slog_async;
 extern crate slog_stream;
 extern crate slog_term;
 
-use isis_ants_api::{AntS, KI2CNum, KANTSController, KANTSAnt};
+use isis_ants_api::{AntS, KANTSAnt, KANTSController, KI2CNum};
 use slog::{Drain, Logger};
 use std::fs::File;
 use std::sync::Mutex;
 
 fn arm(ants: &AntS, logger: &Logger) -> u8 {
-
     match ants.arm() {
         Ok(()) => {
-        	info!(logger, "[Arm Test] Test completed successfully");
-        	return 0;
+            info!(logger, "[Arm Test] Test completed successfully");
+            return 0;
         }
         Err(err) => {
             error!(logger, "[Arm Test] Failed to arm AntS: {}", err);
@@ -43,8 +42,8 @@ fn arm(ants: &AntS, logger: &Logger) -> u8 {
 fn disarm(ants: &AntS, logger: &Logger) -> u8 {
     match ants.disarm() {
         Ok(()) => {
-        	info!(logger, "[Disarm Test] Test completed successfully");
-			return 0;
+            info!(logger, "[Disarm Test] Test completed successfully");
+            return 0;
         }
         Err(err) => {
             error!(logger, "[Disarm Test] Failed to disarm AntS: {}", err);
@@ -56,8 +55,8 @@ fn disarm(ants: &AntS, logger: &Logger) -> u8 {
 fn configure(ants: &AntS, logger: &Logger) -> u8 {
     match ants.configure(KANTSController::Secondary) {
         Ok(()) => {
-        	info!(logger, "[Configure Test] Test completed successfully");
-			return 0;
+            info!(logger, "[Configure Test] Test completed successfully");
+            return 0;
         }
         Err(err) => {
             error!(logger, "[Configure Test] Failed to configure AntS: {}", err);
@@ -66,12 +65,11 @@ fn configure(ants: &AntS, logger: &Logger) -> u8 {
     }
 }
 
-
 fn deploy(ants: &AntS, logger: &Logger) -> u8 {
     match ants.deploy(KANTSAnt::Ant3, false, 1) {
-        Ok(()) => { 
-        	info!(logger, "[Deploy Test] Test completed successfully");
-			return 0;
+        Ok(()) => {
+            info!(logger, "[Deploy Test] Test completed successfully");
+            return 0;
         }
         Err(err) => {
             error!(logger, "[Deploy Test] Failed to deploy antenna 3: {}", err);
@@ -83,14 +81,13 @@ fn deploy(ants: &AntS, logger: &Logger) -> u8 {
 fn deploy_override(ants: &AntS, logger: &Logger) -> u8 {
     match ants.deploy(KANTSAnt::Ant1, true, 1) {
         Ok(()) => {
-        	info!(logger, "[Deploy Override Test] Test completed successfully");
-			return 0;
+            info!(logger, "[Deploy Override Test] Test completed successfully");
+            return 0;
         }
         Err(err) => {
             error!(
                 logger,
-                "[Deploy Override Test] Failed to deploy antenna 1: {}",
-                err
+                "[Deploy Override Test] Failed to deploy antenna 1: {}", err
             );
             return 1;
         }
@@ -100,14 +97,13 @@ fn deploy_override(ants: &AntS, logger: &Logger) -> u8 {
 fn auto_deploy(ants: &AntS, logger: &Logger) -> u8 {
     match ants.auto_deploy(2) {
         Ok(()) => {
-        	info!(logger, "[Auto-Deploy Test] Test completed successfully");
-			return 0;
+            info!(logger, "[Auto-Deploy Test] Test completed successfully");
+            return 0;
         }
         Err(err) => {
             error!(
                 logger,
-                "[Auto-Deploy Test] Failed to auto-deploy antennas: {}",
-                err
+                "[Auto-Deploy Test] Failed to auto-deploy antennas: {}", err
             );
             return 1;
         }
@@ -117,14 +113,13 @@ fn auto_deploy(ants: &AntS, logger: &Logger) -> u8 {
 fn cancel_deploy(ants: &AntS, logger: &Logger) -> u8 {
     match ants.cancel_deploy() {
         Ok(()) => {
-        	info!(logger, "[Disarm Test] Test completed successfully");
-			return 0;
+            info!(logger, "[Disarm Test] Test completed successfully");
+            return 0;
         }
         Err(err) => {
             error!(
                 logger,
-                "[Disarm Test] Failed to cancel AntS deployment: {}",
-                err
+                "[Disarm Test] Failed to cancel AntS deployment: {}", err
             );
             return 1;
         }
@@ -137,14 +132,13 @@ fn passthrough(ants: &AntS, logger: &Logger) -> u8 {
 
     match ants.passthrough(&tx, &mut rx) {
         Ok(()) => {
-			info!(logger, "[Passthrough Test] Result: {:?}", rx);
-			return 0;
+            info!(logger, "[Passthrough Test] Result: {:?}", rx);
+            return 0;
         }
         Err(err) => {
             error!(
                 logger,
-                "[Passthrough Test] Failed to read AntS deployment status: {}",
-                err
+                "[Passthrough Test] Failed to read AntS deployment status: {}", err
             );
             return 1;
         }
@@ -154,8 +148,8 @@ fn passthrough(ants: &AntS, logger: &Logger) -> u8 {
 fn reset(ants: &AntS, logger: &Logger) -> u8 {
     match ants.reset() {
         Ok(()) => {
-        	info!(logger, "[Reset Test] Test completed successfully");
-			return 0;
+            info!(logger, "[Reset Test] Test completed successfully");
+            return 0;
         }
         Err(err) => {
             error!(logger, "[Reset Test] Failed to reset AntS: {}", err);
@@ -165,14 +159,12 @@ fn reset(ants: &AntS, logger: &Logger) -> u8 {
 }
 
 fn get_deploy(ants: &AntS, logger: &Logger) -> u8 {
-
     let deploy = match ants.get_deploy() {
         Ok(result) => result,
         Err(err) => {
             error!(
                 logger,
-                "[Passthrough Test] Failed to read AntS deployment status: {}",
-                err
+                "[Passthrough Test] Failed to read AntS deployment status: {}", err
             );
             return 1;
         }
@@ -182,52 +174,43 @@ fn get_deploy(ants: &AntS, logger: &Logger) -> u8 {
     info!(logger, "    sys_burn_active: {}", deploy.sys_burn_active);
     info!(
         logger,
-        "    sys_ignore_deploy: {}",
-        deploy.sys_ignore_deploy
+        "    sys_ignore_deploy: {}", deploy.sys_ignore_deploy
     );
     info!(logger, "    sys_armed: {}", deploy.sys_armed);
     info!(
         logger,
-        "    ant_1_not_deployed: {}",
-        deploy.ant_1_not_deployed
+        "    ant_1_not_deployed: {}", deploy.ant_1_not_deployed
     );
     info!(
         logger,
-        "    ant_1_stopped_time: {}",
-        deploy.ant_1_stopped_time
+        "    ant_1_stopped_time: {}", deploy.ant_1_stopped_time
     );
     info!(logger, "    ant_1_active: {}", deploy.ant_1_active);
     info!(
         logger,
-        "    ant_2_not_deployed: {}",
-        deploy.ant_2_not_deployed
+        "    ant_2_not_deployed: {}", deploy.ant_2_not_deployed
     );
     info!(
         logger,
-        "    ant_2_stopped_time: {}",
-        deploy.ant_2_stopped_time
+        "    ant_2_stopped_time: {}", deploy.ant_2_stopped_time
     );
     info!(logger, "    ant_2_active: {}", deploy.ant_2_active);
     info!(
         logger,
-        "    ant_3_not_deployed: {}",
-        deploy.ant_3_not_deployed
+        "    ant_3_not_deployed: {}", deploy.ant_3_not_deployed
     );
     info!(
         logger,
-        "    ant_3_stopped_time: {}",
-        deploy.ant_3_stopped_time
+        "    ant_3_stopped_time: {}", deploy.ant_3_stopped_time
     );
     info!(logger, "    ant_3_active: {}", deploy.ant_3_active);
     info!(
         logger,
-        "    ant_4_not_deployed: {}",
-        deploy.ant_4_not_deployed
+        "    ant_4_not_deployed: {}", deploy.ant_4_not_deployed
     );
     info!(
         logger,
-        "    ant_4_stopped_time: {}",
-        deploy.ant_4_stopped_time
+        "    ant_4_stopped_time: {}", deploy.ant_4_stopped_time
     );
     info!(logger, "    ant_4_active: {}", deploy.ant_4_active);
 
@@ -241,14 +224,12 @@ fn get_deploy(ants: &AntS, logger: &Logger) -> u8 {
 }
 
 fn get_sys_telem(ants: &AntS, logger: &Logger) -> u8 {
-
     let sys_telem = match ants.get_system_telemetry() {
         Ok(result) => result,
         Err(err) => {
             error!(
                 logger,
-                "[Passthrough Test] Failed to read AntS deployment status: {}",
-                err
+                "[Passthrough Test] Failed to read AntS deployment status: {}", err
             );
             return 1;
         }
@@ -259,78 +240,63 @@ fn get_sys_telem(ants: &AntS, logger: &Logger) -> u8 {
     info!(logger, "    deploy_status:");
     info!(
         logger,
-        "        sys_burn_active: {}",
-        sys_telem.deploy_status.sys_burn_active
+        "        sys_burn_active: {}", sys_telem.deploy_status.sys_burn_active
     );
     info!(
         logger,
-        "        sys_ignore_deploy: {}",
-        sys_telem.deploy_status.sys_ignore_deploy
+        "        sys_ignore_deploy: {}", sys_telem.deploy_status.sys_ignore_deploy
     );
     info!(
         logger,
-        "        sys_armed: {}",
-        sys_telem.deploy_status.sys_armed
+        "        sys_armed: {}", sys_telem.deploy_status.sys_armed
     );
     info!(
         logger,
-        "        ant_1_not_deployed: {}",
-        sys_telem.deploy_status.ant_1_not_deployed
+        "        ant_1_not_deployed: {}", sys_telem.deploy_status.ant_1_not_deployed
     );
     info!(
         logger,
-        "        ant_1_stopped_time: {}",
-        sys_telem.deploy_status.ant_1_stopped_time
+        "        ant_1_stopped_time: {}", sys_telem.deploy_status.ant_1_stopped_time
     );
     info!(
         logger,
-        "        ant_1_active: {}",
-        sys_telem.deploy_status.ant_1_active
+        "        ant_1_active: {}", sys_telem.deploy_status.ant_1_active
     );
     info!(
         logger,
-        "        ant_2_not_deployed: {}",
-        sys_telem.deploy_status.ant_2_not_deployed
+        "        ant_2_not_deployed: {}", sys_telem.deploy_status.ant_2_not_deployed
     );
     info!(
         logger,
-        "        ant_2_stopped_time: {}",
-        sys_telem.deploy_status.ant_2_stopped_time
+        "        ant_2_stopped_time: {}", sys_telem.deploy_status.ant_2_stopped_time
     );
     info!(
         logger,
-        "        ant_2_active: {}",
-        sys_telem.deploy_status.ant_2_active
+        "        ant_2_active: {}", sys_telem.deploy_status.ant_2_active
     );
     info!(
         logger,
-        "        ant_3_not_deployed: {}",
-        sys_telem.deploy_status.ant_3_not_deployed
+        "        ant_3_not_deployed: {}", sys_telem.deploy_status.ant_3_not_deployed
     );
     info!(
         logger,
-        "        ant_3_stopped_time: {}",
-        sys_telem.deploy_status.ant_3_stopped_time
+        "        ant_3_stopped_time: {}", sys_telem.deploy_status.ant_3_stopped_time
     );
     info!(
         logger,
-        "        ant_3_active: {}",
-        sys_telem.deploy_status.ant_3_active
+        "        ant_3_active: {}", sys_telem.deploy_status.ant_3_active
     );
     info!(
         logger,
-        "        ant_4_not_deployed: {}",
-        sys_telem.deploy_status.ant_4_not_deployed
+        "        ant_4_not_deployed: {}", sys_telem.deploy_status.ant_4_not_deployed
     );
     info!(
         logger,
-        "        ant_4_stopped_time: {}",
-        sys_telem.deploy_status.ant_4_stopped_time
+        "        ant_4_stopped_time: {}", sys_telem.deploy_status.ant_4_stopped_time
     );
     info!(
         logger,
-        "        ant_4_active: {}",
-        sys_telem.deploy_status.ant_4_active
+        "        ant_4_active: {}", sys_telem.deploy_status.ant_4_active
     );
     info!(logger, "    uptime: {}", sys_telem.uptime);
 
@@ -343,14 +309,12 @@ fn get_sys_telem(ants: &AntS, logger: &Logger) -> u8 {
 }
 
 fn get_act_counts(ants: &AntS, logger: &Logger) -> u8 {
-
     let act_count = match ants.get_activation_count(KANTSAnt::Ant1) {
         Ok(result) => result,
         Err(err) => {
             error!(
                 logger,
-                "[Activation Count Test] Failed to get antenna 1's activation count: {}",
-                err
+                "[Activation Count Test] Failed to get antenna 1's activation count: {}", err
             );
             return 1;
         }
@@ -363,8 +327,7 @@ fn get_act_counts(ants: &AntS, logger: &Logger) -> u8 {
         Err(err) => {
             error!(
                 logger,
-                "[Activation Count Test] Failed to get antenna 2's activation count: {}",
-                err
+                "[Activation Count Test] Failed to get antenna 2's activation count: {}", err
             );
             return 1;
         }
@@ -377,8 +340,7 @@ fn get_act_counts(ants: &AntS, logger: &Logger) -> u8 {
         Err(err) => {
             error!(
                 logger,
-                "[Activation Count Test] Failed to get antenna 3's activation count: {}",
-                err
+                "[Activation Count Test] Failed to get antenna 3's activation count: {}", err
             );
             return 1;
         }
@@ -391,8 +353,7 @@ fn get_act_counts(ants: &AntS, logger: &Logger) -> u8 {
         Err(err) => {
             error!(
                 logger,
-                "[Activation Count Test] Failed to get antenna 4's activation count: {}",
-                err
+                "[Activation Count Test] Failed to get antenna 4's activation count: {}", err
             );
             return 1;
         }
@@ -409,14 +370,12 @@ fn get_act_counts(ants: &AntS, logger: &Logger) -> u8 {
 }
 
 fn get_act_times(ants: &AntS, logger: &Logger) -> u8 {
-
     let act_time = match ants.get_activation_time(KANTSAnt::Ant1) {
         Ok(result) => result,
         Err(err) => {
             error!(
                 logger,
-                "[Activation Time Test] Failed to get antenna 1's activation time: {}",
-                err
+                "[Activation Time Test] Failed to get antenna 1's activation time: {}", err
             );
             return 1;
         }
@@ -429,8 +388,7 @@ fn get_act_times(ants: &AntS, logger: &Logger) -> u8 {
         Err(err) => {
             error!(
                 logger,
-                "[Activation Time Test] Failed to get antenna 2's activation time: {}",
-                err
+                "[Activation Time Test] Failed to get antenna 2's activation time: {}", err
             );
             return 1;
         }
@@ -443,8 +401,7 @@ fn get_act_times(ants: &AntS, logger: &Logger) -> u8 {
         Err(err) => {
             error!(
                 logger,
-                "[Activation Time Test] Failed to get antenna 3's activation time: {}",
-                err
+                "[Activation Time Test] Failed to get antenna 3's activation time: {}", err
             );
             return 1;
         }
@@ -457,8 +414,7 @@ fn get_act_times(ants: &AntS, logger: &Logger) -> u8 {
         Err(err) => {
             error!(
                 logger,
-                "[Activation Time Test] Failed to get antenna 4's activation time: {}",
-                err
+                "[Activation Time Test] Failed to get antenna 4's activation time: {}", err
             );
             return 1;
         }
@@ -475,14 +431,12 @@ fn get_act_times(ants: &AntS, logger: &Logger) -> u8 {
 }
 
 fn get_uptime(ants: &AntS, logger: &Logger) -> u8 {
-
     let uptime = match ants.get_uptime() {
         Ok(result) => result,
         Err(err) => {
             error!(
                 logger,
-                "[Passthrough Test] Failed to read AntS deployment status: {}",
-                err
+                "[Passthrough Test] Failed to read AntS deployment status: {}", err
             );
             return 1;
         }

--- a/test/integration/linux/mai400/src/main.rs
+++ b/test/integration/linux/mai400/src/main.rs
@@ -30,10 +30,10 @@ use i2c_linux::I2c;
 use mai400_api::*;
 use slog::{Drain, Logger};
 use std::fs::File;
-use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Sender};
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
@@ -689,14 +689,12 @@ fn read(mai: &MAI400, logger: &Logger) -> u8 {
 fn read_loop(
     mai: MAI400,
     exit: Arc<AtomicBool>,
-    sender: Sender<
-        (
-            Option<StandardTelemetry>,
-            Option<RawIMU>,
-            Option<IREHSTelemetry>,
-            RotatingTelemetry,
-        ),
-    >,
+    sender: Sender<(
+        Option<StandardTelemetry>,
+        Option<RawIMU>,
+        Option<IREHSTelemetry>,
+        RotatingTelemetry,
+    )>,
 ) {
     let mut std: Option<StandardTelemetry> = None;
     let mut imu: Option<RawIMU> = None;


### PR DESCRIPTION
Whenever I ran `cargo fmt` it was picking up on changes outside of my working PRs so decided to make a branch just to clean this up. This was formatted with 0.4.2-stable of rustfmt.