### PR TITLE
SDK Doc Updates

### DIFF
--- a/docs/os-docs/using-kubos-linux.rst
+++ b/docs/os-docs/using-kubos-linux.rst
@@ -569,24 +569,24 @@ under this directory.
     Any files not residing under the /home directory will be destroyed
     during an upgrade/downgrade
 
-/home/usr/bin
-^^^^^^^^^^^^^
+/home/system/usr/bin
+^^^^^^^^^^^^^^^^^^^^
 
 All user-created applications will be loaded into this folder during the
 ``kubos flash`` process. The directory is included in the system's PATH,
 so applications can then be called directly from anywhere, without
 needing to know the full file path.
 
-/home/usr/local/bin
-^^^^^^^^^^^^^^^^^^^
+/home/system/usr/local/bin
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All user-created non-application files will be loaded into this folder
 during the ``kubos flash`` process. There is currently not a way to set
 a destination folder for the ``kubos flash`` command, so if a different
 endpoint directory is desired, the files will need to be manually moved.
 
-/home/etc/init.d
-^^^^^^^^^^^^^^^^
+/home/system/etc/init.d
+^^^^^^^^^^^^^^^^^^^^^^^
 
 All user-application initialization scripts live under this directory.
 The naming format is 'S{run-level}{application}'.

--- a/docs/os-docs/working-with-the-bbb.rst
+++ b/docs/os-docs/working-with-the-bbb.rst
@@ -264,8 +264,7 @@ Doc <http://www.nxp.com/documents/user_manual/UM10204.pdf>`__
 Kubos Linux is currently configured to support the I2C standard-mode
 speed of 100kHz.
 
-For examples and instructions, see the :doc:`../apis/kubos-hal/i2c` and
-:doc:`../apis/kubos-hal/i2c_api` documents.
+For examples and instructions, see the :doc:`I2C HAL documentation <../apis/kubos-hal/i2c-hal/index>`.
 
 SPI
 ~~~
@@ -394,7 +393,7 @@ eMMC
 The user partition on the eMMC device is used as the primary user data storage area.
 All system-related `/home/` paths will reside here.
 
-/home/usr/bin
+/home/system/usr/bin
 ^^^^^^^^^^^^^
 
 All user-created applications will be loaded into this folder during the
@@ -402,7 +401,7 @@ All user-created applications will be loaded into this folder during the
 so applications can then be called directly from anywhere, without
 needing to know the full file path.
 
-/home/usr/local/bin
+/home/system/usr/local/bin
 ^^^^^^^^^^^^^^^^^^^
 
 All user-created non-application files will be loaded into this folder
@@ -410,7 +409,7 @@ during the ``kubos flash`` process. There is currently not a way to set
 a destination folder for the ``kubos flash`` command, so if a different
 endpoint directory is desired, the files will need to be manually moved.
 
-/home/etc/init.d
+/home/system/etc/init.d
 ^^^^^^^^^^^^^^^^
 All user-application initialization scripts live under this directory.
 The naming format is 'S{run-level}{application}'.

--- a/docs/os-docs/working-with-the-bbb.rst
+++ b/docs/os-docs/working-with-the-bbb.rst
@@ -394,7 +394,7 @@ The user partition on the eMMC device is used as the primary user data storage a
 All system-related `/home/` paths will reside here.
 
 /home/system/usr/bin
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 All user-created applications will be loaded into this folder during the
 ``kubos flash`` process. The directory is included in the system's PATH,
@@ -402,7 +402,7 @@ so applications can then be called directly from anywhere, without
 needing to know the full file path.
 
 /home/system/usr/local/bin
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All user-created non-application files will be loaded into this folder
 during the ``kubos flash`` process. There is currently not a way to set
@@ -410,7 +410,7 @@ a destination folder for the ``kubos flash`` command, so if a different
 endpoint directory is desired, the files will need to be manually moved.
 
 /home/system/etc/init.d
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 All user-application initialization scripts live under this directory.
 The naming format is 'S{run-level}{application}'.
 

--- a/docs/os-docs/working-with-the-iobc.rst
+++ b/docs/os-docs/working-with-the-iobc.rst
@@ -197,8 +197,7 @@ speed of 100kHz.
 
 The I2C bus is available through the Kubos HAL as ``K_I2C1``.
 
