### PR TITLE
Converting shell service to use syslog for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "example-rust-c-service"
 version = "0.1.0"
 dependencies = [
@@ -1169,7 +1177,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-protocol 0.1.0",
- "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1285,6 +1293,17 @@ dependencies = [
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syslog"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1558,6 +1577,7 @@ dependencies = [
 "checksum diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "164080ac16a4d1d80a50f0a623e4ddef41cb2779eee85bcc76907d340dfc98cc"
 "checksum diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03bcaf77491f53e400d5ee3bdd57142ea4e1c47fe9217b3361ff9a76ca0e3d37"
 "checksum double 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "21d9ba47ea688a92ebe3bb1c19424b51a33fc1b72e719d6d90b7f93d9decfbf9"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum filetime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6f57e64bf5eae62efd4efed005ae81a7115012a61f522bba54542e1a556af921"
@@ -1639,6 +1659,7 @@ dependencies = [
 "checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0641142b4081d3d44beffa4eefd7346a228cdf91ed70186db2ca2cef762d327"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tar 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)" = "89b518542272d9c12195e72885c7a4c142b89226f681bb129e4a922ba1b1ee74"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"

--- a/services/shell-service/Cargo.toml
+++ b/services/shell-service/Cargo.toml
@@ -11,4 +11,4 @@ kubos-system = { path = "../../apis/system-api" }
 log = "^0.4.0"
 serde_cbor = "0.8"
 shell-protocol = { path = "../../libs/shell-protocol" }
-simplelog = "^0.5.0"
+syslog = "4.0"

--- a/services/shell-service/src/lib.rs
+++ b/services/shell-service/src/lib.rs
@@ -23,7 +23,7 @@ extern crate kubos_system;
 extern crate log;
 extern crate serde_cbor;
 extern crate shell_protocol;
-extern crate simplelog;
+extern crate syslog;
 
 use channel_protocol::{ChannelMessage, ChannelProtocol};
 use kubos_system::Config as ServiceConfig;

--- a/services/shell-service/src/main.rs
+++ b/services/shell-service/src/main.rs
@@ -22,32 +22,18 @@ extern crate kubos_system;
 extern crate log;
 extern crate shell_protocol;
 extern crate shell_service;
-extern crate simplelog;
+extern crate syslog;
 
 use kubos_system::Config as ServiceConfig;
 use shell_service::*;
-use simplelog::*;
-use std::fs::File;
+use syslog::Facility;
 
 fn main() {
-    let mut loggers: Vec<Box<SharedLogger>> = vec![];
-    if let Some(l) = TermLogger::new(LevelFilter::Info, Config::default()) {
-        loggers.push(l);
-    }
-
-    // This will panic if the log file fails to open
-    // But I think that is correct
-    loggers.push(WriteLogger::new(
-        LevelFilter::Info,
-        Config::default(),
-        // TODO: Making log file directory configurable
-        File::create("/var/log/kubos-shell-service.log").unwrap(),
-    ));
-
-    match CombinedLogger::init(loggers) {
-        Err(e) => panic!("Logging failed to start {:?}", e),
-        _ => {}
-    }
+    syslog::init(
+        Facility::LOG_DAEMON,
+        log::LevelFilter::Debug,
+        Some("kubos-shell-service"),
+    ).unwrap();
 
     let config = ServiceConfig::new("shell-service");
 


### PR DESCRIPTION
This is my plan for how all the services will be updated to use syslog for logging.

Worth noting, this does remove the terminal logger component. This behavior can be re-added by the user by setting up a logging policy which routes the messages to the console (or some similar policy):
`daemon.*    /dev/console`