### PR TITLE
Updating GraphQL responses to match spec

### DIFF
--- a/apis/app-api/rust/src/query.rs
+++ b/apis/app-api/rust/src/query.rs
@@ -95,7 +95,7 @@ pub fn query(
 
     let v: serde_json::Value = serde_json::from_slice(&buf[0..(amt)])?;
 
-    if let Some(errs) = v.get("errs") {
+    if let Some(errs) = v.get("errors") {
         if errs.is_string() {
             let errs_str = errs.as_str().unwrap();
             if errs_str.len() > 0 {
@@ -123,10 +123,10 @@ pub fn query(
         _ => {}
     }
 
-    match v.get("msg") {
+    match v.get("data") {
         Some(result) => Ok(result.clone()),
         None => Err(format_err!(
-            "No result returned in 'msg' key: {}",
+            "No result returned in 'data' key: {}",
             serde_json::to_string(&v).unwrap()
         )),
     }

--- a/services/app-service/src/tests/register_app.rs
+++ b/services/app-service/src/tests/register_app.rs
@@ -62,8 +62,8 @@ fn register_good() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": {
                       "active": true,
@@ -114,8 +114,8 @@ fn register_no_manifest() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": null,
                    "errors": "Failed to register app: Exactly two files should be present in the app directory",
@@ -170,8 +170,8 @@ fn register_extra_file() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": null,
                    "errors": "Failed to register app: Exactly two files should be present in the app directory",
@@ -222,8 +222,8 @@ fn register_no_name() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": null,
                    "errors": "Failed to parse manifest.toml: missing field `name`",
@@ -274,8 +274,8 @@ fn register_no_version() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": null,
                    "errors": "Failed to parse manifest.toml: missing field `version`",
@@ -326,8 +326,8 @@ fn register_no_author() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": null,
                    "errors": "Failed to parse manifest.toml: missing field `author`",
@@ -360,8 +360,8 @@ fn register_bad_path() {
     }"#;
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": null,
                    "errors": "Failed to register app: fake/files does not exist",

--- a/services/app-service/src/tests/registry_start_app.rs
+++ b/services/app-service/src/tests/registry_start_app.rs
@@ -79,6 +79,7 @@ fn start_app_good() {
     // the system finishes calling it
     thread::sleep(Duration::from_millis(10));
 
+    eprintln!("Result: {:?}", result);
     assert!(result.is_ok());
 }
 

--- a/services/app-service/src/tests/upgrade_app.rs
+++ b/services/app-service/src/tests/upgrade_app.rs
@@ -64,8 +64,8 @@ fn upgrade_new() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": {
                       "active": true,
@@ -122,8 +122,8 @@ fn upgrade_good() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": {
                       "active": true,
@@ -151,8 +151,8 @@ fn upgrade_good() {
     fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": {
                       "active": true,
@@ -176,8 +176,8 @@ fn upgrade_good() {
     "#;
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "apps": [
                  {
                       "active": false,
@@ -243,8 +243,8 @@ fn upgrade_new_name() {
     );
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": {
                       "active": true,
@@ -278,8 +278,8 @@ fn upgrade_new_name() {
     fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "register": {
                    "entry": {
                       "active": true,
@@ -303,8 +303,8 @@ fn upgrade_new_name() {
     "#;
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                "apps": [
                  {
                       "active": false,

--- a/services/file-service/tests/upload.rs
+++ b/services/file-service/tests/upload.rs
@@ -215,6 +215,9 @@ fn upload_bad_hash() {
     );
     assert!(result.is_ok());
     let hash = result.unwrap();
+    
+    // Give the service a moment to go through its cleanup logic before we mess with things
+    thread::sleep(Duration::from_millis(10));
 
     // Create temp folder with bad chunk so that future hash calculation will fail
     fs::create_dir(format!("service/storage/{}", hash)).unwrap();

--- a/services/isis-ants-service/src/tests/mod.rs
+++ b/services/isis-ants-service/src/tests/mod.rs
@@ -101,8 +101,8 @@ impl IAntS for MockAntS {
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                        "msg": $result,
-                        "errs": ""
+                        "data": $result,
+                        "errors": ""
                 }).to_string()
     }};
 }

--- a/services/kubos-service/src/service.rs
+++ b/services/kubos-service/src/service.rs
@@ -184,11 +184,15 @@ where
                     .collect();
 
                 json!({
-                    "msg": val,
-                    "errs": errs_msg})
+                    "data": val,
+                    "errors": errs_msg})
                     .to_string()
             }
-            Err(e) => serde_json::to_string(&e).unwrap(),
+            Err(e) => {
+                json!({
+                    "errors": e
+                }).to_string()
+            }
         }
     }
 }

--- a/services/mai400-service/src/tests/read.rs
+++ b/services/mai400-service/src/tests/read.rs
@@ -67,8 +67,8 @@ fn read_panic() {
     });
 
     let expected = json!({
-                "msg": expected,
-                "errs": ""
+                "data": expected,
+                "errors": ""
         }).to_string();
 
     assert_eq!(service.process(query.to_owned()), expected);

--- a/services/mai400-service/src/tests/schema.rs
+++ b/services/mai400-service/src/tests/schema.rs
@@ -27,8 +27,8 @@ use tests::test_data::*;
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                                    "msg": $result,
-                                    "errs": ""
+                                    "data": $result,
+                                    "errors": ""
                             }).to_string()
     }};
 }