-For examples and instructions, see the :doc:`../apis/kubos-hal/i2c` and
-:doc:`../apis/kubos-hal/i2c_api` documents.
+For examples and instructions, see the :doc:`I2C HAL documentation <../apis/kubos-hal/i2c-hal/index>`.
 
 PWM
 ~~~

--- a/docs/os-docs/working-with-the-mbm2.rst
+++ b/docs/os-docs/working-with-the-mbm2.rst
@@ -311,7 +311,7 @@ The user partition on the eMMC device is used as the primary user data storage a
 All system-related `/home/` paths will reside here.
 
 /home/system/usr/bin
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 All user-created applications will be loaded into this folder during the
 ``kubos flash`` process. The directory is included in the system's PATH,
@@ -319,7 +319,7 @@ so applications can then be called directly from anywhere, without
 needing to know the full file path.
 
 /home/system/usr/local/bin
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All user-created non-application files will be loaded into this folder
 during the ``kubos flash`` process. There is currently not a way to set
@@ -327,7 +327,7 @@ a destination folder for the ``kubos flash`` command, so if a different
 endpoint directory is desired, the files will need to be manually moved.
 
 /home/system/etc/init.d
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 All user-application initialization scripts live under this directory.
 The naming format is 'S{run-level}{application}'.

--- a/docs/os-docs/working-with-the-mbm2.rst
+++ b/docs/os-docs/working-with-the-mbm2.rst
@@ -273,8 +273,7 @@ speed of 100kHz.
 
 The I2C bus is available through the Kubos HAL as ``K_I2C1``.
 
-For examples and instructions, see the :doc:`../apis/kubos-hal/i2c` and
-:doc:`../apis/kubos-hal/i2c_api` documents.
+For examples and instructions, see the :doc:`I2C HAL documentation <../apis/kubos-hal/i2c-hal/index>`.
 
 UART
 ~~~~
@@ -311,7 +310,7 @@ eMMC
 The user partition on the eMMC device is used as the primary user data storage area.
 All system-related `/home/` paths will reside here.
 
-/home/usr/bin
+/home/system/usr/bin
 ^^^^^^^^^^^^^
 
 All user-created applications will be loaded into this folder during the
@@ -319,7 +318,7 @@ All user-created applications will be loaded into this folder during the
 so applications can then be called directly from anywhere, without
 needing to know the full file path.
 
-/home/usr/local/bin
+/home/system/usr/local/bin
 ^^^^^^^^^^^^^^^^^^^
 
 All user-created non-application files will be loaded into this folder
@@ -327,7 +326,7 @@ during the ``kubos flash`` process. There is currently not a way to set
 a destination folder for the ``kubos flash`` command, so if a different
 endpoint directory is desired, the files will need to be manually moved.
 
-/home/etc/init.d
+/home/system/etc/init.d
 ^^^^^^^^^^^^^^^^
 
 All user-application initialization scripts live under this directory.

--- a/docs/sdk-docs/sdk-examples.rst
+++ b/docs/sdk-docs/sdk-examples.rst
@@ -7,8 +7,8 @@ as well as within the `/home/vagrant/.kubos/kubos/examples` folder of the Kubos 
 
 Each example project directory contains a `README.md` file which details the purpose of the example and how to use it.
 
-Setting Up a C Example Application
-----------------------------------
+Using a C Example Application
+-----------------------------
 
 Each of the example applications written in C contains the files necessary to run as an independent Kubos project. 
 
@@ -33,9 +33,9 @@ To use a Rust example, copy the example into the desired location, then run::
 .. note:: 
 
     While they ultimately resolve to the same underlying target, the target names for Cargo are not the same as the
-    target names used by ``kubos target``. For more information, see :ref:`info about Caro targets <TODO>`.
+    target names used by ``kubos target``. For more information, see :ref:`Rust SDK doc <rust-targets>`.
     
-From here, please refer to the :ref:`Rust project transfer instructions <TODO>` for information about how to transfer and run
+From here, please refer to the :ref:`Rust project transfer instructions <rust-transfer>` for information about how to transfer and run
 a Rust project.
 
 Using a Python Example Application

