### PR TITLE
Adding bad exit code to Python app example and tutorial

### DIFF
--- a/docs/tutorials/first-mission-app.rst
+++ b/docs/tutorials/first-mission-app.rst
@@ -86,6 +86,7 @@ and then call the appropriate run level function based on the input:
 .. code-block:: python
     
     import argparse
+    import sys
 
     def main():
         parser = argparse.ArgumentParser()
@@ -100,6 +101,7 @@ and then call the appropriate run level function based on the input:
             on_command()
         else:
             print "Unknown run level specified"
+            sys.exit(1)
         
     if __name__ == "__main__":
         main()
@@ -116,6 +118,7 @@ All together, it should look like this:
     #!/usr/bin/env python
     
     import argparse
+    import sys
     
     def on_boot():
         
@@ -138,6 +141,7 @@ All together, it should look like this:
             on_command()
         else:
             print "Unknown run level specified"
+            sys.exit(1)
         
     if __name__ == "__main__":
         main()
@@ -171,6 +175,7 @@ Our new file should look like this:
     #!/usr/bin/env python
     
     import argparse
+    import sys
     
     def on_boot():
         
@@ -199,6 +204,7 @@ Our new file should look like this:
         else:
             errors.write("Unknown run level specified\r\n")
             print "Unknown run level specified"
+            sys.exit(1)
         
     if __name__ == "__main__":
         main()
@@ -400,6 +406,7 @@ After adding error handling, our program should look like this:
 
     import argparse
     import app_api
+    import sys
     
     SERVICES = app_api.Services()
     
@@ -419,7 +426,7 @@ After adding error handling, our program should look like this:
         except Exception as e: 
             file.write("Something went wrong: " + str(e) + "\r\n")
             print "OnCommand logic encountered errors"
-            exit()
+            sys.exit(1)
         
         data = response["memInfo"]
         available = data["available"]
@@ -444,6 +451,7 @@ After adding error handling, our program should look like this:
         else:
             errors.write("Unknown run level specified\r\n")
             print "Unknown run level specified"
+            sys.exit(1)
         
     if __name__ == "__main__":
         main()
@@ -525,6 +533,7 @@ With some additional error handling, our final application looks like this:
     
     import argparse
     import app_api
+    import sys
     
     SERVICES = app_api.Services()
     
@@ -544,7 +553,7 @@ With some additional error handling, our final application looks like this:
         except Exception as e: 
             file.write("Something went wrong: " + str(e) + "\r\n")
             print "OnCommand logic encountered errors"
-            exit()
+            sys.exit(1)
         
         data = response["memInfo"]
         available = data["available"]
@@ -565,7 +574,7 @@ With some additional error handling, our final application looks like this:
         except Exception as e: 
             file.write("Something went wrong: " + str(e) + "\r\n")
             print "OnCommand logic encountered errors"
-            exit()
+            sys.exit(1)
             
         data = response["insert"]
         success = data["success"]
@@ -574,6 +583,7 @@ With some additional error handling, our final application looks like this:
         if success == False:
             file.write("Telemetry insert encountered errors: " + str(errors) + "\r\n")
             print "OnCommand logic encountered errors"
+            sys.exit(1)
         else :
             print "OnCommand logic completed successfully"
     
@@ -590,6 +600,7 @@ With some additional error handling, our final application looks like this:
             on_command()
         else:
             print "Unknown run level specified"
+            sys.exit(1)
         
     if __name__ == "__main__":
         main()

--- a/examples/python-mission-application/mission-app.py
+++ b/examples/python-mission-application/mission-app.py
@@ -19,6 +19,7 @@ without the environment indicator at the top of the file:
 import argparse
 import app_api
 import datetime
+import sys
 import toml
 import time
 
@@ -100,6 +101,7 @@ def on_command(cmd_args):
                 write_log(file, "Sending commands to hardware to normal operation")
         else:
             raise ValueError("Command Integer must be positive and non-zero")
+            sys.exit(1)
                     
     else:
         query = '{ apps { active, app { uuid, name, version, author } } }'
@@ -113,6 +115,7 @@ def on_command(cmd_args):
             with open(COMMANDFILE, 'a+') as file:
                 write_log(file, "Housekeeping caused an error: {},{},{}".format(
                     type(e), e.args, e))
+                sys.exit(1)
         
 
 def main():
@@ -123,7 +126,6 @@ def main():
         '-r',
         '--run',
         nargs=1,
-        default='OnBoot',
         help='Determines run behavior. Either "OnBoot" or "OnCommand"',
         required=True)
     
@@ -150,6 +152,7 @@ def main():
         with open(ERRORSFILE, 'a+') as file:
             write_log(file, "Unknown run level specified")
         print "Unknown run level specified"
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding non-zero exit codes to the example Python mission app and the corresponding tutorial. This will become more important once the app service is capable of checking a started app's return code