### PR TITLE
[WIP] Timestamps should be milliseconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ doctrees/
 .kubos-link.json
 .travis.yml
 upload.tar.gz
+config.toml
 
 # vim files
 .*.sw*

--- a/services/telemetry-service/src/db.rs
+++ b/services/telemetry-service/src/db.rs
@@ -66,7 +66,7 @@ impl Database {
                 println!("Telemetry table not found. Creating table.");
                 match sql_query(
                     "CREATE TABLE telemetry (
-                    timestamp INTEGER NOT NULL,
+                    timestamp DOUBLE NOT NULL,
                     subsystem VARCHAR(255) NOT NULL,
                     parameter VARCHAR(255) NOT NULL,
                     value VARCHAR(255) NOT NULL,
@@ -83,7 +83,7 @@ impl Database {
 
 table! {
     telemetry (timestamp) {
-        timestamp -> Integer,
+        timestamp -> Double,
         subsystem -> Text,
         parameter -> Text,
         value -> Text,

--- a/services/telemetry-service/src/models.rs
+++ b/services/telemetry-service/src/models.rs
@@ -16,7 +16,7 @@
 
 #[derive(Debug, Queryable)]
 pub struct Entry {
-    pub timestamp: i32,
+    pub timestamp: f64,
     pub subsystem: String,
     pub parameter: String,
     pub value: String,

--- a/services/telemetry-service/src/schema.rs
+++ b/services/telemetry-service/src/schema.rs
@@ -25,7 +25,7 @@ type Context = kubos_service::Context<Database>;
 graphql_object!(Entry: () |&self| {
     description: "A telemetry entry"
 
-    field timestamp() -> i32 as "Timestamp" {
+    field timestamp() -> f64 as "Timestamp" {
         self.timestamp
     }
 
@@ -47,8 +47,8 @@ pub struct QueryRoot;
 graphql_object!(QueryRoot: Context |&self| {
     field telemetry(
         &executor,
-        timestamp_ge: Option<i32>,
-        timestamp_le: Option<i32>,
+        timestamp_ge: Option<f64>,
+        timestamp_le: Option<f64>,
         subsystem: Option<String>,
         parameter: Option<String>,
         limit: Option<i32>,

--- a/services/telemetry-service/tests/test_filter_parameter.rs
+++ b/services/telemetry-service/tests/test_filter_parameter.rs
@@ -21,9 +21,9 @@ mod utils;
 use utils::*;
 
 static SQL: &'static str = r"
-insert into telemetry values(1000, 'eps', 'voltage', '3.3');
-insert into telemetry values(1000, 'eps', 'voltage5', '3.5');
-insert into telemetry values(1001, 'eps', 'voltage', '3.4');
+insert into telemetry values(1531412196210, 'eps', 'voltage', '3.3');
+insert into telemetry values(1531412196211, 'eps', 'voltage5', '3.5');
+insert into telemetry values(1531412196212, 'eps', 'voltage', '3.4');
 ";
 
 #[test]

--- a/services/telemetry-service/tests/test_filter_subsystem.rs
+++ b/services/telemetry-service/tests/test_filter_subsystem.rs
@@ -21,9 +21,9 @@ mod utils;
 use utils::*;
 
 static SQL: &'static str = r"
-insert into telemetry values(1000, 'eps', 'voltage', '3.3');
-insert into telemetry values(1010, 'gps', 'x_position', '-1.0');
-insert into telemetry values(1011, 'eps', 'voltage', '10');
+insert into telemetry values(1531412196210.0, 'eps', 'voltage', '3.3');
+insert into telemetry values(1531412196211.0, 'gps', 'x_position', '-1.0');
+insert into telemetry values(1531412196212.0, 'eps', 'voltage', '10');
 ";
 
 #[test]
@@ -37,7 +37,7 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1010.0,"subsystem":"gps","parameter":"x_position","value":"-1.0"}
+                    {"timestamp":1531412196211.0,"subsystem":"gps","parameter":"x_position","value":"-1.0"}
                 ]
             }
         })

--- a/services/telemetry-service/tests/test_filter_subsystem.rs
+++ b/services/telemetry-service/tests/test_filter_subsystem.rs
@@ -37,7 +37,7 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1010,"subsystem":"gps","parameter":"x_position","value":"-1.0"}
+                    {"timestamp":1010.0,"subsystem":"gps","parameter":"x_position","value":"-1.0"}
                 ]
             }
         })

--- a/services/telemetry-service/tests/test_filter_timestamp.rs
+++ b/services/telemetry-service/tests/test_filter_timestamp.rs
@@ -21,12 +21,12 @@ mod utils;
 use utils::*;
 
 static SQL: &'static str = r"
-insert into telemetry values(1000, 'eps', 'voltage', '3.3');
-insert into telemetry values(1001, 'eps', 'voltage', '3.4');
-insert into telemetry values(1002, 'eps', 'voltage', '3.5');
-insert into telemetry values(1003, 'eps', 'voltage', '3.6');
-insert into telemetry values(1004, 'eps', 'voltage', '3.7');
-insert into telemetry values(1005, 'eps', 'voltage', '3.8');
+insert into telemetry values(1531347346000, 'eps', 'voltage', '3.3');
+insert into telemetry values(1531347346001, 'eps', 'voltage', '3.4');
+insert into telemetry values(15313473460002, 'eps', 'voltage', '3.5');
+insert into telemetry values(15313473460003, 'eps', 'voltage', '3.6');
+insert into telemetry values(15313473460004, 'eps', 'voltage', '3.7');
+insert into telemetry values(15313473460005, 'eps', 'voltage', '3.8');
 ";
 
 /// These four test cases are all in one test function because
@@ -36,10 +36,10 @@ insert into telemetry values(1005, 'eps', 'voltage', '3.8');
 fn tests() {
     let (handle, sender) = setup(Some(SQL));
 
-    let ge_res = do_query("{telemetry(timestampGe: 1004){value}}");
-    let le_res = do_query("{telemetry(timestampLe: 1002){value}}");
-    let range_res = do_query("{telemetry(timestampGe: 1001, timestampLe:1003){value}}");
-    let single_res = do_query("{telemetry(timestampGe: 1003, timestampLe:1003){value}}");
+    let ge_res = do_query("{telemetry(timestampGe: 15313473460004){value}}");
+    let le_res = do_query("{telemetry(timestampLe: 15313473460002){value}}");
+    let range_res = do_query("{telemetry(timestampGe: 15313473460001, timestampLe:15313473460003){value}}");
+    let single_res = do_query("{telemetry(timestampGe: 15313473460003, timestampLe:15313473460003){value}}");
 
     teardown(handle, sender);
 

--- a/services/telemetry-service/tests/test_filter_timestamp.rs
+++ b/services/telemetry-service/tests/test_filter_timestamp.rs
@@ -21,12 +21,12 @@ mod utils;
 use utils::*;
 
 static SQL: &'static str = r"
-insert into telemetry values(1531347346000, 'eps', 'voltage', '3.3');
-insert into telemetry values(1531347346001, 'eps', 'voltage', '3.4');
-insert into telemetry values(15313473460002, 'eps', 'voltage', '3.5');
-insert into telemetry values(15313473460003, 'eps', 'voltage', '3.6');
-insert into telemetry values(15313473460004, 'eps', 'voltage', '3.7');
-insert into telemetry values(15313473460005, 'eps', 'voltage', '3.8');
+insert into telemetry values(1531412196210, 'eps', 'voltage', '3.3');
+insert into telemetry values(1531412196211, 'eps', 'voltage', '3.4');
+insert into telemetry values(1531412196212, 'eps', 'voltage', '3.5');
+insert into telemetry values(1531412196213, 'eps', 'voltage', '3.6');
+insert into telemetry values(1531412196214, 'eps', 'voltage', '3.7');
+insert into telemetry values(1531412196215, 'eps', 'voltage', '3.8');
 ";
 
 /// These four test cases are all in one test function because
@@ -36,10 +36,10 @@ insert into telemetry values(15313473460005, 'eps', 'voltage', '3.8');
 fn tests() {
     let (handle, sender) = setup(Some(SQL));
 
-    let ge_res = do_query("{telemetry(timestampGe: 15313473460004){value}}");
-    let le_res = do_query("{telemetry(timestampLe: 15313473460002){value}}");
-    let range_res = do_query("{telemetry(timestampGe: 15313473460001, timestampLe:15313473460003){value}}");
-    let single_res = do_query("{telemetry(timestampGe: 15313473460003, timestampLe:15313473460003){value}}");
+    let ge_res = do_query("{telemetry(timestampGe: 1531412196214.0){value}}");
+    let le_res = do_query("{telemetry(timestampLe: 1531412196212.0){value}}");
+    let range_res = do_query("{telemetry(timestampGe: 1531412196211.0, timestampLe:1531412196213.0){value}}");
+    let single_res = do_query("{telemetry(timestampGe: 1531412196213.0, timestampLe:1531412196213.0){value}}");
 
     teardown(handle, sender);
 

--- a/services/telemetry-service/tests/test_limit.rs
+++ b/services/telemetry-service/tests/test_limit.rs
@@ -21,24 +21,24 @@ mod utils;
 use utils::*;
 
 static SQL: &'static str = r"
-insert into telemetry values(1000, 'eps', 'voltage', '3.3');
-insert into telemetry values(1001, 'eps', 'voltage', '3.4');
-insert into telemetry values(1002, 'eps', 'voltage', '3.2');
-insert into telemetry values(1003, 'eps', 'voltage', '3.1');
-insert into telemetry values(1004, 'eps', 'voltage', '3.0');
-insert into telemetry values(1005, 'eps', 'voltage', '2.9');
-insert into telemetry values(1006, 'eps', 'voltage', '2.8');
-insert into telemetry values(1007, 'eps', 'voltage', '2.7');
-insert into telemetry values(1008, 'eps', 'voltage', '2.6');
-insert into telemetry values(1009, 'eps', 'voltage', '2.5');
-insert into telemetry values(1010, 'eps', 'voltage', '2.4');
+insert into telemetry values(1531412196211, 'eps', 'voltage', '3.3');
+insert into telemetry values(1531412196212, 'eps', 'voltage', '3.4');
+insert into telemetry values(1531412196213, 'eps', 'voltage', '3.2');
+insert into telemetry values(1531412196214, 'eps', 'voltage', '3.1');
+insert into telemetry values(1531412196215, 'eps', 'voltage', '3.0');
+insert into telemetry values(1531412196216, 'eps', 'voltage', '2.9');
+insert into telemetry values(1531412196217, 'eps', 'voltage', '2.8');
+insert into telemetry values(1531412196218, 'eps', 'voltage', '2.7');
+insert into telemetry values(1531412196219, 'eps', 'voltage', '2.6');
+insert into telemetry values(1531412196220, 'eps', 'voltage', '2.5');
+insert into telemetry values(1531412196221, 'eps', 'voltage', '2.4');
 ";
 
 #[test]
 fn test() {
     let (handle, sender) = setup(Some(SQL));
     let res =
-        do_query("{telemetry(limit: 2, timestampGe: 1008){timestamp,subsystem,parameter,value}}");
+        do_query("{telemetry(limit: 2, timestampGe: 1531412196215){timestamp,subsystem,parameter,value}}");
     teardown(handle, sender);
     assert_eq!(
         res,
@@ -46,8 +46,8 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1008.0,"subsystem":"eps","parameter":"voltage","value":"2.6"},
-                    {"timestamp":1009.0,"subsystem":"eps","parameter":"voltage","value":"2.5"},
+                    {"timestamp":1531412196216.0,"subsystem":"eps","parameter":"voltage","value":"2.9"},
+                    {"timestamp":1531412196217.0,"subsystem":"eps","parameter":"voltage","value":"2.8"},
                 ]
             }
         })

--- a/services/telemetry-service/tests/test_limit.rs
+++ b/services/telemetry-service/tests/test_limit.rs
@@ -46,8 +46,8 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1008,"subsystem":"eps","parameter":"voltage","value":"2.6"},
-                    {"timestamp":1009,"subsystem":"eps","parameter":"voltage","value":"2.5"},
+                    {"timestamp":1008.0,"subsystem":"eps","parameter":"voltage","value":"2.6"},
+                    {"timestamp":1009.0,"subsystem":"eps","parameter":"voltage","value":"2.5"},
                 ]
             }
         })

