### PR TITLE
Adding the ability to upgrade applications

### DIFF
--- a/docs/app-docs/app-service.rst
+++ b/docs/app-docs/app-service.rst
@@ -212,28 +212,29 @@ started during system initialization.
 
 This logic may also be triggered by manually starting the applications service with the ``-b`` flag.
 
-.. todo::
+Upgrading
+---------
 
-    Upgrading
-    //---------
+Users may register a new version of an application without needing to remove the existing registration.
+
+To do this, they will use the ``register`` mutation with the optional ``uuid`` input parameter.
+An application's UUID is given as a return field of the ``register`` mutation and can also be looked up
+using the ``apps`` query.
+
+::
     
-    Users may register a new version of an application without needing to remove the existing registration.
-    
-    To do this, they will use the ``register`` mutation with the optional ``uuid`` input parameter.
-    An application's UUID is given as a return field of the ``register`` mutation and can also be looked up
-    using the ``apps`` query.
-    
-    ::
-    
-        mutation {
-            register(path: /home/kubos/payload-app, uuid: 60ff7516-a5c4-4fea-bdea-1b163ee9bd7a) {
-                active,
-                app {
-                    name,
-                    version
-                }
+    mutation {
+        register(path: /home/kubos/payload-app, uuid: 60ff7516-a5c4-4fea-bdea-1b163ee9bd7a) {
+            active,
+            app {
+                name,
+                version
             }
         }
+    }
+        
+        
+.. todo::
     
     Recovery
     //--------

--- a/docs/tutorials/app-register.rst
+++ b/docs/tutorials/app-register.rst
@@ -46,7 +46,7 @@ To register an application, we use the service's ``register`` mutation.
 It has the following schema::
 
      mutation {
-        register(path: String!) {
+        register(path: String!, uuid: String) {
             success: Bool!,
             errors: String,
             entry: {
@@ -66,6 +66,10 @@ The ``path`` input parameter specifies the directory *on the OBC* where the appl
 files reside.
 They **must be the only files in this directory** in order for the service to be able to complete the
 registration process.
+
+The ``uuid`` input parameter specifies the desired UUID for the registered application.
+If not specified, one will be automatically generated.
+This field is normally used when updating an existing application.
 
 The mutation can return the following fields:
 
@@ -177,9 +181,10 @@ Since this is a new version of our application, we'll then need to update our ``
 file to change the ``version`` key from ``"1.0"`` to ``"2.0"``.
 
 After transferring both of the files into our remote folder, ``/home/kubos/my-app``,
-we can register the updated application using the same ``register`` mutation as before::
+we can register the updated application using the same ``register`` mutation as before,
+except this time we'll add the ``uuid`` input parameter::
  
-    $ echo "mutation {register(path: \"/home/kubos/my-app\"){success,entry{app{uuid,name,path}}}}" | nc -uw1 10.0.2.20 8000
+    $ echo "mutation {register(path: \"/home/kubos/my-app\", uuid: \"8052dbe9-bab1-428e-8414-fb72b4af90bc\"){success,entry{app{uuid,name,path}}}}" | nc -uw1 10.0.2.20 8000
 
 The returned UUID should match our original UUID::
 

--- a/examples/python-mission-application/manifest.toml
+++ b/examples/python-mission-application/manifest.toml
@@ -1,3 +1,3 @@
 name = "mission-app.py"
-version = "0.1.0"
+version = "0.1.1"
 author = "Jesse Coffey <jcoffey@kubos.com>"

--- a/services/app-service/src/objects.rs
+++ b/services/app-service/src/objects.rs
@@ -35,7 +35,7 @@ pub struct RegisterResponse {
     /// Request completion success or failure
     pub success: bool,
     /// The new registry entry created after successfully registration
-    pub entry: Option<KAppRegistryEntry>
+    pub entry: Option<KAppRegistryEntry>,
 }
 
 /// Response fields for the `startApp` mutation
@@ -46,7 +46,7 @@ pub struct StartResponse {
     /// Request completion success or failure
     pub success: bool,
     /// PID of the started process
-    pub pid: Option<i32>
+    pub pid: Option<i32>,
 }
 
 pub struct KApp(pub app_entry::App);

--- a/services/app-service/src/schema.rs
+++ b/services/app-service/src/schema.rs
@@ -22,8 +22,6 @@ use registry::AppRegistry;
 
 type Context = kubos_service::Context<AppRegistry>;
 
-
-
 ///
 pub struct QueryRoot;
 
@@ -68,11 +66,11 @@ pub struct MutationRoot;
 /// Base GraphQL mutation model
 graphql_object!(MutationRoot : Context as "Mutation" |&self| {
 
-    field register(&executor, path: String) -> FieldResult<RegisterResponse>
+    field register(&executor, path: String, uuid: Option<String>) -> FieldResult<RegisterResponse>
         as "Register App"
     {
         let registry = executor.context().subsystem();
-        Ok(match registry.register(&path) {
+        Ok(match registry.register(&path, uuid) {
             Ok(app) =>  RegisterResponse { success: true, errors: "".to_owned(), entry: Some(KAppRegistryEntry(app))},
             Err(error) => RegisterResponse {
                 success: false,

--- a/services/app-service/src/tests/mod.rs
+++ b/services/app-service/src/tests/mod.rs
@@ -14,7 +14,31 @@
  * limitations under the License.
  */
 
+macro_rules! mock_service {
+    ($registry_dir:ident) => {{
+        let registry = AppRegistry::new_from_dir(&$registry_dir.path().to_string_lossy()).unwrap();
+
+        let config = format!(
+            r#"
+            [app-service]
+            registry-dir = "{}"
+            [app-service.addr]
+            ip = "127.0.0.1"
+            port = 9999"#,
+            $registry_dir.path().to_str().unwrap(),
+        );
+
+        Service::new(
+            Config::new_from_str("app-service", &config),
+            registry,
+            schema::QueryRoot,
+            schema::MutationRoot,
+        )
+    }};
+}
+
 mod register_app;
 mod registry_onboot;
 mod registry_start_app;
 mod registry_test;
+mod upgrade_app;

--- a/services/app-service/src/tests/register_app.rs
+++ b/services/app-service/src/tests/register_app.rs
@@ -22,29 +22,6 @@ use tempfile::TempDir;
 use registry::*;
 use schema;
 
-macro_rules! mock_service {
-    ($registry_dir:ident) => {{
-        let registry = AppRegistry::new_from_dir(&$registry_dir.path().to_string_lossy()).unwrap();
-
-        let config = format!(
-            r#"
-            [app-service]
-            registry-dir = "{}"
-            [app-service.addr]
-            ip = "127.0.0.1"
-            port = 9999"#,
-            $registry_dir.path().to_str().unwrap(),
-        );
-
-        Service::new(
-            Config::new_from_str("app-service", &config),
-            registry,
-            schema::QueryRoot,
-            schema::MutationRoot,
-        )
-    }};
-}
-
 #[test]
 fn register_good() {
     let registry_dir = TempDir::new().unwrap();
@@ -146,7 +123,7 @@ fn register_no_manifest() {
                }
             }
         }).to_string();
-    
+
     assert_eq!(service.process(register_query.to_owned()), expected);
 }
 
@@ -191,8 +168,8 @@ fn register_extra_file() {
     }}"#,
         app_bin.to_str().unwrap()
     );
-    
-        let expected = json!({
+
+    let expected = json!({
             "errs": "",
             "msg": {
                "register": {
@@ -243,8 +220,8 @@ fn register_no_name() {
     }}"#,
         app_bin.to_str().unwrap()
     );
-    
-        let expected = json!({
+
+    let expected = json!({
             "errs": "",
             "msg": {
                "register": {
@@ -295,8 +272,8 @@ fn register_no_version() {
     }}"#,
         app_bin.to_str().unwrap()
     );
-    
-        let expected = json!({
+
+    let expected = json!({
             "errs": "",
             "msg": {
                "register": {
@@ -347,7 +324,7 @@ fn register_no_author() {
     }}"#,
         app_bin.to_str().unwrap()
     );
-    
+
     let expected = json!({
             "errs": "",
             "msg": {
@@ -381,7 +358,7 @@ fn register_bad_path() {
             }
         }
     }"#;
-    
+
     let expected = json!({
             "errs": "",
             "msg": {

--- a/services/app-service/src/tests/registry_onboot.rs
+++ b/services/app-service/src/tests/registry_onboot.rs
@@ -53,7 +53,7 @@ fn registry_onboot_good() {
             "#;
     fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
 
-    registry.register(&app_bin.to_string_lossy()).unwrap();
+    registry.register(&app_bin.to_string_lossy(), None).unwrap();
 
     let result = registry.run_onboot();
 
@@ -83,7 +83,7 @@ fn registry_onboot_fail() {
             "#;
     fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
 
-    registry.register(&app_bin.to_string_lossy()).unwrap();
+    registry.register(&app_bin.to_string_lossy(), None).unwrap();
 
     assert_eq!(
         registry.run_onboot().unwrap_err(),

--- a/services/app-service/src/tests/upgrade_app.rs
+++ b/services/app-service/src/tests/upgrade_app.rs
@@ -1,0 +1,334 @@
+/*
+ * Copyright (C) 2018 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use kubos_service::{Config, Service};
+use std::fs;
+
+use tempfile::TempDir;
+
+use registry::*;
+use schema;
+
+// Perform an "upgrade" of a brand new application.
+// It's basically allowing a user to register a new application with a custom UUID
+#[test]
+fn upgrade_new() {
+    let registry_dir = TempDir::new().unwrap();
+    let service = mock_service!(registry_dir);
+
+    let app_dir = TempDir::new().unwrap();
+    let app_bin = app_dir.path().join("dummy-app");
+
+    fs::create_dir(app_bin.clone()).unwrap();
+
+    // Create dummy app file
+    fs::File::create(app_bin.join("dummy")).unwrap();
+
+    // Create manifest file
+    let manifest = r#"
+            name = "dummy"
+            version = "0.0.1"
+            author = "user"
+            "#;
+    fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
+
+    let upgrade_query = format!(
+        r#"mutation {{
+        register(path: "{}", uuid: "a-b-c-d-e") {{
+            success,
+            errors,
+            entry {{
+                active, 
+                app {{
+                    name,
+                    version,
+                    uuid
+                }}
+            }}
+        }}
+    }}"#,
+        app_bin.to_str().unwrap()
+    );
+
+    let expected = json!({
+            "errs": "",
+            "msg": {
+               "register": {
+                   "entry": {
+                      "active": true,
+                       "app": {
+                           "name": "dummy",
+                           "version": "0.0.1",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   },
+                   "errors": "",
+                   "success": true,
+               }
+            }
+        }).to_string();
+
+    assert_eq!(service.process(upgrade_query.to_owned()), expected);
+}
+
+#[test]
+fn upgrade_good() {
+    let registry_dir = TempDir::new().unwrap();
+    let service = mock_service!(registry_dir);
+
+    let app_dir = TempDir::new().unwrap();
+    let app_bin = app_dir.path().join("dummy-app");
+
+    fs::create_dir(app_bin.clone()).unwrap();
+
+    fs::File::create(app_bin.join("dummy")).unwrap();
+
+    let manifest = r#"
+            name = "dummy"
+            version = "0.0.1"
+            author = "user"
+            "#;
+    fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
+
+    let upgrade_query = format!(
+        r#"mutation {{
+        register(path: "{}", uuid: "a-b-c-d-e") {{
+            success,
+            errors,
+            entry {{
+                active, 
+                app {{
+                    name,
+                    version,
+                    uuid
+                }}
+            }}
+        }}
+    }}"#,
+        app_bin.to_str().unwrap()
+    );
+
+    let expected = json!({
+            "errs": "",
+            "msg": {
+               "register": {
+                   "entry": {
+                      "active": true,
+                       "app": {
+                           "name": "dummy",
+                           "version": "0.0.1",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   },
+                   "errors": "",
+                   "success": true,
+               }
+            }
+        }).to_string();
+
+    // Register the initial app so we have something to upgrade
+    assert_eq!(service.process(upgrade_query.to_owned()), expected);
+
+    // Update the manifest for the new version of the app
+    let manifest = r#"
+            name = "dummy"
+            version = "0.0.2"
+            author = "user"
+            "#;
+    fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
+
+    let expected = json!({
+            "errs": "",
+            "msg": {
+               "register": {
+                   "entry": {
+                      "active": true,
+                       "app": {
+                           "name": "dummy",
+                           "version": "0.0.2",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   },
+                   "errors": "",
+                   "success": true,
+               }
+            }
+        }).to_string();
+
+    // Register the new version
+    assert_eq!(service.process(upgrade_query.to_owned()), expected);
+
+    let app_query = r#"
+        { apps(uuid: "a-b-c-d-e") { active, app { name, version, uuid } } }
+    "#;
+
+    let expected = json!({
+            "errs": "",
+            "msg": {
+               "apps": [
+                 {
+                      "active": false,
+                       "app": {
+                           "name": "dummy",
+                           "version": "0.0.1",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   },
+                   {
+                      "active": true,
+                       "app": {
+                           "name": "dummy",
+                           "version": "0.0.2",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   }
+               ]
+            }
+    }).to_string();
+
+    // Verify:
+    //   - There are two registered versions of the app
+    //   - The 0.0.2 version is the active version
+    assert_eq!(service.process(app_query.to_owned()), expected);
+}
+
+#[test]
+fn upgrade_new_name() {
+    let registry_dir = TempDir::new().unwrap();
+    let service = mock_service!(registry_dir);
+
+    let app_dir = TempDir::new().unwrap();
+    let app_bin = app_dir.path().join("dummy-app");
+
+    fs::create_dir(app_bin.clone()).unwrap();
+
+    fs::File::create(app_bin.join("dummy")).unwrap();
+
+    let manifest = r#"
+            name = "dummy"
+            version = "0.0.1"
+            author = "user"
+            "#;
+    fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
+
+    let upgrade_query = format!(
+        r#"mutation {{
+        register(path: "{}", uuid: "a-b-c-d-e") {{
+            success,
+            errors,
+            entry {{
+                active, 
+                app {{
+                    name,
+                    version,
+                    uuid
+                }}
+            }}
+        }}
+    }}"#,
+        app_bin.to_str().unwrap()
+    );
+
+    let expected = json!({
+            "errs": "",
+            "msg": {
+               "register": {
+                   "entry": {
+                      "active": true,
+                       "app": {
+                           "name": "dummy",
+                           "version": "0.0.1",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   },
+                   "errors": "",
+                   "success": true,
+               }
+            }
+        }).to_string();
+
+    // Register the initial app so we have something to upgrade
+    assert_eq!(service.process(upgrade_query.to_owned()), expected);
+
+    // Delete the old app file
+    fs::remove_file(app_bin.join("dummy")).unwrap();
+    // Create the new app file
+    fs::File::create(app_bin.join("dummy2")).unwrap();
+
+    // Update the manifest for the new version of the app,
+    // with the new app file name
+    let manifest = r#"
+            name = "dummy2"
+            version = "0.0.2"
+            author = "user"
+            "#;
+    fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
+
+    let expected = json!({
+            "errs": "",
+            "msg": {
+               "register": {
+                   "entry": {
+                      "active": true,
+                       "app": {
+                           "name": "dummy2",
+                           "version": "0.0.2",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   },
+                   "errors": "",
+                   "success": true,
+               }
+            }
+        }).to_string();
+
+    // Register the new version
+    assert_eq!(service.process(upgrade_query.to_owned()), expected);
+
+    let app_query = r#"
+        { apps(uuid: "a-b-c-d-e") { active, app { name, version, uuid } } }
+    "#;
+
+    let expected = json!({
+            "errs": "",
+            "msg": {
+               "apps": [
+                 {
+                      "active": false,
+                       "app": {
+                           "name": "dummy",
+                           "version": "0.0.1",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   },
+                   {
+                      "active": true,
+                       "app": {
+                           "name": "dummy2",
+                           "version": "0.0.2",
+                           "uuid": "a-b-c-d-e"
+                       }
+                   }
+               ]
+            }
+    }).to_string();
+
+    // Verify:
+    //   - There are two registered versions of the app
+    //   - The 0.0.2 version is the active version
+    //   - The app names are different
+    assert_eq!(service.process(app_query.to_owned()), expected);
+}


### PR DESCRIPTION
Currently it is possible to upgrade applications with the applications service by simply re-registering them. However, this only works if the application name remain the same.

The original intention was that the application name could be changed between versions and the application UUID would be used as the main identifier.

This PR updates the `register` mutation to allow a UUID to be passed in order to upgrade an existing application. The documentation has also been updated to reflect the changes.