### PR TITLE
Added new circleci step to regenerate just the docs on a release tag.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,3 +24,8 @@ deployment:
       - ./deploy.sh
       - docker run -t -v $PWD:$PWD --workdir $PWD kubos/kubos-docs:latest sh prep_docs.sh
       - ./deploy_docs.sh
+  release:
+    tag: /^[0-9]+(\.[0-9]+)*$/
+    commands:
+      - docker run -t -v $PWD:$PWD --workdir $PWD kubos/kubos-docs:latest sh prep_docs.sh
+      - ./deploy_docs.sh


### PR DESCRIPTION
Our current Circle configuration will not run when release tags are generated. This requires us to manually run the docs generation step for each release. These changes should instruct Circle to just regenerate and publish the docs when a new release (`x.y.x` *not* `x.y.z+abc`) tag is made. Following configuration instructions from here - https://circleci.com/docs/1.0/configuration/#tags.