### PR TITLE
Update S3 asset location

### DIFF
--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -28,11 +28,11 @@ RUN echo "Installing Kubos Linux Toolchain"
 RUN apt-get install -y minicom
 RUN apt-get install -y libc6-i386 lib32stdc++6 lib32z1
 
-RUN wget https://s3.amazonaws.com/provisioning-kubos/iobc_toolchain.tar.gz
+RUN wget https://s3.amazonaws.com/kubos-world-readable-assets/iobc_toolchain.tar.gz
 RUN tar -xf ./iobc_toolchain.tar.gz -C /usr/bin
 RUN rm ./iobc_toolchain.tar.gz
 
-RUN wget https://s3.amazonaws.com/provisioning-kubos/bbb_toolchain.tar.gz
+RUN wget https://s3.amazonaws.com/kubos-world-readable-assets/bbb_toolchain.tar.gz
 RUN tar -xf ./bbb_toolchain.tar.gz -C /usr/bin
 RUN rm ./bbb_toolchain.tar.gz
 


### PR DESCRIPTION
Update the location of the `*_toolchain.tar.gz` packages.

Goes along with https://github.com/kubos/kubos-vagrant/pull/47.