### PR TITLE
Adding return codes to Rust app API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ name = "rust-mission-app"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-app 0.1.0",
 ]

--- a/apis/app-api/rust/src/framework.rs
+++ b/apis/app-api/rust/src/framework.rs
@@ -60,9 +60,11 @@ pub trait AppHandler {
 /// # Examples
 ///
 /// ```
+/// extern crate failure;
 /// #[macro_use]
 /// extern crate kubos_app;
 ///
+/// use failure::Error;
 /// use kubos_app::AppHandler;
 ///
 /// struct MyApp;
@@ -70,15 +72,18 @@ pub trait AppHandler {
 /// impl AppHandler for MyApp {
 ///   fn on_boot(&self, _args: Vec<String>) -> Result<(), Error> {
 ///     println!("OnBoot logic");
+///     Ok(())
 ///   }
 ///   fn on_command(&self, _args: Vec<String>) -> Result<(), Error> {
 ///     println!("OnCommand logic");
+///     Ok(())
 ///   }
 /// }
 ///
-/// fn main() {
+/// fn main() -> Result<(), Error> {
 ///     let app = MyApp { };
-///     app_main!(&app);
+///     app_main!(&app)?;
+///     Ok(())
 /// }
 /// ```
 #[macro_export]

--- a/apis/app-api/rust/src/framework.rs
+++ b/apis/app-api/rust/src/framework.rs
@@ -19,6 +19,7 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
+use failure::Error;
 use getopts::Options;
 use std::env;
 use std::fmt;
@@ -44,10 +45,10 @@ impl fmt::Display for RunLevel {
 /// Common trait which is used to ensure handlers for all required run levels are defined
 pub trait AppHandler {
     /// Called when the application is started at system boot time
-    fn on_boot(&self, args: Vec<String>);
+    fn on_boot(&self, args: Vec<String>) -> Result<(), Error>;
 
     /// Called when the application is started on-demand through the `start_app` GraphQL mutation
-    fn on_command(&self, args: Vec<String>);
+    fn on_command(&self, args: Vec<String>) -> Result<(), Error>;
 }
 
 /// A helper macro which detects the requested run level and calls the appropriate handler function
@@ -67,10 +68,10 @@ pub trait AppHandler {
 /// struct MyApp;
 ///
 /// impl AppHandler for MyApp {
-///   fn on_boot(&self, _args: Vec<String>) {
+///   fn on_boot(&self, _args: Vec<String>) -> Result<(), Error> {
 ///     println!("OnBoot logic");
 ///   }
-///   fn on_command(&self, _args: Vec<String>) {
+///   fn on_command(&self, _args: Vec<String>) -> Result<(), Error> {
 ///     println!("OnCommand logic");
 ///   }
 /// }
@@ -89,7 +90,7 @@ macro_rules! app_main {
 
 /// The entry point for all KubOS applications. The preferred way to use this application
 /// is through the `app_main!` macro
-pub fn app_start(_pid: u32, handler: &AppHandler) {
+pub fn app_start(_pid: u32, handler: &AppHandler) -> Result<(), Error> {
     let args: Vec<String> = env::args().collect();
     let program = args[0].clone();
 
@@ -110,24 +111,19 @@ pub fn app_start(_pid: u32, handler: &AppHandler) {
     if matches.opt_present("h") {
         let brief = format!("Usage: {} [options]", program);
         print!("{}", opts.usage(&brief));
-        return;
+        return Ok(())
     }
 
     let _uuid = env::var_os("KUBOS_APP_UUID");
     let run_level = matches.opt_str("r").unwrap_or("OnCommand".to_owned());
 
     match run_level.as_ref() {
-        "OnBoot" => {
-            handler.on_boot(args);
-        }
-        "OnCommand" => {
-            handler.on_command(args);
-        }
+        "OnBoot" => handler.on_boot(args),
+        "OnCommand" => handler.on_command(args),
         level => {
-            eprintln!(
+            bail!(
                 "Error: Unknown run level was requested - {}. Available run levels: OnBoot, OnCommand", level
             );
-            return;
         }
     }
 }

--- a/apis/app-api/rust/src/lib.rs
+++ b/apis/app-api/rust/src/lib.rs
@@ -21,15 +21,18 @@
 //!
 //! ```
 //! #[macro_use]
+//! extern crate failure;
+//! #[macro_use]
 //! extern crate kubos_app;
 //!
+//! use failure::Error;
 //! use kubos_app::*;
 //! use std::time::Duration;
 //!
 //! struct MyApp;
 //!
 //! impl AppHandler for MyApp {
-//!   fn on_boot(&self, _args: Vec<String>) {
+//!   fn on_boot(&self, _args: Vec<String>) -> Result<(), Error> {
 //!     println!("OnBoot logic");
 //!
 //!     let request = r#"mutation {
@@ -39,10 +42,7 @@
 //!         }"#;
 //!
 //!     match query(ServiceConfig::new("radio-service"), request, Some(Duration::from_secs(1))) {
-//!         Err(error) => {
-//!             eprintln!("Failed to communicate with radio service: {}", error);
-//!             return;
-//!         }
+//!         Err(error) => bail!("Failed to communicate with radio service: {}", error),
 //!         Ok(data) => {
 //!             if let Some(success) = data.get("power")
 //!                 .and_then(|power| power.get("success"))
@@ -53,20 +53,23 @@
 //!                     None => eprintln!("Failed to fetch radio power state")
 //!                 }
 //!             } else {
-//!                 eprintln!("Failed to fetch radio power state");
-//!                 return;
+//!                 bail!("Failed to fetch radio power state");
 //!             }
 //!         }
 //!     }
+//!
+//!     Ok(())
 //!   }
-//!   fn on_command(&self, _args: Vec<String>) {
+//!   fn on_command(&self, _args: Vec<String>) Result<(), Error> {
 //!     println!("OnCommand logic");
+//!     Ok(())
 //!   }
 //! }
 //!
-//! fn main() {
+//! fn main() -> Result<(), Error> {
 //!     let app = MyApp { };
-//!     app_main!(&app);
+//!     app_main!(&app)?;
+//!     Ok(())
 //! }
 //! ```
 //!

--- a/apis/app-api/rust/src/lib.rs
+++ b/apis/app-api/rust/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //!     Ok(())
 //!   }
-//!   fn on_command(&self, _args: Vec<String>) Result<(), Error> {
+//!   fn on_command(&self, _args: Vec<String>) -> Result<(), Error> {
 //!     println!("OnCommand logic");
 //!     Ok(())
 //!   }

--- a/examples/rust-mission-app/Cargo.toml
+++ b/examples/rust-mission-app/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Catherine Garabedian <catherine@kubos.co>"]
 
 [dependencies]
 chrono = "0.4"
+failure = "0.1.2"
 getopts = "0.2"
 kubos-app = { path = "../../apis/app-api/rust" }


### PR DESCRIPTION
Adding `Result<(), Error>` to the AppHandler trait's functions.

This can be more properly tested once the app service is updated to wait a moment to check for app execution issues.