### PR TITLE
Updating aux-sd gen docs

### DIFF
--- a/docs/installation-docs/installing-linux-bbb.rst
+++ b/docs/installation-docs/installing-linux-bbb.rst
@@ -164,7 +164,7 @@ Install the Auxiliary Image
 Re-Flash the SD Card
 ~~~~~~~~~~~~~~~~~~~~
 
-Now flash the microSD card with the auxiliary SD card image. This image contains the
+Now flash the microSD card with the auxiliary SD card image (``aux-sd.img``). This image contains the
 Kubos Linux upgrade partition and the second user data partition.
 
 Once the flash process has completed, put the card back into the microSD slot

--- a/docs/installation-docs/installing-linux-mbm2.rst
+++ b/docs/installation-docs/installing-linux-mbm2.rst
@@ -157,7 +157,7 @@ Install the Auxiliary Image
 Re-Flash the SD Card
 ~~~~~~~~~~~~~~~~~~~~
 
-Now flash the microSD card with the auxiliary SD card image. This image contains the
+Now flash the microSD card with the auxiliary SD card image (``aux-sd.img``). This image contains the
 Kubos Linux upgrade partition and the second user data partition.
 
 Once the flash process has completed, put the card back into the microSD slot

--- a/docs/os-docs/kubos-linux-on-bbb.rst
+++ b/docs/os-docs/kubos-linux-on-bbb.rst
@@ -152,8 +152,11 @@ The relevant files are:
 -  beaglebone-black.dtb - The Device Tree Binary that Linux uses to configure itself
    for the Beaglebone Black board
 -  rootfs.tar - The root file system. Contains BusyBox and other libraries
--  kubos-linux.img - The complete Kubos Linux SD card image. It has a disk
-   signature of 0x4B4C4E58 ("KLNX").
+-  kubos-linux.tar.gz - A compressed file containing the complete Kubos Linux SD card
+   image, ``kubos-linux.img``. It has a disk signature of 0x4B4C4E58 ("KLNX").
+-  aux-sd.tar.gz - A compressed file containing the auxilliary SD card image which
+   contains the upgrade partition and the ``kpack-base.itb`` file which is used for
+   OS recovery. It has a disk signature of 0x41555820 ("AUX ").
 
 Changing the Output Toolchain Directory (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,36 +168,6 @@ If you would like to build your toolchain in somewhere other than the
 If you would like BuildRoot to just build the toolchain locally, you may remove
 the ``BR2_HOST_DIR`` variable entirely. The toolchain will then be built under the
 main "buildroot-2017.02.8" directory in a new "output/host" folder.
-
-Create auxilliary SD Card Image
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default, the build process will create a bootable SD card image. This will be flashed
-onto the eMMC. In order to create a full Kubos Linux setup, you'll want to also create
-an auxiliary image for the microSD card containing the upgrade partition and an additional
-user data partition.
-
-Follow the :ref:`upgrade-creation` instructions in order to create a base Kubos Package file
-(`kpack-base.itb`) to be used for recovery.
-
-Then, from the `kubos-linux-build/tools` folder, run the ``format-aux.sh`` script. 
-This will create a new SD card image, `aux-sd.img`, with two partitions:
-
-- An upgrade partition containing `kpack-base.itb`
-- A user data partition
-
-The image's disk signature will be 0x41555820 ("AUX ").
-
-There are two parameters which may be specified:
-
--  -s : Sets the size of the aux-sd.img file, specified in MB. The default is 3800 (3.8GB)
--  -i : Specifies the name and location of the kpack-\*.itb file to use as kpack-base.itb
-
-For example:
-
-::
-
-    $ ./format-aux.sh -i ../kpack-2017.07.21.itb
 
 Reset the Global Links
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/os-docs/kubos-linux-on-mbm2.rst
+++ b/docs/os-docs/kubos-linux-on-mbm2.rst
@@ -152,8 +152,11 @@ The relevant files are:
 -  pumpkin-mbm2.dtb - The Device Tree Binary that Linux uses to configure itself
    for the Pumpkin MBM2 board
 -  rootfs.tar - The root file system. Contains BusyBox and other libraries
--  kubos-linux.img - The complete Kubos Linux SD card image. It has a disk
-   signature of 0x4B4C4E58 ("KLNX").
+-  kubos-linux.tar.gz - A compressed file containing the complete Kubos Linux SD card
+   image, ``kubos-linux.img``. It has a disk signature of 0x4B4C4E58 ("KLNX").
+-  aux-sd.tar.gz - A compressed file containing the auxilliary SD card image which
+   contains the upgrade partition and the ``kpack-base.itb`` file which is used for
+   OS recovery. It has a disk signature of 0x41555820 ("AUX ").
 
 Changing the Output Toolchain Directory (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,36 +168,6 @@ If you would like to build your toolchain in somewhere other than the
 If you would like BuildRoot to just build the toolchain locally, you may remove
 the ``BR2_HOST_DIR`` variable entirely. The toolchain will then be built under the
 main "buildroot-2017.02.8" directory in a new "output/host" folder.
-
-Create auxilliary SD Card Image
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default, the build process will create a bootable SD card image. This will be flashed
-onto the eMMC. In order to create a full Kubos Linux setup, you'll want to also create
-an auxiliary image for the microSD card containing the upgrade partition and an additional
-user data partition.
-
-Follow the :ref:`upgrade-creation` instructions in order to create a base Kubos Package file
-(`kpack-base.itb`) to be used for recovery.
-
-Then, from the `kubos-linux-build/tools` folder, run the ``format-aux.sh`` script. 
-This will create a new SD card image, `aux-sd.img`, with two partitions:
-
-- An upgrade partition containing `kpack-base.itb`
-- A user data partition
-
-The image's disk signature will be 0x41555820 ("AUX ").
-
-There are two parameters which may be specified:
-
--  -s : Sets the size of the aux-sd.img file, specified in MB. The default is 3800 (3.8GB)
--  -i : Specifies the name and location of the kpack-\*.itb file to use as kpack-base.itb
-
-For example:
-
-::
-
-    $ ./format-aux.sh -i ../kpack-2017.07.21.itb
 
 
 Reset the Global Links


### PR DESCRIPTION
The auxiliary SD card image for BBB and MBM2 is now automatically generated as part of the build process (kubos/kubos-linux-build#106). Updating the docs to reflect that.