--- a/services/telemetry-service/tests/test_select_all.rs
+++ b/services/telemetry-service/tests/test_select_all.rs
@@ -21,9 +21,9 @@ mod utils;
 use utils::*;
 
 static SQL: &'static str = r"
-insert into telemetry values(1000, 'eps', 'voltage', '3.3');
-insert into telemetry values(1001, 'eps', 'voltage', '3.4');
-insert into telemetry values(1002, 'eps', 'voltage', '3.2');
+insert into telemetry values(1531412196211, 'eps', 'voltage', '3.3');
+insert into telemetry values(1531412196212, 'eps', 'voltage', '3.4');
+insert into telemetry values(1531412196213, 'eps', 'voltage', '3.2');
 ";
 
 #[test]
@@ -37,9 +37,9 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1000.0,"subsystem":"eps","parameter":"voltage","value":"3.3"},
-                    {"timestamp":1001.0,"subsystem":"eps","parameter":"voltage","value":"3.4"},
-                    {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"}
+                    {"timestamp":1531412196211.0,"subsystem":"eps","parameter":"voltage","value":"3.3"},
+                    {"timestamp":1531412196212.0,"subsystem":"eps","parameter":"voltage","value":"3.4"},
+                    {"timestamp":1531412196213.0,"subsystem":"eps","parameter":"voltage","value":"3.2"}
                 ]
             }
         })

