### PR TITLE
Expanding timestamp size to be a Double. Change units to seconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/apis/telemetry-db-api/src/lib.rs
+++ b/apis/telemetry-db-api/src/lib.rs
@@ -91,7 +91,7 @@ impl Database {
 
     pub fn insert<'a>(
         &self,
-        timestamp: i32,
+        timestamp: f64,
         subsystem: &'a str,
         parameter: &'a str,
         value: &'a str,
@@ -117,14 +117,14 @@ impl Database {
         value: &'a str,
     ) -> QueryResult<usize> {
         let time = time::now_utc().to_timespec();
-        let timestamp = (time.sec * 1000) as i32 + (time.nsec / 1000000);
-        self.insert(timestamp as i32, subsystem, parameter, value)
+        let timestamp = time.sec as f64 + (time.nsec as f64 / 1000000000.0);
+        self.insert(timestamp, subsystem, parameter, value)
     }
 }
 
 table! {
     telemetry (timestamp) {
-        timestamp -> Integer,
+        timestamp -> Double,
         subsystem -> Text,
         parameter -> Text,
         value -> Text,

--- a/apis/telemetry-db-api/src/models.rs
+++ b/apis/telemetry-db-api/src/models.rs
@@ -18,7 +18,7 @@ use super::telemetry;
 
 #[derive(Debug, Queryable, Serialize, Deserialize)]
 pub struct Entry {
-    pub timestamp: i32,
+    pub timestamp: f64,
     pub subsystem: String,
     pub parameter: String,
     pub value: String,
@@ -27,7 +27,7 @@ pub struct Entry {
 #[derive(Insertable)]
 #[table_name = "telemetry"]
 pub struct NewEntry<'a> {
-    pub timestamp: i32,
+    pub timestamp: f64,
     pub subsystem: &'a str,
     pub parameter: &'a str,
     pub value: &'a str,

--- a/services/telemetry-service/Cargo.toml
+++ b/services/telemetry-service/Cargo.toml
@@ -16,3 +16,4 @@ tar = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
+time = "0.1"

--- a/services/telemetry-service/src/schema.rs
+++ b/services/telemetry-service/src/schema.rs
@@ -56,8 +56,8 @@ pub struct Entry(kubos_telemetry_db::Entry);
 graphql_object!(Entry: () |&self| {
     description: "A telemetry entry"
 
-    field timestamp() -> i32 as "Timestamp" {
-        self.0.timestamp
+    field timestamp() -> f64 as "Timestamp" {
+        self.0.timestamp as f64
     }
 
     field subsystem() -> &String as "Subsystem name" {
@@ -75,8 +75,8 @@ graphql_object!(Entry: () |&self| {
 
 fn query_db(
     database: &Arc<Mutex<kubos_telemetry_db::Database>>,
-    timestamp_ge: Option<i32>,
-    timestamp_le: Option<i32>,
+    timestamp_ge: Option<f64>,
+    timestamp_le: Option<f64>,
     subsystem: Option<String>,
     parameter: Option<String>,
     limit: Option<i32>,
@@ -124,8 +124,8 @@ pub struct QueryRoot;
 graphql_object!(QueryRoot: Context |&self| {
     field telemetry(
         &executor,
-        timestamp_ge: Option<i32>,
-        timestamp_le: Option<i32>,
+        timestamp_ge: Option<f64>,
+        timestamp_le: Option<f64>,
         subsystem: Option<String>,
         parameter: Option<String>,
         limit: Option<i32>,
@@ -136,8 +136,8 @@ graphql_object!(QueryRoot: Context |&self| {
     }
     field routed_telemetry(
         &executor,
-        timestamp_ge: Option<i32>,
-        timestamp_le: Option<i32>,
+        timestamp_ge: Option<f64>,
+        timestamp_le: Option<f64>,
         subsystem: Option<String>,
         parameter: Option<String>,
         limit: Option<i32>,
@@ -198,7 +198,7 @@ struct DeleteResponse {
 }
 
 graphql_object!(MutationRoot: Context | &self | {
-    field insert(&executor, timestamp: Option<i32>, subsystem: String, parameter: String, value: String) -> FieldResult<InsertResponse> {
+    field insert(&executor, timestamp: Option<f64>, subsystem: String, parameter: String, value: String) -> FieldResult<InsertResponse> {
         let result = match timestamp {
             Some(time) => executor.context().subsystem().database.lock()?.insert(time, &subsystem, &parameter, &value),
             None => executor.context().subsystem().database.lock()?.insert_systime(&subsystem, &parameter, &value),
@@ -215,8 +215,8 @@ graphql_object!(MutationRoot: Context | &self | {
 
     field delete(
         &executor,
-        timestamp_ge: Option<i32>,
-        timestamp_le: Option<i32>,
+        timestamp_ge: Option<f64>,
+        timestamp_le: Option<f64>,
         subsystem: Option<String>,
         parameter: Option<String>,
     ) -> FieldResult<DeleteResponse>

--- a/services/telemetry-service/src/udp.rs
+++ b/services/telemetry-service/src/udp.rs
@@ -48,7 +48,7 @@ impl DirectUdp {
     }
 
     fn process(&self, message: Value) -> Result<(), String> {
-        let timestamp = serde_json::from_value::<i32>(message["timestamp"].clone()).ok();
+        let timestamp = serde_json::from_value::<f64>(message["timestamp"].clone()).ok();
 
         let subsystem = serde_json::from_value::<String>(message["subsystem"].clone())
             .map_err(|err| format!("Failed to parse subsystem parameter: {}", err))?;

--- a/services/telemetry-service/tests/test_delete.rs
+++ b/services/telemetry-service/tests/test_delete.rs
@@ -81,25 +81,25 @@ fn test_delete_ge() {
             "msg": {
                 "telemetry": [
                     {
-                    "timestamp": 1003,
+                    "timestamp": 1003.0,
                     "subsystem": "eps",
                     "parameter": "current",
                     "value": "3.1"
                     },
                     {
-                    "timestamp": 1002,
+                    "timestamp": 1002.0,
                     "subsystem": "gps",
                     "parameter": "voltage",
                     "value": "3.2"
                     },
                     {
-                    "timestamp": 1001,
+                    "timestamp": 1001.0,
                     "subsystem": "mcu",
                     "parameter": "voltage",
                     "value": "3.4"
                     },
                     {
-                    "timestamp": 1000,
+                    "timestamp": 1000.0,
                     "subsystem": "eps",
                     "parameter": "voltage",
                     "value": "3.3"
@@ -159,13 +159,13 @@ fn test_delete_le() {
             "msg": {
                 "telemetry": [
                     {
-                    "timestamp": 1010,
+                    "timestamp": 1010.0,
                     "subsystem": "mcu",
                     "parameter": "current",
                     "value": "2.4"
                     },
                     {
-                    "timestamp": 1009,
+                    "timestamp": 1009.0,
                     "subsystem": "eps",
                     "parameter": "current",
                     "value": "2.5"
@@ -225,13 +225,13 @@ fn test_delete_range() {
             "msg": {
                 "telemetry": [
                     {
-                    "timestamp": 1010,
+                    "timestamp": 1010.0,
                     "subsystem": "mcu",
                     "parameter": "current",
                     "value": "2.4"
                     },
                     {
-                    "timestamp": 1000,
+                    "timestamp": 1000.0,
                     "subsystem": "eps",
                     "parameter": "voltage",
                     "value": "3.3"
@@ -289,31 +289,31 @@ fn test_delete_subsystem() {
             "msg": {
                 "telemetry": [
                     {
-                    "timestamp": 1010,
+                    "timestamp": 1010.0,
                     "subsystem": "mcu",
                     },
                     {
-                    "timestamp": 1008,
+                    "timestamp": 1008.0,
                     "subsystem": "gps",
                     },
                     {
-                    "timestamp": 1007,
+                    "timestamp": 1007.0,
                     "subsystem": "mcu",
                     },
                     {
-                    "timestamp": 1005,
+                    "timestamp": 1005.0,
                     "subsystem": "gps",
                     },
                     {
-                    "timestamp": 1004,
+                    "timestamp": 1004.0,
                     "subsystem": "mcu",
                     },
                     {
-                    "timestamp": 1002,
+                    "timestamp": 1002.0,
                     "subsystem": "gps",
                     },
                     {
-                    "timestamp": 1001,
+                    "timestamp": 1001.0,
                     "subsystem": "mcu",
                     },
                 ]
@@ -369,23 +369,23 @@ fn test_delete_parameter() {
             "msg": {
                 "telemetry": [
                     {
-                    "timestamp": 1010,
+                    "timestamp": 1010.0,
                     "subsystem": "mcu",
                     },
                     {
-                    "timestamp": 1009,
+                    "timestamp": 1009.0,
                     "subsystem": "eps",
                     },
                     {
-                    "timestamp": 1005,
+                    "timestamp": 1005.0,
                     "subsystem": "gps",
                     },
                     {
-                    "timestamp": 1004,
+                    "timestamp": 1004.0,
                     "subsystem": "mcu",
                     },
                     {
-                    "timestamp": 1003,
+                    "timestamp": 1003.0,
                     "subsystem": "eps",
                     },
                 ]

--- a/services/telemetry-service/tests/test_filter_subsystem.rs
+++ b/services/telemetry-service/tests/test_filter_subsystem.rs
@@ -41,7 +41,7 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1010,"subsystem":"gps","parameter":"x_position","value":"-1.0"}
+                    {"timestamp":1010.0,"subsystem":"gps","parameter":"x_position","value":"-1.0"}
                 ]
             }
         })

--- a/services/telemetry-service/tests/test_insert.rs
+++ b/services/telemetry-service/tests/test_insert.rs
@@ -118,7 +118,7 @@ fn test_insert_custom_timestamp() {
             "errs": "",
             "msg": {
                 "telemetry": [{
-                    "timestamp": 5,
+                    "timestamp": 5.0,
                     "subsystem": "test2",
                     "parameter": "voltage",
                     "value": "4.0"

--- a/services/telemetry-service/tests/test_limit.rs
+++ b/services/telemetry-service/tests/test_limit.rs
@@ -49,8 +49,8 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1010,"subsystem":"eps","parameter":"voltage","value":"2.4"},
-                    {"timestamp":1009,"subsystem":"eps","parameter":"voltage","value":"2.5"},
+                    {"timestamp":1010.0,"subsystem":"eps","parameter":"voltage","value":"2.4"},
+                    {"timestamp":1009.0,"subsystem":"eps","parameter":"voltage","value":"2.5"},
                 ]
             }
         })

--- a/services/telemetry-service/tests/test_route.rs
+++ b/services/telemetry-service/tests/test_route.rs
@@ -75,16 +75,16 @@ fn test_route_file() {
     assert_eq!(
         entries,
         json!([
-            {"timestamp":1004,"subsystem":"mcu","parameter":"voltage","value":"4.6"},
-            {"timestamp":1004,"subsystem":"eps","parameter":"voltage","value":"3.6"},
-            {"timestamp":1003,"subsystem":"mcu","parameter":"current","value":"4.5"},
-            {"timestamp":1003,"subsystem":"eps","parameter":"current","value":"3.5"},
-            {"timestamp":1002,"subsystem":"mcu","parameter":"voltage","value":"4.2"},
-            {"timestamp":1002,"subsystem":"eps","parameter":"voltage","value":"3.2"},
-            {"timestamp":1001,"subsystem":"mcu","parameter":"current","value":"4.4"},
-            {"timestamp":1001,"subsystem":"eps","parameter":"current","value":"3.4"},
-            {"timestamp":1000,"subsystem":"mcu","parameter":"voltage","value":"4.3"},
-            {"timestamp":1000,"subsystem":"eps","parameter":"voltage","value":"3.3"},
+            {"timestamp":1004.0,"subsystem":"mcu","parameter":"voltage","value":"4.6"},
+            {"timestamp":1004.0,"subsystem":"eps","parameter":"voltage","value":"3.6"},
+            {"timestamp":1003.0,"subsystem":"mcu","parameter":"current","value":"4.5"},
+            {"timestamp":1003.0,"subsystem":"eps","parameter":"current","value":"3.5"},
+            {"timestamp":1002.0,"subsystem":"mcu","parameter":"voltage","value":"4.2"},
+            {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"},
+            {"timestamp":1001.0,"subsystem":"mcu","parameter":"current","value":"4.4"},
+            {"timestamp":1001.0,"subsystem":"eps","parameter":"current","value":"3.4"},
+            {"timestamp":1000.0,"subsystem":"mcu","parameter":"voltage","value":"4.3"},
+            {"timestamp":1000.0,"subsystem":"eps","parameter":"voltage","value":"3.3"},
         ])
     );
 }
@@ -167,8 +167,8 @@ fn test_route_filter() {
     assert_eq!(
         entries,
         json!([
-            {"timestamp":1003,"subsystem":"eps","parameter":"current","value":"3.5"},
-            {"timestamp":1001,"subsystem":"eps","parameter":"current","value":"3.4"},
+            {"timestamp":1003.0,"subsystem":"eps","parameter":"current","value":"3.5"},
+            {"timestamp":1001.0,"subsystem":"eps","parameter":"current","value":"3.4"},
         ])
     );
 }
@@ -217,16 +217,16 @@ fn test_route_compress_file() {
     assert_eq!(
         entries,
         json!([
-            {"timestamp":1004,"subsystem":"mcu","parameter":"voltage","value":"4.6"},
-            {"timestamp":1004,"subsystem":"eps","parameter":"voltage","value":"3.6"},
-            {"timestamp":1003,"subsystem":"mcu","parameter":"current","value":"4.5"},
-            {"timestamp":1003,"subsystem":"eps","parameter":"current","value":"3.5"},
-            {"timestamp":1002,"subsystem":"mcu","parameter":"voltage","value":"4.2"},
-            {"timestamp":1002,"subsystem":"eps","parameter":"voltage","value":"3.2"},
-            {"timestamp":1001,"subsystem":"mcu","parameter":"current","value":"4.4"},
-            {"timestamp":1001,"subsystem":"eps","parameter":"current","value":"3.4"},
-            {"timestamp":1000,"subsystem":"mcu","parameter":"voltage","value":"4.3"},
-            {"timestamp":1000,"subsystem":"eps","parameter":"voltage","value":"3.3"},
+            {"timestamp":1004.0,"subsystem":"mcu","parameter":"voltage","value":"4.6"},
+            {"timestamp":1004.0,"subsystem":"eps","parameter":"voltage","value":"3.6"},
+            {"timestamp":1003.0,"subsystem":"mcu","parameter":"current","value":"4.5"},
+            {"timestamp":1003.0,"subsystem":"eps","parameter":"current","value":"3.5"},
+            {"timestamp":1002.0,"subsystem":"mcu","parameter":"voltage","value":"4.2"},
+            {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"},
+            {"timestamp":1001.0,"subsystem":"mcu","parameter":"current","value":"4.4"},
+            {"timestamp":1001.0,"subsystem":"eps","parameter":"current","value":"3.4"},
+            {"timestamp":1000.0,"subsystem":"mcu","parameter":"voltage","value":"4.3"},
+            {"timestamp":1000.0,"subsystem":"eps","parameter":"voltage","value":"3.3"},
         ])
     );
 }

--- a/services/telemetry-service/tests/test_select_all.rs
+++ b/services/telemetry-service/tests/test_select_all.rs
@@ -38,9 +38,9 @@ fn test() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1002,"subsystem":"eps","parameter":"voltage","value":"3.2"},
-                    {"timestamp":1001,"subsystem":"eps","parameter":"voltage","value":"3.4"},
-                    {"timestamp":1000,"subsystem":"eps","parameter":"voltage","value":"3.3"},
+                    {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"},
+                    {"timestamp":1001.0,"subsystem":"eps","parameter":"voltage","value":"3.4"},
+                    {"timestamp":1000.0,"subsystem":"eps","parameter":"voltage","value":"3.3"},
                 ]
             }
         })

--- a/services/telemetry-service/tests/test_udp.rs
+++ b/services/telemetry-service/tests/test_udp.rs
@@ -85,9 +85,9 @@ fn test_udp_timestamp() {
             "errs": "",
             "msg": {
                 "telemetry":[
-                    {"timestamp":1002,"subsystem":"eps","parameter":"voltage","value":"3.2"},
-                    {"timestamp":1001,"subsystem":"eps","parameter":"voltage","value":"3.4"},
-                    {"timestamp":1000,"subsystem":"eps","parameter":"voltage","value":"3.3"},
+                    {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"},
+                    {"timestamp":1001.0,"subsystem":"eps","parameter":"voltage","value":"3.4"},
+                    {"timestamp":1000.0,"subsystem":"eps","parameter":"voltage","value":"3.3"},
                 ]
             }
         })

--- a/test/benchmark/db-test/src/main.rs
+++ b/test/benchmark/db-test/src/main.rs
@@ -41,22 +41,22 @@ fn db_test(config: &Config) {
     let db = Database::new(&db_path);
     db.setup();
 
-    let mut times: Vec<i64> = Vec::new();
+    let mut times: Vec<f64> = Vec::new();
 
     for _ in 0..ITERATIONS {
         let mut rng = thread_rng();
-        let timestamp = rng.gen_range(0, ::std::i32::MAX);
+        let timestamp: f64 = rng.gen_range(0.0, ::std::f64::MAX);
 
         let start = PreciseTime::now();
         if db.insert(timestamp, "db-test", "parameter", "value")
             .is_ok()
         {
-            times.push(start.to(PreciseTime::now()).num_microseconds().unwrap());
+            times.push(start.to(PreciseTime::now()).num_seconds() as f64);
         }
     }
 
-    let num_entries = times.len() as i64;
-    let sum: i64 = times.iter().sum();
+    let num_entries = times.len() as f64;
+    let sum: f64 = times.iter().sum();
 
     let average = sum / num_entries;
 


### PR DESCRIPTION
Milliseconds since unix epoch overflowed the current i32 storage size. GraphQL (and Juniper) doesn't support i64, meaning the next biggest available data size is f64.

As a result, the telem db timestamps have been updated to use fractional seconds