### PR TITLE
File Service Threading Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ name = "aho-corasick"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -66,7 +66,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -273,7 +273,7 @@ dependencies = [
  "cbor-protocol 0.1.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,8 +435,8 @@ dependencies = [
  "isis-ants-api 0.1.0",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -471,8 +471,8 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_codegen 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -508,8 +508,8 @@ dependencies = [
  "kubos-app 0.1.0",
  "kubos-service 0.1.0",
  "kubos-system 0.1.0",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -530,7 +530,7 @@ dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-system 0.1.0",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -540,8 +540,8 @@ version = "0.1.0"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -628,8 +628,8 @@ dependencies = [
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
  "mai400-api 0.1.0",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -645,10 +645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -660,8 +662,8 @@ dependencies = [
  "kubos-service 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -688,7 +690,7 @@ name = "nom"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -762,7 +764,7 @@ name = "ordermap"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -876,7 +878,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -941,7 +943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -950,12 +952,12 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -970,7 +972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1150,7 +1152,7 @@ dependencies = [
  "kubos-service 0.1.0",
  "kubos-telemetry-db 0.1.0",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1224,7 +1226,7 @@ name = "toml"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1237,8 +1239,8 @@ name = "udp-client"
 version = "0.1.0"
 dependencies = [
  "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1396,7 +1398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
+"checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
 "checksum nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "898696750eb5c3ce5eb5afbfbe46e7f7c4e1936e19d3e97be4b7937da7b6d114"
@@ -1424,9 +1426,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum resize-slice 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a3cb2f74a9891e76958b9e0ccd269a25b466c3ae3bb3efd71db157248308c4a"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
-"checksum serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)" = "92ec94e2754699adddbbc4f555791bd3acc2a2f5574cba16c93a4a9cf4a04415"
+"checksum serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "84257ccd054dc351472528c8587b4de2dbf0dc0fe2e634030c1a90bfdacebaa9"
 "checksum serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ad7872ff6e6c2a9221f4c1abe681e7eefc56ca5b3e87196afbfc717d141dc8"
-"checksum serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)" = "0fb622d85245add5327d4f08b2d24fd51fa5d35fe1bba19ee79a1f211e9ac0ff"
+"checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
 "checksum serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c"
 "checksum serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
 "checksum serial-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ name = "backtrace-sys"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -120,7 +120,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -176,7 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "diesel"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -272,6 +272,7 @@ dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbor-protocol 0.1.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -290,7 +291,7 @@ dependencies = [
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -495,7 +496,7 @@ dependencies = [
  "kubos-service 0.1.0",
  "kubos-system 0.1.0",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -510,7 +511,7 @@ dependencies = [
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -541,7 +542,7 @@ dependencies = [
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -549,7 +550,7 @@ dependencies = [
 name = "kubos-telemetry-db"
 version = "0.1.0"
 dependencies = [
- "diesel 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -731,7 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -739,7 +740,7 @@ name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -748,12 +749,12 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -959,7 +960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1108,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1144,7 +1145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "telemetry-service"
 version = "0.1.0"
 dependencies = [
- "diesel 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
  "kubos-telemetry-db 0.1.0",
@@ -1154,9 +1155,10 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1359,14 +1361,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
-"checksum cc 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "70f2a88c2e69ceee91c209d8ef25b81fc1a65f42c7f14dfd59d1fed189e514d1"
+"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crc16 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "11a65c4797332f3e3a5945e0377875afc79b1bdc87082a4f98ac1ef15b47e2dd"
-"checksum diesel 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e71e7a348ae6064e86c4cf0709f0e4c3ef6f30e8e7d3dc05737164af4ebd3511"
+"checksum diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "164080ac16a4d1d80a50f0a623e4ddef41cb2779eee85bcc76907d340dfc98cc"
 "checksum diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03bcaf77491f53e400d5ee3bdd57142ea4e1c47fe9217b3361ff9a76ca0e3d37"
 "checksum double 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "21d9ba47ea688a92ebe3bb1c19424b51a33fc1b72e719d6d90b7f93d9decfbf9"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
@@ -1401,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
-"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
@@ -1441,11 +1443,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum syn 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e5c1514eb7bb4216fc722b3cd08783d326d7de0d62f6d5e48a774f610bc97cb6"
+"checksum syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9056ebe7f2d6a38bc63171816fd1d3430da5a43896de21676dc5c0a4b8274a11"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-"checksum tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b103c6d08d323b92ff42c8ce62abcd83ca8efa7fd5bf7927efefec75f58c76"
+"checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "kubos-system 0.1.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/clients/file-client/src/main.rs
+++ b/clients/file-client/src/main.rs
@@ -5,10 +5,10 @@ extern crate log;
 extern crate simplelog;
 
 use clap::{App, Arg};
+use file_protocol::{FileProtocol, State};
 use simplelog::*;
 use std::path::Path;
 use std::time::Duration;
-use file_protocol::{FileProtocol, State};
 
 fn upload(
     host_ip: &str,

--- a/clients/file-client/src/main.rs
+++ b/clients/file-client/src/main.rs
@@ -61,7 +61,7 @@ fn download(
 
     // Send our file request to the remote addr and verify that it's
     // going to be able to send it
-    f_protocol.send_import(channel as u32, source_path)?;
+    f_protocol.send_import(channel, source_path)?;
 
     // Wait for the request reply.
     // Note/TODO: We don't use a timeout here because we don't know how long it will

--- a/clients/file-client/src/main.rs
+++ b/clients/file-client/src/main.rs
@@ -5,10 +5,10 @@ extern crate log;
 extern crate simplelog;
 
 use clap::{App, Arg};
+use file_protocol::{FileProtocol, State};
 use simplelog::*;
 use std::path::Path;
 use std::time::Duration;
-use file_protocol::{FileProtocol, State};
 
 fn upload(
     host_ip: &str,
@@ -38,7 +38,11 @@ fn upload(
     f_protocol.send_export(&hash, &target_path, mode)?;
 
     // Start the engine to send the file data chunks
-    Ok(f_protocol.message_engine(Duration::from_secs(2), State::Transmitting)?)
+    Ok(f_protocol.message_engine(
+        |d| f_protocol.recv(Some(d)),
+        Duration::from_secs(2),
+        State::Transmitting,
+    )?)
 }
 
 fn download(
@@ -77,7 +81,7 @@ fn download(
         },
     )?;
 
-    Ok(f_protocol.message_engine(Duration::from_secs(2), state)?)
+    Ok(f_protocol.message_engine(|d| f_protocol.recv(Some(d)), Duration::from_secs(2), state)?)
 }
 
 fn main() {

--- a/clients/file-client/src/main.rs
+++ b/clients/file-client/src/main.rs
@@ -5,10 +5,10 @@ extern crate log;
 extern crate simplelog;
 
 use clap::{App, Arg};
-use file_protocol::{FileProtocol, State};
 use simplelog::*;
 use std::path::Path;
 use std::time::Duration;
+use file_protocol::{FileProtocol, State};
 
 fn upload(
     host_ip: &str,
@@ -27,6 +27,7 @@ fn upload(
     // Copy file to upload to temp storage. Calculate the hash and chunk info
     let (hash, num_chunks, mode) = f_protocol.initialize_file(&source_path)?;
 
+    // Generate channel id for transaction
     let channel = f_protocol.generate_channel()?;
 
     // Tell our destination the hash and number of chunks to expect
@@ -57,6 +58,7 @@ fn download(
         source_path, target_path
     );
 
+    // Generate channel id for transaction
     let channel = f_protocol.generate_channel()?;
 
     // Send our file request to the remote addr and verify that it's

--- a/clients/file-client/src/main.rs
+++ b/clients/file-client/src/main.rs
@@ -72,8 +72,7 @@ fn download(
     let reply = match f_protocol.recv(None) {
         Ok(Some(message)) => message,
         Ok(None) => return Err("Failed to import file".to_owned()),
-        Err(Some(error)) => return Err(format!("Failed to import file: {}", error)),
-        Err(None) => return Err("Failed to import file".to_owned()),
+        Err(error) => return Err(format!("Failed to import file: {}", error)),
     };
 
     let state = f_protocol.process_message(

--- a/docs/services/file-protocol.rst
+++ b/docs/services/file-protocol.rst
@@ -66,9 +66,8 @@ Messages
 All messages in the file protocol are encoded as `CBOR <http://cbor.io/>`__ arrays and are sent
 in UDP packets.
 
-The first value in the encoded list is the ``channel_id``
-for request/response type messages and it is followed by
-the ``hash`` for content-addressable messages.
+The first value in the encoded list is the ``channel_id`` for all messages
+and it is followed by the ``hash`` for content-addressable messages.
 
     - The ``channel_id`` parameter is used to indicate a group of messages associated with
       a particular file protocol transaction.

--- a/docs/services/file-protocol.rst
+++ b/docs/services/file-protocol.rst
@@ -67,33 +67,33 @@ All messages in the file protocol are encoded as `CBOR <http://cbor.io/>`__ arra
 in UDP packets.
 
 The first value in the encoded list is the ``channel_id``
-for request/response type messages or the ``hash`` for content-addressable
-messages.
+for request/response type messages and it is followed by
+the ``hash`` for content-addressable messages.
 
     - The ``channel_id`` parameter is used to indicate a group of messages associated with
       a particular file protocol transaction.
     - The ``hash`` parameter is the BLAKE2 hash for the corresponding file
       which is being transferred.
 
-+-------------------------------+----------------------------------------------------------------+
-| Name                          | Syntax                                                         |
-+===============================+================================================================+
-| `Metadata`_                   | { `hash`, `num_chunks` }                                       |
-+-------------------------------+----------------------------------------------------------------+
-| `Export Request`_             | { `channel_id`, export, `hash`, `path`, `mode` }               |
-+-------------------------------+----------------------------------------------------------------+
-| `Import Request`_             | { `channel_id`, import, `path` }                               |
-+-------------------------------+----------------------------------------------------------------+
-| `File Chunk`_                 | { `hash`, `chunk_index`, `data` }                              |
-+-------------------------------+----------------------------------------------------------------+
-| `Acknowledge (ACK)`_          | { `hash`, true, `num_chunks` }                                 |
-+-------------------------------+----------------------------------------------------------------+
-| `Negative Acknowledge (NAK)`_ | { `hash`, false, `x_start`, `x_end`, `y_start`, `y_end`, ... } |
-+-------------------------------+----------------------------------------------------------------+
-| `Request Success`_            | { `channel_id`, true, ..`values` }                             |
-+-------------------------------+----------------------------------------------------------------+
-| `Request Failure`_            | { `channel_id`, false, `error_message` }                       |
-+-------------------------------+----------------------------------------------------------------+
++-------------------------------+------------------------------------------------------------------------------+
+| Name                          | Syntax                                                                       |
++===============================+==============================================================================+
+| `Metadata`_                   | { `channel_id`, `hash`, `num_chunks` }                                       |
++-------------------------------+------------------------------------------------------------------------------+
+| `Export Request`_             | { `channel_id`, export, `hash`, `path`, `mode` }                             |
++-------------------------------+------------------------------------------------------------------------------+
+| `Import Request`_             | { `channel_id`, import, `path` }                                             |
++-------------------------------+------------------------------------------------------------------------------+
+| `File Chunk`_                 | { `channel_id`, `hash`, `chunk_index`, `data` }                              |
++-------------------------------+------------------------------------------------------------------------------+
+| `Acknowledge (ACK)`_          | { `channel_id`, `hash`, true, `num_chunks` }                                 |
++-------------------------------+------------------------------------------------------------------------------+
+| `Negative Acknowledge (NAK)`_ | { `channel_id`, `hash`, false, `x_start`, `x_end`, `y_start`, `y_end`, ... } |
++-------------------------------+------------------------------------------------------------------------------+
+| `Request Success`_            | { `channel_id`, true, ..`values` }                                           |
++-------------------------------+------------------------------------------------------------------------------+
+| `Request Failure`_            | { `channel_id`, false, `error_message` }                                     |
++-------------------------------+------------------------------------------------------------------------------+
 
 Metadata
 ~~~~~~~~
@@ -108,7 +108,7 @@ the accompanying ``meta`` file.
 This message should be sent prior to an ``export`` request
 to ensure the expected number of chunks is known.
 
-    ``{ hash, num_chunks }``
+    ``{ channel_id, hash, num_chunks }``
 
 Export Request
 ~~~~~~~~~~~~~~
@@ -156,7 +156,7 @@ an immediate reply. However, if no chunks are received within the
 timeout window then an ``ACK`` or ``NAK`` will be sent depending
 on whether all the chunks have been received or not.
 
-    ``{ hash, chunk_index, data }``
+    ``{ channel_id, hash, chunk_index, data }``
     
 .. note::
 
@@ -171,7 +171,7 @@ message sender has all chunks for a given file. It contains the
 file's hash, the boolean value true, and the number of
 chunks in the file.
 
-    ``{ hash, true, num_chunks }``
+    ``{ channel_id, hash, true, num_chunks }``
 
 Negative Acknowledge (NAK)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -189,7 +189,7 @@ or after a timeout during a file ``import`` or ``export`` operation.
 The message sender should expect the message receiver to send
 the missing file chunks upon receipt of a ``NAK``.
 
-    ``{ hash, false, 1, 4, 6, 7 }``
+    ``{ channel_id, hash, false, 1, 4, 6, 7 }``
 
 The above example ``NAK`` indicates that chunks 1-3 and 6
 are missing.

--- a/libs/cbor-protocol/src/lib.rs
+++ b/libs/cbor-protocol/src/lib.rs
@@ -226,7 +226,8 @@ impl Protocol {
     ///
     pub fn recv_message(&self) -> Result<Option<serde_cbor::Value>, Option<String>> {
         let mut buf = [0; MSG_SIZE];
-        let (size, _peer) = self.handle
+        let (size, _peer) = self
+            .handle
             .recv_from(&mut buf)
             .map_err(|err| Some(format!("Failed to receive a message: {}", err)))?;
 
@@ -252,7 +253,8 @@ impl Protocol {
     pub fn peek_peer(&self) -> Result<SocketAddr, String> {
         let mut buf = [0; MSG_SIZE];
 
-        let (_size, peer) = self.handle
+        let (_size, peer) = self
+            .handle
             .peek_from(&mut buf)
             .map_err(|err| format!("Failed to receive a message: {}", err))?;
 
@@ -277,7 +279,8 @@ impl Protocol {
     ///
     pub fn recv_message_peer(&self) -> Result<(SocketAddr, Option<serde_cbor::Value>), String> {
         let mut buf = [0; MSG_SIZE];
-        let (size, peer) = self.handle
+        let (size, peer) = self
+            .handle
             .recv_from(&mut buf)
             .map_err(|err| format!("Failed to receive a message: {}", err))?;
 

--- a/libs/cbor-protocol/src/lib.rs
+++ b/libs/cbor-protocol/src/lib.rs
@@ -49,34 +49,12 @@
 extern crate serde_cbor;
 
 use serde_cbor::de;
-use serde_cbor::Value;
 use std::net::{SocketAddr, UdpSocket};
 use std::time::Duration;
 
 // Was 4136
 // Somewhere we are sending packets bigger than this...
 const MSG_SIZE: usize = 4500;
-
-/// Parse and return the channel_id for a message
-pub fn peek_channel_id(message: &Option<serde_cbor::Value>) -> Result<Option<u32>, String> {
-    let data = match message {
-        Some(Value::Array(val)) => val.to_owned(),
-        _ => return Err("Unable to parse message: Data not an array".to_owned()),
-    };
-
-    let mut pieces = data.iter();
-
-    let first_param: Value = pieces
-        .next()
-        .ok_or(format!("Unable to parse message: No contents"))?
-        .to_owned();
-
-    if let Value::U64(channel_id) = first_param {
-        Ok(Some(channel_id as u32))
-    } else {
-        Ok(None)
-    }
-}
 
 /// CBOR protocol communication structure
 pub struct Protocol {
@@ -248,8 +226,7 @@ impl Protocol {
     ///
     pub fn recv_message(&self) -> Result<Option<serde_cbor::Value>, Option<String>> {
         let mut buf = [0; MSG_SIZE];
-        let (size, _peer) = self
-            .handle
+        let (size, _peer) = self.handle
             .recv_from(&mut buf)
             .map_err(|err| Some(format!("Failed to receive a message: {}", err)))?;
 
@@ -275,8 +252,7 @@ impl Protocol {
     pub fn peek_peer(&self) -> Result<SocketAddr, String> {
         let mut buf = [0; MSG_SIZE];
 
-        let (_size, peer) = self
-            .handle
+        let (_size, peer) = self.handle
             .peek_from(&mut buf)
             .map_err(|err| format!("Failed to receive a message: {}", err))?;
 
@@ -301,8 +277,7 @@ impl Protocol {
     ///
     pub fn recv_message_peer(&self) -> Result<(SocketAddr, Option<serde_cbor::Value>), String> {
         let mut buf = [0; MSG_SIZE];
-        let (size, peer) = self
-            .handle
+        let (size, peer) = self.handle
             .recv_from(&mut buf)
             .map_err(|err| format!("Failed to receive a message: {}", err))?;
 

--- a/libs/cbor-protocol/src/lib.rs
+++ b/libs/cbor-protocol/src/lib.rs
@@ -58,7 +58,7 @@ use std::time::Duration;
 const MSG_SIZE: usize = 4500;
 
 /// Parse and return the channel_id for a message
-pub fn peek_channel_id(message: &Option<serde_cbor::Value>) -> Result<Option<u64>, String> {
+pub fn peek_channel_id(message: &Option<serde_cbor::Value>) -> Result<Option<u32>, String> {
     let data = match message {
         Some(Value::Array(val)) => val.to_owned(),
         _ => return Err("Unable to parse message: Data not an array".to_owned()),
@@ -72,7 +72,7 @@ pub fn peek_channel_id(message: &Option<serde_cbor::Value>) -> Result<Option<u64
         .to_owned();
 
     if let Value::U64(channel_id) = first_param {
-        Ok(Some(channel_id))
+        Ok(Some(channel_id as u32))
     } else {
         Ok(None)
     }

--- a/libs/cbor-protocol/src/lib.rs
+++ b/libs/cbor-protocol/src/lib.rs
@@ -399,9 +399,8 @@ impl Protocol {
         let (size, _peer) = match result {
             Ok(data) => data,
             Err(err) => match err.kind() {
-                ::std::io::ErrorKind::WouldBlock => {
-                    return Err(format!("Failed to receive a message: WouldBlock"))
-                } // For some reason, UDP recv returns WouldBlock for timeouts
+                // For some reason, UDP recv returns WouldBlock for timeouts
+                ::std::io::ErrorKind::WouldBlock => return Ok(None),
                 _ => return Err(format!("Failed to receive a message: {:?}", err)),
             },
         };

--- a/libs/cbor-protocol/src/lib.rs
+++ b/libs/cbor-protocol/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! # Examples
 //!
-//! ```
+//! ```no_run
 //! extern crate cbor_protocol;
 //! extern crate serde_cbor;
 //!
@@ -35,9 +35,9 @@
 //!     Ok((source, message)) => {
 //!         if let Some(msg) = message {
 //!             println!("Received message from {:?}: {:?}", source, msg);
-//!            }
-//!        }
-//!        Err(None) => println!("Timed out waiting for reply"),
+//!         }
+//!     }
+//!     Err(None) => println!("Timed out waiting for reply"),
 //!     Err(Some(err)) => eprintln!("Failed to receive message: {}", err)
 //! }
 //! ```
@@ -94,7 +94,7 @@ impl Protocol {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// extern crate cbor_protocol;
     ///
     /// use cbor_protocol::*;
@@ -122,7 +122,7 @@ impl Protocol {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// extern crate cbor_protocol;
     /// extern crate serde_cbor;
     ///
@@ -160,7 +160,7 @@ impl Protocol {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use cbor_protocol::*;
     ///
     /// let cbor_connection = Protocol::new("0.0.0.0:8000".to_owned());
@@ -190,7 +190,7 @@ impl Protocol {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use cbor_protocol::*;
     ///
     /// let cbor_connection = Protocol::new("0.0.0.0:8000".to_owned());
@@ -361,7 +361,7 @@ impl Protocol {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// extern crate cbor_protocol;
     ///
     /// use cbor_protocol::*;
@@ -370,12 +370,12 @@ impl Protocol {
     /// let cbor_connection = Protocol::new("0.0.0.0:9000".to_owned());
     ///
     /// let message = match cbor_connection.recv_message_timeout(Duration::from_secs(1)) {
-    ///     Ok(data) => data,
-    ///     Err(None) => {
-    ///            println!("Timeout waiting for message");
-    ///            return;
-    ///        }
-    ///     Err(Some(err)) => panic!("Failed to receive message: {}", err),
+    ///     Ok(Some(data)) => data,
+    ///     Ok(None) => {
+    ///        println!("Timeout waiting for message");
+    ///        return;
+    ///     }
+    ///     Err(err) => panic!("Failed to receive message: {}", err),
     /// };
     /// ```
     ///

--- a/libs/file-protocol/Cargo.toml
+++ b/libs/file-protocol/Cargo.toml
@@ -10,4 +10,5 @@ log = "^0.4.0"
 time = "0.1"
 blake2-rfc = "0.2.18"
 serde = "1.0.58"
+rand = "0.5"
 cbor-protocol = { path = "../cbor-protocol" }

--- a/libs/file-protocol/src/lib.rs
+++ b/libs/file-protocol/src/lib.rs
@@ -91,6 +91,7 @@ extern crate blake2_rfc;
 extern crate cbor_protocol;
 #[macro_use]
 extern crate log;
+extern crate rand;
 extern crate serde;
 extern crate serde_cbor;
 extern crate time;

--- a/libs/file-protocol/src/lib.rs
+++ b/libs/file-protocol/src/lib.rs
@@ -106,18 +106,18 @@ pub use protocol::State;
 const CHUNK_SIZE: usize = 4096;
 
 /// File protocol message types
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Message {
     /// TODO: Decide whether or not to keep this
-    Sync(String),
+    Sync(u64, String),
     /// Receiver should prepare a new temporary storage folder with the specified metadata
-    Metadata(String, u32),
+    Metadata(u64, String, u32),
     /// File data chunk message
-    ReceiveChunk(String, u32, Vec<u8>),
+    ReceiveChunk(u64, String, u32, Vec<u8>),
     /// Receiver has successfully gotten all data chunks of the requested file
-    ACK(String),
+    ACK(u64, String),
     /// Receiver is missing the specified file data chunks
-    NAK(String, Option<Vec<(u32, u32)>>),
+    NAK(u64, String, Option<Vec<(u32, u32)>>),
     /// (Client Only) Message requesting the recipient to receive the specified file
     ReqReceive(u64, String, String, Option<u32>),
     /// (Client Only) Message requesting the recipient to transmit the specified file
@@ -128,4 +128,99 @@ pub enum Message {
     SuccessTransmit(u64, String, u32, Option<u32>),
     /// (Server Only) The transmit or receive request has failed to be completed
     Failure(u64, String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{messages, parsers, Message};
+    use serde_cbor::{self, de, ser, Value};
+
+    #[test]
+    fn create_parse_export_request() {
+        let channel_id: u64 = 10;
+        let hash = "abcdedf".to_owned();
+        let target_path = "/path/to/file".to_owned();
+        let mode = 0o623;
+
+        let raw = messages::export_request(channel_id, &hash, &target_path, mode).unwrap();
+
+        let msg = parsers::parse_message(de::from_slice(&raw).unwrap());
+
+        assert_eq!(
+            msg,
+            Ok(Message::ReqReceive(
+                channel_id,
+                hash,
+                target_path,
+                Some(mode)
+            ))
+        );
+    }
+
+    #[test]
+    fn create_parse_sync() {
+        let channel_id = 10;
+        let hash = "abcdefg".to_owned();
+        let num_chunks = 100;
+
+        let raw = messages::sync(channel_id, &hash).unwrap();
+        let msg = parsers::parse_message(de::from_slice(&raw).unwrap());
+
+        assert_eq!(msg, Ok(Message::Sync(channel_id, hash)));
+    }
+
+    #[test]
+    fn create_parse_metadata() {
+        let channel_id = 10;
+        let hash = "abcdefg".to_owned();
+        let num_chunks = 100;
+
+        let raw = messages::metadata(channel_id, &hash, num_chunks).unwrap();
+        let msg = parsers::parse_message(de::from_slice(&raw).unwrap());
+
+        assert_eq!(msg, Ok(Message::Metadata(channel_id, hash, num_chunks)));
+    }
+
+    #[test]
+    fn create_parse_chunk() {
+        let channel_id = 10;
+        let hash = "abcdefg".to_owned();
+        let chunk_num = 10;
+        let chunk_data: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
+
+        let raw = messages::chunk(channel_id, &hash, chunk_num, &chunk_data).unwrap();
+        let msg = parsers::parse_message(de::from_slice(&raw).unwrap());
+
+        assert_eq!(
+            msg,
+            Ok(Message::ReceiveChunk(
+                channel_id, hash, chunk_num, chunk_data
+            ))
+        );
+    }
+
+    #[test]
+    fn create_parse_ack() {
+        let channel_id = 14;
+        let hash = "abcdefg".to_owned();
+        let num_chunks = 10;
+
+        let raw = messages::ack(channel_id, &hash, Some(num_chunks)).unwrap();
+        let msg = parsers::parse_message(de::from_slice(&raw).unwrap());
+
+        assert_eq!(msg, Ok(Message::ACK(channel_id, hash)));
+    }
+
+    #[test]
+    fn create_parse_nak() {
+        let channel_id = 11;
+        let hash = "abcdefg".to_owned();
+        let missing_chunks = vec![0, 1, 4, 10];
+        let chunk_ranges: Vec<(u32, u32)> = vec![(0, 1), (4, 10)];
+
+        let raw = messages::nak(channel_id, &hash, &missing_chunks).unwrap();
+        let msg = parsers::parse_message(de::from_slice(&raw).unwrap());
+
+        assert_eq!(msg, Ok(Message::NAK(channel_id, hash, Some(chunk_ranges))));
+    }
 }

--- a/libs/file-protocol/src/lib.rs
+++ b/libs/file-protocol/src/lib.rs
@@ -137,7 +137,7 @@ pub enum Message {
 #[cfg(test)]
 mod tests {
     use super::{messages, parsers, Message};
-    use serde_cbor::{self, de, ser, Value};
+    use serde_cbor::de;
 
     #[test]
     fn create_parse_export_request() {
@@ -165,7 +165,6 @@ mod tests {
     fn create_parse_sync() {
         let channel_id = 10;
         let hash = "abcdefg".to_owned();
-        let num_chunks = 100;
 
         let raw = messages::sync(channel_id, &hash).unwrap();
         let msg = parsers::parse_message(de::from_slice(&raw).unwrap());

--- a/libs/file-protocol/src/lib.rs
+++ b/libs/file-protocol/src/lib.rs
@@ -110,25 +110,25 @@ const CHUNK_SIZE: usize = 4096;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Message {
     /// TODO: Decide whether or not to keep this
-    Sync(u64, String),
+    Sync(u32, String),
     /// Receiver should prepare a new temporary storage folder with the specified metadata
-    Metadata(u64, String, u32),
+    Metadata(u32, String, u32),
     /// File data chunk message
-    ReceiveChunk(u64, String, u32, Vec<u8>),
+    ReceiveChunk(u32, String, u32, Vec<u8>),
     /// Receiver has successfully gotten all data chunks of the requested file
-    ACK(u64, String),
+    ACK(u32, String),
     /// Receiver is missing the specified file data chunks
-    NAK(u64, String, Option<Vec<(u32, u32)>>),
+    NAK(u32, String, Option<Vec<(u32, u32)>>),
     /// (Client Only) Message requesting the recipient to receive the specified file
-    ReqReceive(u64, String, String, Option<u32>),
+    ReqReceive(u32, String, String, Option<u32>),
     /// (Client Only) Message requesting the recipient to transmit the specified file
-    ReqTransmit(u64, String),
+    ReqTransmit(u32, String),
     /// (Server Only) Recipient has successfully processed a request to receive a file
-    SuccessReceive(u64),
+    SuccessReceive(u32),
     /// (Server Only) Recipient has successfully prepared to transmit a file
-    SuccessTransmit(u64, String, u32, Option<u32>),
+    SuccessTransmit(u32, String, u32, Option<u32>),
     /// (Server Only) The transmit or receive request has failed to be completed
-    Failure(u64, String),
+    Failure(u32, String),
 }
 
 #[cfg(test)]
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn create_parse_export_request() {
-        let channel_id: u64 = 10;
+        let channel_id = 10;
         let hash = "abcdedf".to_owned();
         let target_path = "/path/to/file".to_owned();
         let mode = 0o623;

--- a/libs/file-protocol/src/lib.rs
+++ b/libs/file-protocol/src/lib.rs
@@ -70,8 +70,7 @@
 //!     let reply = match f_protocol.recv(None) {
 //!         Ok(Some(message)) => message,
 //!         Ok(None) => return Err("Failed to import file".to_owned()),
-//!         Err(Some(error)) => return Err(format!("Failed to import file: {}", error)),
-//!         Err(None) => return Err("Failed to import file".to_owned()),
+//!         Err(error) => return Err(format!("Failed to import file: {}", error)),
 //!     };
 //!
 //!     let state = f_protocol.process_message(

--- a/libs/file-protocol/src/messages.rs
+++ b/libs/file-protocol/src/messages.rs
@@ -18,7 +18,7 @@ use serde_cbor::{ser, Value};
 
 // Create export message
 pub fn export_request(
-    channel_id: u64,
+    channel_id: u32,
     hash: &str,
     target_path: &str,
     mode: u32,
@@ -40,21 +40,21 @@ pub fn import_request(channel_id: u32, source_path: &str) -> Result<Vec<u8>, Str
 }
 
 // Create sync message
-pub fn metadata(channel_id: u64, hash: &str, num_chunks: u32) -> Result<Vec<u8>, String> {
+pub fn metadata(channel_id: u32, hash: &str, num_chunks: u32) -> Result<Vec<u8>, String> {
     info!("-> {{ {}, {}, {} }}", channel_id, hash, num_chunks);
     ser::to_vec_packed(&(channel_id, hash, num_chunks))
         .map_err(|err| format!("Failed to create metadata message: {}", err))
 }
 
 // Send an acknowledge to the remote address
-pub fn ack(channel_id: u64, hash: &str, num_chunks: Option<u32>) -> Result<Vec<u8>, String> {
+pub fn ack(channel_id: u32, hash: &str, num_chunks: Option<u32>) -> Result<Vec<u8>, String> {
     info!("-> {{ {}, {}, true, {:?} }}", channel_id, hash, num_chunks);
     ser::to_vec_packed(&(channel_id, hash, true, num_chunks))
         .map_err(|err| format!("Failed to create ACK message: {}", err))
 }
 
 // Sends a nak with ranges of missing chunks
-pub fn nak(channel_id: u64, hash: &str, missing_chunks: &[u32]) -> Result<Vec<u8>, String> {
+pub fn nak(channel_id: u32, hash: &str, missing_chunks: &[u32]) -> Result<Vec<u8>, String> {
     let chunks = if missing_chunks.len() > 20 {
         &missing_chunks[0..20]
     } else {
@@ -82,7 +82,7 @@ pub fn nak(channel_id: u64, hash: &str, missing_chunks: &[u32]) -> Result<Vec<u8
 }
 
 // Create chunk message
-pub fn chunk(channel_id: u64, hash: &str, index: u32, chunk: &[u8]) -> Result<Vec<u8>, String> {
+pub fn chunk(channel_id: u32, hash: &str, index: u32, chunk: &[u8]) -> Result<Vec<u8>, String> {
     let chunk_bytes = Value::Bytes(chunk.to_vec());
     info!("-> {{ {}, {}, {}, chunk_data }}", channel_id, hash, index);
     ser::to_vec_packed(&(channel_id, hash, index, chunk_bytes))
@@ -91,7 +91,7 @@ pub fn chunk(channel_id: u64, hash: &str, index: u32, chunk: &[u8]) -> Result<Ve
 
 // Create succesful import request response message
 pub fn import_setup_success(
-    channel_id: u64,
+    channel_id: u32,
     hash: &str,
     num_chunks: u32,
     mode: u32,
@@ -106,21 +106,21 @@ pub fn import_setup_success(
 }
 
 // Create successful export request response message
-pub fn operation_success(channel_id: u64) -> Result<Vec<u8>, String> {
+pub fn operation_success(channel_id: u32) -> Result<Vec<u8>, String> {
     info!("-> {{ {}, true }}", channel_id);
     ser::to_vec_packed(&(channel_id, true))
         .map_err(|err| format!("Failed to create operation success message: {}", err))
 }
 
 // Create an operation failure response message
-pub fn operation_failure(channel_id: u64, error: &str) -> Result<Vec<u8>, String> {
+pub fn operation_failure(channel_id: u32, error: &str) -> Result<Vec<u8>, String> {
     info!("-> {{ {}, false, {} }}", channel_id, error);
     ser::to_vec_packed(&(channel_id, false, error))
         .map_err(|err| format!("Failed to create operation failure message: {}", err))
 }
 
 // Create sync message
-pub fn sync(channel_id: u64, hash: &str) -> Result<Vec<u8>, String> {
+pub fn sync(channel_id: u32, hash: &str) -> Result<Vec<u8>, String> {
     info!("-> {{ {}, {} }}", channel_id, hash);
     ser::to_vec_packed(&(channel_id, hash))
         .map_err(|err| format!("Failed to create sync message: {}", err))

--- a/libs/file-protocol/src/parsers.rs
+++ b/libs/file-protocol/src/parsers.rs
@@ -19,7 +19,7 @@ use serde_cbor::Value;
 use std::slice::Iter;
 
 /// Parse out just the channel ID from a message
-pub fn parse_channel_id(message: &Option<Value>) -> Result<Option<u32>, String> {
+pub fn parse_channel_id(message: &Option<Value>) -> Result<u32, String> {
     let data = match message {
         Some(Value::Array(val)) => val.to_owned(),
         _ => return Err("Unable to parse message: Data not an array".to_owned()),
@@ -33,9 +33,9 @@ pub fn parse_channel_id(message: &Option<Value>) -> Result<Option<u32>, String> 
         .to_owned();
 
     if let Value::U64(channel_id) = first_param {
-        Ok(Some(channel_id as u32))
+        Ok(channel_id as u32)
     } else {
-        Ok(None)
+        Err("No channel ID found".to_owned())
     }
 }
 

--- a/libs/file-protocol/src/parsers.rs
+++ b/libs/file-protocol/src/parsers.rs
@@ -18,6 +18,27 @@ use super::Message;
 use serde_cbor::Value;
 use std::slice::Iter;
 
+/// Parse out just the channel ID from a message
+pub fn parse_channel_id(message: &Option<Value>) -> Result<Option<u32>, String> {
+    let data = match message {
+        Some(Value::Array(val)) => val.to_owned(),
+        _ => return Err("Unable to parse message: Data not an array".to_owned()),
+    };
+
+    let mut pieces = data.iter();
+
+    let first_param: Value = pieces
+        .next()
+        .ok_or(format!("Unable to parse message: No contents"))?
+        .to_owned();
+
+    if let Value::U64(channel_id) = first_param {
+        Ok(Some(channel_id as u32))
+    } else {
+        Ok(None)
+    }
+}
+
 pub fn parse_message(message: Value) -> Result<Message, String> {
     let raw = match message {
         Value::Array(val) => val.to_owned(),

--- a/libs/file-protocol/src/parsers.rs
+++ b/libs/file-protocol/src/parsers.rs
@@ -18,7 +18,6 @@ use super::Message;
 use serde_cbor::Value;
 
 pub fn parse_message(message: Value) -> Result<Message, String> {
-    info!("parsing {:?}", message);
     let data = match message {
         Value::Array(val) => val.to_owned(),
         _ => return Err("Unable to parse message: Data not an array".to_owned()),

--- a/libs/file-protocol/src/parsers.rs
+++ b/libs/file-protocol/src/parsers.rs
@@ -313,8 +313,6 @@ pub fn parse_sync(channel_id: u32, mut pieces: Iter<Value>) -> Result<Option<Mes
             if let Value::U64(num) = second_param {
                 if let None = pieces.next() {
                     // It's a sync message: { hash, num_chunks }
-                    // TODO: Whoever processes this message should do the sync_and_send
-                    //self.sync_and_send(&hash, Some(*num as u32));
                     return Ok(Some(Message::Metadata(
                         channel_id,
                         hash.to_owned(),
@@ -324,8 +322,6 @@ pub fn parse_sync(channel_id: u32, mut pieces: Iter<Value>) -> Result<Option<Mes
             }
         } else {
             // It's a sync message: { hash }
-            // TODO: Whoever processes this message should do the sync_and_send
-            //self.sync_and_send(&hash, None)?;
             return Ok(Some(Message::Sync(channel_id, hash.to_owned())));
         }
     }

--- a/libs/file-protocol/src/parsers.rs
+++ b/libs/file-protocol/src/parsers.rs
@@ -18,6 +18,7 @@ use super::Message;
 use serde_cbor::Value;
 
 pub fn parse_message(message: Value) -> Result<Message, String> {
+    info!("parsing {:?}", message);
     let data = match message {
         Value::Array(val) => val.to_owned(),
         _ => return Err("Unable to parse message: Data not an array".to_owned()),
@@ -184,7 +185,9 @@ pub fn parse_success_transmit(data: Vec<Value>) -> Result<Option<Message>, Strin
                 ))? {
                     Value::U64(val) => *val,
                     _ => {
-                        return Err("Unable to parse success message: Invalid num_chunks param".to_owned())
+                        return Err(
+                            "Unable to parse success message: Invalid num_chunks param".to_owned()
+                        )
                     }
                 };
 

--- a/libs/file-protocol/src/protocol.rs
+++ b/libs/file-protocol/src/protocol.rs
@@ -426,6 +426,7 @@ impl Protocol {
         let mut state = start_state.clone();
         loop {
             // Listen on UDP port
+            info!("engine pump {:?}", state);
             let message = match pump(timeout) {
                 //let message = match self.cbor_proto.recv_message_peer_timeout(timeout) {
                 Ok(Some(message)) => {

--- a/libs/file-protocol/src/protocol.rs
+++ b/libs/file-protocol/src/protocol.rs
@@ -194,7 +194,7 @@ impl Protocol {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// extern crate file_protocol;
     ///
     /// use file_protocol::*;
@@ -204,15 +204,11 @@ impl Protocol {
     ///
     /// let message = match f_protocol.recv(Some(Duration::from_secs(1))) {
     /// 	Ok(data) => data,
-    /// 	Err(None) => {
-    ///			println!("Timeout waiting for message");
-    ///			return;
-    ///		}
-    /// 	Err(Some(err)) => panic!("Failed to receive message: {}", err),
+    /// 	Err(err) => panic!("Failed to receive message: {}", err),
     /// };
     /// ```
     ///
-    pub fn recv(&self, timeout: Option<Duration>) -> Result<Option<Value>, Option<String>> {
+    pub fn recv(&self, timeout: Option<Duration>) -> Result<Option<Value>, String> {
         match timeout {
             Some(value) => self.cbor_proto.recv_message_timeout(value),
             None => self.cbor_proto.recv_message(),
@@ -455,7 +451,7 @@ impl Protocol {
         start_state: State,
     ) -> Result<(), String>
     where
-        F: Fn(Duration) -> Result<Option<Value>, Option<String>>,
+        F: Fn(Duration) -> Result<Option<Value>, String>,
     {
         let mut state = start_state.clone();
         loop {

--- a/libs/file-protocol/src/protocol.rs
+++ b/libs/file-protocol/src/protocol.rs
@@ -39,7 +39,6 @@ pub struct Protocol {
     prefix: String,
     cbor_proto: CborProtocol,
     remote_addr: Cell<SocketAddr>,
-    channel_id: Option<u64>,
 }
 
 /// Current state of the file protocol transaction
@@ -60,7 +59,7 @@ pub enum State {
     /// Currently receiving a file
     Receiving {
         /// Transaction identifier
-        channel_id: u64,
+        channel_id: u32,
         /// File hash
         hash: String,
         /// Destination file path
@@ -71,7 +70,7 @@ pub enum State {
     /// All file chunks have been received
     ReceivingDone {
         /// Transaction identifier
-        channel_id: u64,
+        channel_id: u32,
         /// File hash
         hash: String,
         /// Destination file path
@@ -117,7 +116,6 @@ impl Protocol {
             prefix: prefix.unwrap_or("file-transfer".to_owned()),
             cbor_proto: c_protocol,
             remote_addr: Cell::new(remote_addr.parse::<SocketAddr>().unwrap()),
-            channel_id: None,
         }
     }
 
@@ -149,7 +147,6 @@ impl Protocol {
             prefix: prefix.unwrap_or("file-transfer".to_owned()),
             cbor_proto: CborProtocol::new_from_socket(socket),
             remote_addr: Cell::new(remote_addr.parse::<SocketAddr>().unwrap()),
-            channel_id: None,
         }
     }
 
@@ -223,9 +220,9 @@ impl Protocol {
     }
 
     /// Generate channel id
-    pub fn generate_channel(&self) -> Result<u64, String> {
+    pub fn generate_channel(&self) -> Result<u32, String> {
         let mut rng = rand::thread_rng();
-        let channel_id: u64 = rng.gen_range(100000, 999999);
+        let channel_id: u32 = rng.gen_range(100000, 999999);
         Ok(channel_id)
     }
 
@@ -255,7 +252,7 @@ impl Protocol {
     ///
     pub fn send_metadata(
         &self,
-        channel_id: u64,
+        channel_id: u32,
         hash: &str,
         num_chunks: u32,
     ) -> Result<(), String> {
@@ -289,7 +286,7 @@ impl Protocol {
     ///
     pub fn send_export(
         &self,
-        channel_id: u64,
+        channel_id: u32,
         hash: &str,
         target_path: &str,
         mode: u32,
@@ -366,7 +363,7 @@ impl Protocol {
     //
     fn finalize_file(
         &self,
-        channel_id: u64,
+        channel_id: u32,
         hash: &str,
         target_path: &str,
         mode: Option<u32>,
@@ -386,7 +383,7 @@ impl Protocol {
     // Send all requested chunks of a file to the remote destination
     fn send_chunks(
         &self,
-        channel_id: u64,
+        channel_id: u32,
         hash: &str,
         chunks: &[(u32, u32)],
     ) -> Result<(), String> {

--- a/libs/file-protocol/src/protocol.rs
+++ b/libs/file-protocol/src/protocol.rs
@@ -203,8 +203,12 @@ impl Protocol {
     /// let f_protocol = FileProtocol::new("0.0.0.0", "0.0.0.0:7000", None);
     ///
     /// let message = match f_protocol.recv(Some(Duration::from_secs(1))) {
-    /// 	Ok(data) => data,
-    /// 	Err(err) => panic!("Failed to receive message: {}", err),
+    ///     Ok(Some(data)) => data,
+    ///     Ok(None) =>  {
+    ///         println!("Timeout waiting for message");
+    ///         return;
+    ///     }
+    ///     Err(err) => panic!("Failed to receive message: {}", err),
     /// };
     /// ```
     ///
@@ -215,7 +219,7 @@ impl Protocol {
         }
     }
 
-    /// Generates a new random channel id for use when initiating a
+    /// Generates a new random channel ID for use when initiating a
     /// file transfer.
     ///
     /// # Errors

--- a/libs/file-protocol/src/storage.rs
+++ b/libs/file-protocol/src/storage.rs
@@ -41,10 +41,11 @@ pub fn store_chunk(prefix: &str, hash: &str, index: u32, data: &[u8]) -> Result<
         .join(hash)
         .join(file_name);
 
-    fs::create_dir_all(&storage_path
-        .parent()
-        .ok_or(format!("Failed to get path parent for {:?}", storage_path))?)
-        .map_err(|err| {
+    fs::create_dir_all(
+        &storage_path
+            .parent()
+            .ok_or(format!("Failed to get path parent for {:?}", storage_path))?,
+    ).map_err(|err| {
         format!(
             "Failed to create storage directory {:?}: {}",
             storage_path, err

--- a/services/file-service/Cargo.toml
+++ b/services/file-service/Cargo.toml
@@ -9,6 +9,7 @@ log = "^0.4.0"
 cbor-protocol = { path = "../../libs/cbor-protocol" }
 file-protocol = { path = "../../libs/file-protocol" }
 kubos-system = { path = "../../apis/system-api" }
+serde_cbor = "0.8"
 
 [dev-dependencies]
 blake2-rfc = "0.2.18"

--- a/services/file-service/src/lib.rs
+++ b/services/file-service/src/lib.rs
@@ -19,10 +19,13 @@ extern crate file_protocol;
 extern crate kubos_system;
 #[macro_use]
 extern crate log;
+extern crate serde_cbor;
 extern crate simplelog;
 
 use file_protocol::{FileProtocol, State};
 use kubos_system::Config as ServiceConfig;
+use std::collections::HashMap;
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::Duration;
 
@@ -50,39 +53,112 @@ pub fn recv_loop(config: ServiceConfig) -> Result<(), String> {
                 .and_then(|num| Some(Duration::from_secs(num as u64)))
         })
         .unwrap_or(Duration::from_secs(2));
+    // Setup maps of channel_id -> tx channel
+    let mut threads: HashMap<u64, Sender<Option<serde_cbor::Value>>> = HashMap::new();
 
     loop {
         // Listen on UDP port
         let (source, first_message) = c_protocol.recv_message_peer()?;
+        info!("msg from {:?}", source);
 
         let prefix_ref = prefix.clone();
         let host_ref = host_ip.clone();
         let timeout_ref = timeout.clone();
 
-        // Break the processing work off into its own thread so we can
-        // listen for requests from other clients
-        thread::spawn(move || {
-            let mut state = State::Holding {
-                count: 0,
-                prev_state: Box::new(State::Done),
-            };
+        let channel_id = match cbor_protocol::peek_channel_id(&first_message) {
+            Ok(Some(channel_id)) => channel_id,
+            Ok(None) => 0,
+            Err(e) => {
+                warn!("Error parsing channel id: {:?}", e);
+                continue;
+            }
+        };
 
-            // Set up the file system processor with the reply socket information
-            let f_protocol = FileProtocol::new(&host_ref, &format!("{}", source), prefix_ref);
+        if !threads.contains_key(&channel_id) {
+            println!("create new thread {}", channel_id);
+            let (tx, rx): (
+                Sender<Option<serde_cbor::Value>>,
+                Receiver<Option<serde_cbor::Value>>,
+            ) = mpsc::channel();
+            threads.insert(channel_id, tx.clone());
+            // Break the processing work off into its own thread so we can
+            // listen for requests from other clients
+            thread::spawn(move || {
+                let mut state = State::Holding {
+                    count: 0,
+                    prev_state: Box::new(State::Done),
+                };
 
-            // Process that first message that we got
-            if let Some(msg) = first_message {
-                if let Ok(new_state) = f_protocol.process_message(msg, state.clone()) {
-                    state = new_state;
+                let my_channel = channel_id;
+
+                let receiver = rx;
+
+                // Set up the file system processor with the reply socket information
+                let f_protocol = FileProtocol::new(&host_ref, &format!("{}", source), prefix_ref);
+
+                loop {
+                    // // Process that first message that we got
+                    // if let Some(msg) = first_message {
+                    //     if let Ok(new_state) = f_protocol.process_message(msg, state.clone()) {
+                    //         state = new_state;
+                    //     }
+                    // }
+
+                    // Listen, process, and react to the remaining messages in the
+                    // requested operation
+                    match f_protocol.message_engine(
+                        |d| match receiver.recv_timeout(d) {
+                            Ok(v) => Ok(v),
+                            Err(RecvTimeoutError) => Ok(None),
+                            Err(e) => Err(Some(format!("Error {:?}", e))),
+                        },
+                        timeout_ref,
+                        state.clone(),
+                    ) {
+                        Err(e) => warn!("Encountered errors while processing transaction: {}", e),
+                        _ => {}
+                    }
                 }
-            }
 
-            // Listen, process, and react to the remaining messages in the
-            // requested operation
-            match f_protocol.message_engine(|d| f_protocol.recv(Some(d)), timeout_ref, state) {
-                Err(e) => warn!("Encountered errors while processing transaction: {}", e),
-                _ => {}
-            }
-        });
+                info!("thread {} done", my_channel);
+            });
+        }
+
+        if let Some(sender) = threads.get(&channel_id) {
+            info!("send msg {:?} to channel {}", first_message, channel_id);
+            sender.send(first_message);
+        } else {
+            warn!("no sender found for {}", channel_id);
+        }
     }
 }
+
+// Break the processing work off into its own thread so we can
+// // listen for requests from other clients
+// thread::spawn(move || {
+//     let mut state = State::Holding {
+//         count: 0,
+//         prev_state: Box::new(State::Done),
+//     };
+
+//     // Set up the file system processor with the reply socket information
+//     let f_protocol = FileProtocol::new(&host_ref, &format!("{}", source), prefix_ref);
+
+//     // Process that first message that we got
+//     if let Some(msg) = first_message {
+//         if let Ok(new_state) = f_protocol.process_message(msg, state.clone()) {
+//             state = new_state;
+//         }
+//     }
+
+//     // Listen, process, and react to the remaining messages in the
+//     // requested operation
+//     match f_protocol.message_engine(
+//         |d| f_protocol.recv(Some(d)),
+//         Duration::from_secs(2),
+//         state,
+//     ) {
+//         Err(e) => warn!("Encountered errors while processing transaction: {}", e),
+//         _ => {}
+//     }
+// });

--- a/services/file-service/src/lib.rs
+++ b/services/file-service/src/lib.rs
@@ -96,28 +96,26 @@ pub fn recv_loop(config: ServiceConfig) -> Result<(), String> {
                 // Set up the file system processor with the reply socket information
                 let f_protocol = FileProtocol::new(&host_ref, &format!("{}", source), prefix_ref);
 
-                loop {
-                    // // Process that first message that we got
-                    // if let Some(msg) = first_message {
-                    //     if let Ok(new_state) = f_protocol.process_message(msg, state.clone()) {
-                    //         state = new_state;
-                    //     }
-                    // }
+                // // Process that first message that we got
+                // if let Some(msg) = first_message {
+                //     if let Ok(new_state) = f_protocol.process_message(msg, state.clone()) {
+                //         state = new_state;
+                //     }
+                // }
 
-                    // Listen, process, and react to the remaining messages in the
-                    // requested operation
-                    match f_protocol.message_engine(
-                        |d| match receiver.recv_timeout(d) {
-                            Ok(v) => Ok(v),
-                            Err(RecvTimeoutError) => Ok(None),
-                            Err(e) => Err(Some(format!("Error {:?}", e))),
-                        },
-                        timeout_ref,
-                        state.clone(),
-                    ) {
-                        Err(e) => warn!("Encountered errors while processing transaction: {}", e),
-                        _ => {}
-                    }
+                // Listen, process, and react to the remaining messages in the
+                // requested operation
+                match f_protocol.message_engine(
+                    |d| match receiver.recv_timeout(d) {
+                        Ok(v) => Ok(v),
+                        Err(RecvTimeoutError) => Ok(None),
+                        Err(e) => Err(Some(format!("Error {:?}", e))),
+                    },
+                    timeout_ref,
+                    state.clone(),
+                ) {
+                    Err(e) => warn!("Encountered errors while processing transaction: {}", e),
+                    _ => {}
                 }
 
                 info!("thread {} done", my_channel);

--- a/services/file-service/src/lib.rs
+++ b/services/file-service/src/lib.rs
@@ -100,7 +100,7 @@ pub fn recv_loop(config: ServiceConfig) -> Result<(), String> {
                     |d| match receiver.recv_timeout(d) {
                         Ok(v) => Ok(v),
                         Err(RecvTimeoutError::Timeout) => Ok(None),
-                        Err(e) => Err(Some(format!("Error {:?}", e))),
+                        Err(e) => Err(format!("Error {:?}", e)),
                     },
                     timeout_ref,
                     state,

--- a/services/file-service/src/lib.rs
+++ b/services/file-service/src/lib.rs
@@ -79,7 +79,7 @@ pub fn recv_loop(config: ServiceConfig) -> Result<(), String> {
 
             // Listen, process, and react to the remaining messages in the
             // requested operation
-            match f_protocol.message_engine(timeout_ref, state) {
+            match f_protocol.message_engine(|d| f_protocol.recv(Some(d)), timeout_ref, state) {
                 Err(e) => warn!("Encountered errors while processing transaction: {}", e),
                 _ => {}
             }

--- a/services/file-service/src/lib.rs
+++ b/services/file-service/src/lib.rs
@@ -54,7 +54,7 @@ pub fn recv_loop(config: ServiceConfig) -> Result<(), String> {
         })
         .unwrap_or(Duration::from_secs(2));
     // Setup maps of channel_id -> tx channel
-    let mut threads: HashMap<u64, Sender<Option<serde_cbor::Value>>> = HashMap::new();
+    let mut threads: HashMap<u32, Sender<Option<serde_cbor::Value>>> = HashMap::new();
 
     loop {
         // Listen on UDP port

--- a/services/file-service/src/lib.rs
+++ b/services/file-service/src/lib.rs
@@ -66,10 +66,9 @@ pub fn recv_loop(config: ServiceConfig) -> Result<(), String> {
         let timeout_ref = timeout.clone();
 
         let channel_id = match file_protocol::parse_channel_id(&first_message) {
-            Ok(Some(channel_id)) => channel_id,
-            Ok(None) => 0,
+            Ok(channel_id) => channel_id,
             Err(e) => {
-                warn!("Error parsing channel id: {:?}", e);
+                warn!("Error parsing channel ID: {:?}", e);
                 continue;
             }
         };
@@ -100,7 +99,7 @@ pub fn recv_loop(config: ServiceConfig) -> Result<(), String> {
                         Err(e) => Err(Some(format!("Error {:?}", e))),
                     },
                     timeout_ref,
-                    state.clone(),
+                    state,
                 ) {
                     Err(e) => warn!("Encountered errors while processing transaction: {}", e),
                     _ => {}
@@ -113,8 +112,11 @@ pub fn recv_loop(config: ServiceConfig) -> Result<(), String> {
                 Err(e) => warn!("Error when sending to channel {}: {:?}", channel_id, e),
                 _ => {}
             };
-        } else {
-            warn!("no sender found for {}", channel_id);
+        }
+
+        if !threads.contains_key(&channel_id) {
+            warn!("No sender found for {}", channel_id);
+            threads.remove(&channel_id);
         }
     }
 }

--- a/services/file-service/tests/download.rs
+++ b/services/file-service/tests/download.rs
@@ -81,8 +81,7 @@ fn download(
     let reply = match f_protocol.recv(None) {
         Ok(Some(message)) => message,
         Ok(None) => return Err("Failed to import file".to_owned()),
-        Err(Some(error)) => return Err(format!("Failed to import file: {}", error)),
-        Err(None) => return Err("Failed to import file".to_owned()),
+        Err(error) => return Err(format!("Failed to import file: {}", error)),
     };
 
     let state = f_protocol.process_message(

--- a/services/file-service/tests/upload.rs
+++ b/services/file-service/tests/upload.rs
@@ -20,15 +20,11 @@ extern crate file_service;
 extern crate kubos_system;
 extern crate rand;
 extern crate tempfile;
-#[macro_use]
-extern crate log;
-extern crate simplelog;
 
 use file_protocol::{FileProtocol, State};
 use file_service::recv_loop;
 use kubos_system::Config as ServiceConfig;
 use rand::{thread_rng, Rng};
-use simplelog::*;
 use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
@@ -57,7 +53,7 @@ macro_rules! service_new {
             )).unwrap();
         });
 
-        thread::sleep(Duration::new(1, 0));
+        thread::sleep(Duration::new(0, 500));
     }};
 }
 
@@ -129,8 +125,6 @@ fn upload_single() {
 
     let hash = result.unwrap();
 
-    thread::sleep(Duration::from_secs(10));
-
     // Cleanup the temporary files so that the test can be repeatable
     fs::remove_dir_all(format!("client/storage/{}", hash)).unwrap();
     fs::remove_dir_all(format!("service/storage/{}", hash)).unwrap();
@@ -149,7 +143,7 @@ fn upload_multi_clean() {
     let dest = format!("{}/dest", test_dir_str);
     let service_port = 7001;
 
-    let contents = [1; 10];
+    let contents = [1; 5000];
 
     create_test_file(&source, &contents);
 


### PR DESCRIPTION
The threading model of the file service has been updated to better support multiple simultaneous clients uploading or downloading files. This has also relieved the need for most non-timeout related delays in the protocol implementation :tada:.

Other majorish changes:
- Content addressable messages (metadata, chunk, ack, nak) now include the channel id as first parameter
- Channel ids moved from `u64` -> `u32`