--- a/docs/sdk-docs/sdk-examples.rst
+++ b/docs/sdk-docs/sdk-examples.rst
@@ -5,122 +5,41 @@ We have provided a variety of example applications to help you get started with 
 These examples are located in the 'Examples' folder of the `Kubos repo <http://github.com/kubos/kubos/tree/master/examples>`__, 
 as well as within the `/home/vagrant/.kubos/kubos/examples` folder of the Kubos SDK box.
 
-Using an Example Application
-----------------------------
+Each example project directory contains a `README.md` file which details the purpose of the example and how to use it.
 
-Each of the example applications contains the files necessary to run as an independent Kubos project. 
+Setting Up a C Example Application
+----------------------------------
+
+Each of the example applications written in C contains the files necessary to run as an independent Kubos project. 
 
 In order to use them, copy the example into the desired location and then run these commands from within the top level
-of the example folder:
+of the example folder::
 
     $ kubos link -a
+    $ kubos target {desired target}
     $ kubos build
+
+The ``kubos flash`` command can then be used to transfer the compiled binary onto your OBC.
+
+Once transferred, you can connect to your OBC and run the binary.
+
+Using a Rust Example Application
+--------------------------------
+
+To use a Rust example, copy the example into the desired location, then run::
+
+    $ cargo build --target {desired target}
     
-.. todo::
-
-    When Rust and/or Python examples get added, these instructions will need to be updated
-
-"Compatible Targets" indicates which target boards for which the application should execute successfully without modification.
-
 .. note:: 
 
-    The default target for all of these applications is ``stm32f407-disco-gcc``. 
-    You will need to manually change the target if this is not your desired endpoint device. 
+    While they ultimately resolve to the same underlying target, the target names for Cargo are not the same as the
+    target names used by ``kubos target``. For more information, see :ref:`info about Caro targets <TODO>`.
+    
+From here, please refer to the :ref:`Rust project transfer instructions <TODO>` for information about how to transfer and run
+a Rust project.
 
-TCP Receive
------------
+Using a Python Example Application
+----------------------------------
 
-`Example Code - GitHub <http://github.com/kubos/kubos/tree/master/examples/kubos-linux-tcprx>`__
-
-**Compatible Targets: Pumpkin MBM2, Beaglebone Black**
-
-+----------------------+--------------------+
-| High-level Component | Specific Area      |
-+======================+====================+
-| Linux                | sockets, TCP, IPv4 |
-+----------------------+--------------------+
-
-This is a demo program to test receiving TCP data over a valid IP connection (the ethernet port for the Pumpkin MBM2 and Beaglebone 
-Black targets)
-
-The program will wait for a client to connect over the socket, then read in any messages and send back a reply.
-
-TCP Send
---------
-
-`Example Code - GitHub <http://github.com/kubos/kubos/tree/master/examples/kubos-linux-tcprx>`__
-
-**Compatible Targets: Pumpkin MBM2, Beaglebone Black**
-
-+----------------------+--------------------+
-| High-level Component | Specific Area      |
-+======================+====================+
-| Linux                | sockets, TCP, IPv4 |
-+----------------------+--------------------+
-
-This is a demo program to test sending TCP data over a valid IP connection (the ethernet port for the Pumpkin MBM2 and Beaglebone Black 
-targets)
-
-The program takes the IP address and port to send to as input parameters, then sends a test message to the requested end point.
-It then waits for a reply message to be returned and exits.
-
-    Usage: kubos-linux-tcptx <ip_addr> <port>
-
-UART Receive
-------------
-
-`Example Code - GitHub <http://github.com/kubos/kubos/tree/master/examples/kubos-linux-uartrx>`__
-
-**Compatible Targets: All targets with UART ports**
-
-+----------------------+-------------------------------------------------------------------+
-| High-level Component | Specific Area                                                     |
-+======================+===================================================================+
-| Linux                | `termios <http://man7.org/linux/man-pages/man3/termios.3.html>`__ |
-+----------------------+-------------------------------------------------------------------+
-
-This is a demo program to test receiving UART data in non-blocking mode as an interrupt. It expects to read the incrementing message 
-"Test message nnn" every 5 seconds from `/dev/ttyS1`.
-
-This program should be paired with the UART Send demo program.
-
-UART Send
----------
-
-`Example Code - GitHub <http://github.com/kubos/kubos/tree/master/examples/kubos-linux-uarttx>`__
-
-**Compatible Targets: All targets with UART ports**
-
-+----------------------+-------------------------------------------------------------------+
-| High-level Component | Specific Area                                                     |
-+======================+===================================================================+
-| Linux                | `termios <http://man7.org/linux/man-pages/man3/termios.3.html>`__ |
-+----------------------+-------------------------------------------------------------------+
-
-This is a demo program to test UART transmission. It will write an incrementing message "Test message nnn" every 5 seconds out of `/dev/ttyS3`.
-
-This program should be paired with the UART Receive demo program.
-
-ADC Thermistor
---------------
-
-`Example Code - GitHub <http://github.com/kubos/kubos/tree/master/examples/adc-thermistor>`__
-
-**Compatible Targets: All targets with ADC pins**
-
-**Additional Hardware: Thermistor, 10 kOhm resistor**
-
-+----------------------+---------------+
-| High-level Component | Specific Area |
-+======================+===============+
-| Linux                | ADC (IIO)     |
-+----------------------+---------------+
-
-This is a demo program to test reading a raw value from an ADC pin.
-It will use the raw value to derive a temperature reading from the connected thermistor.    
-
-.. note::
-
-    This example is configured for an ADC pin with a 10-bit resolution connected to a 10 kOhm
-    thermistor with a 3.3V reference voltage and a voltage supply of 2.4V. These values might
-    need to be changed based on your test setup
+Since Python modules do not require compilation, the Python examples can be directly transferred to the OBC and
+run. For more information, see the :doc:`Python SDK guide <sdk-python>`.