--- a/services/telemetry-service/tests/test_select_all.rs
+++ b/services/telemetry-service/tests/test_select_all.rs
@@ -37,9 +37,9 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1000,"subsystem":"eps","parameter":"voltage","value":"3.3"},
-                    {"timestamp":1001,"subsystem":"eps","parameter":"voltage","value":"3.4"},
-                    {"timestamp":1002,"subsystem":"eps","parameter":"voltage","value":"3.2"}
+                    {"timestamp":1000.0,"subsystem":"eps","parameter":"voltage","value":"3.3"},
+                    {"timestamp":1001.0,"subsystem":"eps","parameter":"voltage","value":"3.4"},
+                    {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"}
                 ]
             }
         })

--- a/services/telemetry-service/tests/utils/mod.rs
+++ b/services/telemetry-service/tests/utils/mod.rs
@@ -65,7 +65,7 @@ fn start_telemetry() -> (JoinHandle<()>, Sender<bool>) {
             .arg("-c")
             .arg("tests/config.toml")
             .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
+            .stdout(Stdio::inherit())
             .spawn()
             .unwrap();
 
@@ -100,6 +100,7 @@ pub fn do_query(query: &str) -> serde_json::Value {
     let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8110);
 
     let socket = UdpSocket::bind(local_addr).expect("couldn't bind to address");
+    socket.set_write_timeout(Some(Duration::new(10, 0))).unwrap();
     socket
         .send_to(&query.as_bytes(), &remote_addr)
         .expect("couldn't send message");


### PR DESCRIPTION
Update to use `DOUBLE` for the `timestamp` column in sqlite and `f64` in Rust.

@cantino paired with @plauche.