### PR TITLE
Allowing `"Errs": null` in GraphQL Response

### DIFF
--- a/apis/app-api/rust/src/query.rs
+++ b/apis/app-api/rust/src/query.rs
@@ -89,7 +89,7 @@ pub fn query(
             if errs_str.len() > 0 {
                 return Err(format_err!("{}", errs_str.to_string()));
             }
-        } else {
+        } else if !errs.is_null() {
             match errs.get("message") {
                 Some(message) => {
                     return Err(format_err!("{}", message.as_str().unwrap().to_string()));


### PR DESCRIPTION
Currently, when the Rust `kubos-service` crate processes a good graphql request, it returns `{"errs": "", "msg": {response data}}`, while the Python version returns `{"errs": null, "msg": {response}}`.

This PR updates the Rust `query()` function to allow either format.