### PR TITLE
Removing failure version requirement

### DIFF
--- a/apis/clyde-3g-eps-api/Cargo.toml
+++ b/apis/clyde-3g-eps-api/Cargo.toml
@@ -6,6 +6,6 @@ authors = ["Ryan Plauche <ryan@kubos.co>"]
 [dependencies]
 bitflags = "1.0"
 eps-api = { path = "../eps-api" }
-failure = { git = "https://github.com/rust-lang-nursery/failure", version = "1.0"  }
+failure = { git = "https://github.com/rust-lang-nursery/failure" }
 nom = "4.0"
 rust-i2c = { path = "../../hal/rust-hal/rust-i2c" }

--- a/apis/system-api/Cargo.toml
+++ b/apis/system-api/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Marshall Culpepper <marshall@kubos.com>"]
 
 [dependencies]
-failure = { git = "https://github.com/rust-lang-nursery/failure", version = "1.0"  }
+failure = { git = "https://github.com/rust-lang-nursery/failure" }
 getopts = "0.2"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
The Rust `failure` crate is changing ownership and the in-progress `1.0` version has now been deprecated. This breaks two of our crates. I'm simply removing the version requirement for now.

Note: This is a bandaid fix. There will likely be breaking changes in the `failure` crate in the future, which we'll need to handle.