--- a/services/novatel-oem6-service/src/tests/schema/mod.rs
+++ b/services/novatel-oem6-service/src/tests/schema/mod.rs
@@ -25,8 +25,8 @@ use std::sync::mpsc::sync_channel;
 macro_rules! wrap {
     ($result:ident) => {{
         json!({
-                                    "msg": $result,
-                                    "errs": ""
+                                    "data": $result,
+                                    "errors": ""
                             }).to_string()
     }};
 }

--- a/services/telemetry-service/tests/test_delete.rs
+++ b/services/telemetry-service/tests/test_delete.rs
@@ -57,8 +57,8 @@ fn test_delete_ge() {
         }"#;
 
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "delete": {
                     "entriesDeleted": 7,
                     "errors": "",
@@ -77,8 +77,8 @@ fn test_delete_ge() {
             }
         }"#;
     let query_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {
                     "timestamp": 1003.0,
@@ -135,8 +135,8 @@ fn test_delete_le() {
         }"#;
 
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "delete": {
                     "entriesDeleted": 9,
                     "errors": "",
@@ -155,8 +155,8 @@ fn test_delete_le() {
             }
         }"#;
     let query_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {
                     "timestamp": 1010.0,
@@ -201,8 +201,8 @@ fn test_delete_range() {
         }"#;
 
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "delete": {
                     "entriesDeleted": 9,
                     "errors": "",
@@ -221,8 +221,8 @@ fn test_delete_range() {
             }
         }"#;
     let query_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {
                     "timestamp": 1010.0,
@@ -267,8 +267,8 @@ fn test_delete_subsystem() {
         }"#;
 
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "delete": {
                     "entriesDeleted": 4,
                     "errors": "",
@@ -285,8 +285,8 @@ fn test_delete_subsystem() {
             }
         }"#;
     let query_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {
                     "timestamp": 1010.0,
@@ -347,8 +347,8 @@ fn test_delete_parameter() {
         }"#;
 
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "delete": {
                     "entriesDeleted": 6,
                     "errors": "",
@@ -365,8 +365,8 @@ fn test_delete_parameter() {
             }
         }"#;
     let query_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {
                     "timestamp": 1010.0,

--- a/services/telemetry-service/tests/test_empty_db.rs
+++ b/services/telemetry-service/tests/test_empty_db.rs
@@ -29,8 +29,8 @@ fn test() {
     assert_eq!(
         res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry":[]
             }
         })

--- a/services/telemetry-service/tests/test_filter_parameter.rs
+++ b/services/telemetry-service/tests/test_filter_parameter.rs
@@ -35,8 +35,8 @@ fn test() {
     assert_eq!(
         res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {"parameter":"voltage","value":"3.4"},
                     {"parameter":"voltage","value":"3.3"}

--- a/services/telemetry-service/tests/test_filter_subsystem.rs
+++ b/services/telemetry-service/tests/test_filter_subsystem.rs
@@ -38,8 +38,8 @@ fn test() {
     assert_eq!(
         res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry":[
                     {"timestamp":1010.0,"subsystem":"gps","parameter":"x_position","value":"-1.0"}
                 ]

--- a/services/telemetry-service/tests/test_filter_timestamp.rs
+++ b/services/telemetry-service/tests/test_filter_timestamp.rs
@@ -50,8 +50,8 @@ fn test_ge() {
     assert_eq!(
         ge_res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {"value":"3.8"},
                     {"value":"3.7"}
@@ -79,8 +79,8 @@ fn test_le() {
     assert_eq!(
         le_res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {"value":"3.5"},
                     {"value":"3.4"},
@@ -112,8 +112,8 @@ fn test_range() {
     assert_eq!(
         range_res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {"value":"3.6"},
                     {"value":"3.5"},
@@ -145,8 +145,8 @@ fn test_single() {
     assert_eq!(
         single_res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                     {"value":"3.6"},
                 ]

--- a/services/telemetry-service/tests/test_insert.rs
+++ b/services/telemetry-service/tests/test_insert.rs
@@ -44,8 +44,8 @@ fn test_insert_auto_timestamp() {
             }
         }"#;
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "insert": {
                     "errors": "",
                     "success": true
@@ -62,8 +62,8 @@ fn test_insert_auto_timestamp() {
             }
         }"#;
     let query_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [{
                     "subsystem": "test2",
                     "parameter": "voltage",
@@ -97,8 +97,8 @@ fn test_insert_custom_timestamp() {
             }
         }"#;
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "insert": {
                     "errors": "",
                     "success": true
@@ -116,8 +116,8 @@ fn test_insert_custom_timestamp() {
             }
         }"#;
     let query_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [{
                     "timestamp": 5.0,
                     "subsystem": "test2",
@@ -146,8 +146,8 @@ fn test_insert_multi_auto() {
     let (handle, sender) = setup(Some(db), Some(port), Some(udp), None);
 
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "insert": {
                     "errors": "",
                     "success": true
@@ -184,8 +184,8 @@ fn test_insert_multi_auto() {
             }
         }"#;
     let query_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry": [
                 {
                     "subsystem": "eps",
@@ -244,8 +244,8 @@ fn test_insert_current_timestamp() {
         }}"#, now);
     
     let mutation_expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "insert": {
                     "errors": "",
                     "success": true
@@ -266,7 +266,7 @@ fn test_insert_current_timestamp() {
 
     assert_eq!(mutation_result, mutation_expected);
     
-    let timestamp = query_result["msg"]["telemetry"][0]["timestamp"].as_f64().unwrap();
+    let timestamp = query_result["data"]["telemetry"][0]["timestamp"].as_f64().unwrap();
     
     // The original f64 value gets converted to a string and then back to f64.
     // This is notoriously complicated and frequently results in discrepencies.

--- a/services/telemetry-service/tests/test_limit.rs
+++ b/services/telemetry-service/tests/test_limit.rs
@@ -46,8 +46,8 @@ fn test() {
     assert_eq!(
         res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry":[
                     {"timestamp":1010.0,"subsystem":"eps","parameter":"voltage","value":"2.4"},
                     {"timestamp":1009.0,"subsystem":"eps","parameter":"voltage","value":"2.5"},

--- a/services/telemetry-service/tests/test_route.rs
+++ b/services/telemetry-service/tests/test_route.rs
@@ -117,8 +117,8 @@ fn test_route_response() {
     fs::remove_file(output_path).unwrap();
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "routedTelemetry": "output"
             }
         });
@@ -259,8 +259,8 @@ fn test_route_compress_response() {
     fs::remove_file(&format!("{}.tar.gz", output_path)).unwrap();
 
     let expected = json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "routedTelemetry": "output.tar.gz"
             }
         });

--- a/services/telemetry-service/tests/test_select_all.rs
+++ b/services/telemetry-service/tests/test_select_all.rs
@@ -35,8 +35,8 @@ fn test() {
     assert_eq!(
         res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry":[
                     {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"},
                     {"timestamp":1001.0,"subsystem":"eps","parameter":"voltage","value":"3.4"},

--- a/services/telemetry-service/tests/test_udp.rs
+++ b/services/telemetry-service/tests/test_udp.rs
@@ -82,8 +82,8 @@ fn test_udp_timestamp() {
     assert_eq!(
         res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry":[
                     {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"},
                     {"timestamp":1001.0,"subsystem":"eps","parameter":"voltage","value":"3.4"},
@@ -152,8 +152,8 @@ fn test_udp_no_timestamp() {
     assert_eq!(
         res,
         json!({
-            "errs": "",
-            "msg": {
+            "errors": "",
+            "data": {
                 "telemetry":[
                     {"subsystem":"test4","parameter":"current","value":"2.2"},
                     {"subsystem":"test3","parameter":"current","value":"2.1"},


### PR DESCRIPTION
Updating our GraphQL responses to [match the spec](https://facebook.github.io/graphql/June2018/#sec-Response-Format)

- "msg" -> "data"
- "errs" -> "errors"
- Updated the case where an error is hit before any data is generated to return the errors array in an object, rather than just an array