### PR TITLE
Adding info about using SLIP connections

### DIFF
--- a/docs/os-docs/using-kubos-linux.rst
+++ b/docs/os-docs/using-kubos-linux.rst
@@ -28,9 +28,10 @@ Board-Specific Documentation
 Communicating with an OBC
 -------------------------
 
-There are currently two primary methods for users to communicate directly with their OBCs:
+There are currently three primary methods for users to communicate directly with their OBCs:
 
     - Via a debug UART port
+    - Via SLIP using a UART port
     - Via an ethernet port (not supported by all boards)
 
 Debug Console
@@ -88,6 +89,54 @@ Fully logged in, the console should look like this:
     Please make sure to either logout of your board, or change it back to the
     root user's home directory before beginning any file transfer
 
+.. _slip:
+    
+SLIP
+~~~~
+
+Using `SLIP <https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol>`__ over a UART port allows
+users to communicate with a target OBC as though it has a normal network connection set up.
+This is most useful for communicating with OBCs which do not provide an ethernet port.
+
+All supported boards include SLIP configuration in their ``/etc/network/interfaces`` file.
+
+In order to communicate with an OBC from the :doc:`Kubos SDK <../sdk-docs/index>`, users will need
+to do the following:
+
+- Connect an FTDI cable to the pins of the UART port (please refer to the UART section of the
+  appropriate `Working with {board}` document for details about the default SLIP UART port for the board)
+
+    - Ground -> Ground
+    - TX -> RX
+    - RX -> TX
+    - RTS -> CTS (Might not be available on all boards/UART ports)
+    - CTS -> RTS (Might not be available on all boards/UART ports)
+    - Vcc -> ignore
+
+- Connect the USB portion of the FTDI cable to the host machine
+- Issue ``ls /dev`` and identify the ``/dev/ttyUSB*`` device associated with the FTDI cable
+- Set up the SLIP device
+
+    - If the UART port has RTS/CTS available, issue the following::
+    
+        $ sudo slattach -s 115200 -p cslip {USB-device} &
+        
+    - Otherwise, issue this command instead::
+    
+        $ sudo slattach -FL -s 115200 -p cslip {USB-device} &
+
+- Define a new network interface for the device::
+
+    $ sudo ifconfig sl0 192.168.0.1 pointopoint 192.168.0.2 up
+    
+- Finally, ensure that the SLIP traffic will be routed to the SDK's host IP::
+
+    $ sudo route add 192.168.0.1 dev lo
+    
+Worth noting, the baud rate, protocol, and IP addresses may all be changed.
+In this case, the corresponding values in the OBC's ``/etc/network/interfaces`` file should also be
+changed to match.
+
 .. _ethernet:
 
 Ethernet
@@ -111,9 +160,9 @@ Once updated, run the following commands in order to make the board use the new 
 The address can be verified by running the ``ipaddr`` command
 
 Communicating via SSH
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~
 
-Once a board has been given a valid IP address, you can create an SSH connection to it.
+Once a board has been given a valid IP address (via ethernet or SLIP), you can create an SSH connection to it.
 
 This can be done from either the SDK or your host machine.
 
@@ -123,7 +172,7 @@ You will be prompted for the `kubos` account password.
 You can also use a tool, like PuTTY, to create an SSH connection.
 
 File Transfer
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 Once the IP address has been set, you can also transfer files to and from the stack using the ``scp`` command.
 Again, this command can be run from either the SDK or your host machine.
@@ -132,6 +181,11 @@ For example, if I wanted to send a file on my host machine, `test.txt`, to resid
 given a stack IP of ``10.50.1.10``, I would enter::
 
     $ scp test.txt kubos@10.50.1.10:/home/kubos
+    
+.. note::
+
+    While file transfer can be done over a SLIP connection, it is significantly faster and more
+    reliable when done over an ethernet connection instead.
 
 User Applications
 -----------------

--- a/docs/os-docs/working-with-the-bbb.rst
+++ b/docs/os-docs/working-with-the-bbb.rst
@@ -341,19 +341,19 @@ UART
 
 The Beaglebone Black has 5 UART ports available for use:
 
-+--------------+--------+--------+---------+---------+
-| Linux Device | TX Pin | RX Pin | RTS Pin | CTS Pin |
-+==============+========+========+=========+=========+
-| /dev/ttyS1   | P9.24  | P9.26  |         |         |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS2   | P9.21  | P9.22  |         |         |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS3   | P9.42  |        | P8.34   | P8.36   |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS4   | P9.13  | P9.11  | P8.33   | P8.35   |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS5   | P8.37  | P8.38  | P8.32   | P8.31   |
-+--------------+--------+--------+---------+---------+
++-------------------+--------+--------+---------+---------+
+| Linux Device      | TX Pin | RX Pin | RTS Pin | CTS Pin |
++===================+========+========+=========+=========+
+| /dev/ttyS1        | P9.24  | P9.26  |         |         |
++-------------------+--------+--------+---------+---------+
+| /dev/ttyS2        | P9.21  | P9.22  |         |         |
++-------------------+--------+--------+---------+---------+
+| /dev/ttyS3        | P9.42  |        | P8.34   | P8.36   |
++-------------------+--------+--------+---------+---------+
+| /dev/ttyS4        | P9.13  | P9.11  | P8.33   | P8.35   |
++-------------------+--------+--------+---------+---------+
+| /dev/ttyS5 (SLIP) | P8.37  | P8.38  | P8.32   | P8.31   |
++-------------------+--------+--------+---------+---------+
 
 .. note:: /dev/ttyS3 (UART3) is TX-only. /dev/ttyS1 and /dev/ttyS2 do not 
     have RTS/CTS due to pin conflicts with other buses.