--- a/docs/sdk-docs/sdk-project-config.rst
+++ b/docs/sdk-docs/sdk-project-config.rst
@@ -166,7 +166,7 @@ System
       generated with the run level specified by ``runLevel`` 
     :property number runLevel: `(Default: 50. Range: 10-99)` The priority of the generated init script. 
       Scripts with lower values will be run first
-    :property string destDir: `(Default: "/home/usr/local/bin")` Specifies flashing destination directory for all 
+    :property string destDir: `(Default: "/home/system/usr/local/bin")` Specifies flashing destination directory for all 
       non-application files
     :property string password: `(Default: "Kubos123") Specifies the root password to be used by 
       ``kubos flash`` to successfully connect to the target device

--- a/docs/sdk-docs/sdk-rust.rst
+++ b/docs/sdk-docs/sdk-rust.rst
@@ -73,6 +73,8 @@ The target name varies depending which command is used to compile the project.
 | Pumpkin MBM2     | arm-unknown-linux-gnueabihf   | kubos-linux-pumpkin-mbm2-gcc |
 +------------------+-------------------------------+------------------------------+
 
+.. _rust-transfer:
+
 Flashing
 --------
 

--- a/docs/sdk-docs/sdk-rust.rst
+++ b/docs/sdk-docs/sdk-rust.rst
@@ -110,7 +110,7 @@ It is a bit of a process laid out in the following steps:
    binary over to the target.
 
 If you would like the transferred binary to be accessible from any location in the system,
-it will then need to be manually transferred to a locatoin the system PATH:
+it will then need to be manually transferred to a location the system PATH:
 
 1. Run ``minicom kubos`` from inside of the Vagrant box.
 2. Enter the username ``kubos`` and the password ``Kubos123``.
@@ -144,8 +144,7 @@ To format your code:
 Important Notes
 ~~~~~~~~~~~~~~~
 
-- Kubos is currently using the ``0.4.2-nightly`` version of ``rustfmt``.
-  Despite the name, it is the latest version of ``rustfmt`` for stable Rust.
+- Kubos is currently using the ``0.4.2-stable`` version of ``rustfmt``.
 - Using ``cargo install rustfmt`` to install ``rustfmt`` will result in the deprecated version being installed, 
   which has slightly different formatting rules. Please use the ``rustup`` installation method instead.
 


### PR DESCRIPTION
- Making the examples page just refer to the 'examples' folder of the repo, rather than explaining each available example
- Adding instructions to the examples page on how to use the Rust and Python example projects
- Updating the Rust SDK instructions to cover the normal `cargo build` process
- Fixing all our system path locations to actually be correct... >.>
- Fixing some I2C HAL links which I missed