### PR TITLE
Increasing OEM6 receive timeout

### DIFF
--- a/services/novatel-oem6-service/src/model.rs
+++ b/services/novatel-oem6-service/src/model.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 
 use objects::*;
 
-pub const RECV_TIMEOUT: Duration = Duration::from_millis(300);
+pub const RECV_TIMEOUT: Duration = Duration::from_millis(350);
 
 pub struct LockData {
     pub status: Mutex<LockStatus>,


### PR DESCRIPTION
When requesting version information from the OEM6 (which is the only command that does on-demand requests for information), the current timeout when waiting for the information to be returned is slightly too slow sometimes. When I was debugging this, I saw return times of around 305ms.

Increasing the timeout so that we can get the version info successfully (consistently)