@@ -380,6 +380,9 @@ The ``cat`` command can be used to read any data from the RX
 pin. For example::
 
     $ cat < /dev/ttyS1
+    
+The ``/dev/ttyS5`` device has be preconfigured to be used for SLIP connections.
+Please refer to the :ref:`SLIP instructions <slip>` for more information.
 
 User Data Partitions
 --------------------

--- a/docs/os-docs/working-with-the-iobc.rst
+++ b/docs/os-docs/working-with-the-iobc.rst
@@ -320,17 +320,20 @@ UART
 
 The iOBC has 2 UART ports available for use in varying capacities:
 
-+--------------+--------+--------+---------+---------+
-| Linux Device | TX Pin | RX Pin | RTS Pin | CTS Pin |
-+==============+========+========+=========+=========+
-| /dev/ttyS1   | TX0    | RX0    |         |         |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS3   | TX2    | RX2    | RTS2    | CTS2    |
-+--------------+--------+--------+---------+---------+
++--------------------+--------+--------+---------+---------+
+| Linux Device       | TX Pin | RX Pin | RTS Pin | CTS Pin |
++====================+========+========+=========+=========+
+| /dev/ttyS1 (SLIP)  | TX0    | RX0    |         |         |
++--------------------+--------+--------+---------+---------+
+| /dev/ttyS3         | TX2    | RX2    | RTS2    | CTS2    |
++--------------------+--------+--------+---------+---------+
 
 Users can interact with these ports using Linux's `termios <http://man7.org/linux/man-pages/man3/termios.3.html>`__ interface.
 
 `A tutorial on this interface can be found here <http://tldp.org/HOWTO/Serial-Programming-HOWTO/x115.html>`__
+
+The ``/dev/ttyS1`` device has be preconfigured to be used for SLIP connections.
+Please refer to the :ref:`SLIP instructions <slip>` for more information.
 
 User Data Partition
 -------------------

--- a/docs/os-docs/working-with-the-mbm2.rst
+++ b/docs/os-docs/working-with-the-mbm2.rst
@@ -287,23 +287,26 @@ UART
 
 The Pumpkin MBM2 has 5 UART ports available for use in varying capacities:
 
-+--------------+--------+--------+---------+---------+
-| Linux Device | TX Pin | RX Pin | RTS Pin | CTS Pin |
-+==============+========+========+=========+=========+
-| /dev/ttyS1   | H1.18  | H1.17  | H1.10   | H1.9    |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS2   | H1.8   | H1.7   |         |         |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS3   | H1.5   |        |         |         |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS4   | H1.16  | H1.15  |         |         |
-+--------------+--------+--------+---------+---------+
-| /dev/ttyS5   | H1.20  | H1.19  | H1.12   | H1.11   |
-+--------------+--------+--------+---------+---------+
++-------------------+--------+--------+---------+---------+
+| Linux Device      | TX Pin | RX Pin | RTS Pin | CTS Pin |
++===================+========+========+=========+=========+
+| /dev/ttyS1        | H1.18  | H1.17  | H1.10   | H1.9    |
++-------------------+--------+--------+---------+---------+
+| /dev/ttyS2        | H1.8   | H1.7   |         |         |
++-------------------+--------+--------+---------+---------+
+| /dev/ttyS3        | H1.5   |        |         |         |
++-------------------+--------+--------+---------+---------+
+| /dev/ttyS4        | H1.16  | H1.15  |         |         |
++-------------------+--------+--------+---------+---------+
+| /dev/ttyS5 (SLIP) | H1.20  | H1.19  | H1.12   | H1.11   |
++-------------------+--------+--------+---------+---------+
 
 Users can interact with these ports using Linux's `termios <http://man7.org/linux/man-pages/man3/termios.3.html>`__ interface.
 
 `A tutorial on this interface can be found here <http://tldp.org/HOWTO/Serial-Programming-HOWTO/x115.html>`__
+
+The ``/dev/ttyS5`` device has be preconfigured to be used for SLIP connections.
+Please refer to the :ref:`SLIP instructions <slip>` for more information.
 
 User Data Partitions
 --------------------


### PR DESCRIPTION
The ability to use SLIP to create a network connection over a UART port has been added to all boards with kubos/kubos-linux-build#134

This PR adds the corresponding doc updates