### PR TITLE
Allowing multiple files to be present in app registry dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,11 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +582,7 @@ name = "kubos-app-service"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-app 0.1.0",
@@ -1601,6 +1607,7 @@ dependencies = [
 "checksum flate2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0c7353385f92079524de3b7116cf99d73947c08a7472774e9b3b04bff3b901"
 "checksum float-cmp 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "08117a43ef6d98f44f38cadd33b996d2322bf460422fceccb4fa03930ca231f0"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"

--- a/docs/app-docs/app-guide.rst
+++ b/docs/app-docs/app-guide.rst
@@ -11,6 +11,9 @@ In order to be compatible with the applications service, mission applications mu
 
 Once an application has been built, it should be transferred to the system, along with its manifest, and then :ref:`registered with the applications service <register-app>`.
 
+For projects written in languages like Python, where there is no executable file, multiple files
+may be used for the application.
+
 APIs
 ----
 
@@ -87,7 +90,7 @@ In order for the applications service to properly maintain versioning informatio
 
 This file must have the following key values:
 
-- ``name`` - The name of the application
+- ``name`` - The name of the application which will be called for execution
 - ``version`` - The version number of the application
 - ``author`` - The author of the application
 
@@ -96,6 +99,11 @@ For example::
     name = "mission-app"
     version = "1.1"
     author = "Me"
+
+.. note::
+
+    The ``name`` parameter must exactly match the name of the file which should be called for
+    execution
 
 Additional Resources
 --------------------

--- a/docs/app-docs/app-service.rst
+++ b/docs/app-docs/app-service.rst
@@ -9,7 +9,8 @@ The Kubos applications service is responsible for monitoring and managing all mi
     
     TODO: User/App/Service interaction diagram
 
-Whenever a new application is registered with the service, its path and manifest file are copied into the service's application registry.
+Whenever a new application is registered with the service, its manifest file and all other files in
+the specified directory are copied into the service's application registry.
 By default, this registry is stored under `/home/system/kubos/apps`.
 
 Each application will be automatically assigned a UUID to be used for identification purposes internally.
@@ -105,7 +106,9 @@ Once an application has been written and compiled, the application and its accom
 should be transferred to a new directory on the OBC.
 This file transfer can be done using the :doc:`file transfer service <../services/file>`.
 
-The application and manifest *must* be the only files in the directory.
+The application may be split into multiple files (which is useful for large Python apps), however,
+the name of the initial file which should be called for execution must exactly match the ``name``
+property in the manifest file.
 
 It can then be registered with the applications service using the ``register`` mutation by specifying
 the directory containing the application files.

--- a/services/app-service/Cargo.toml
+++ b/services/app-service/Cargo.toml
@@ -8,6 +8,7 @@ kubos-app = { path = "../../apis/app-api/rust" }
 kubos-service = { path = "../kubos-service" }
 
 failure = "0.1.2"
+fs_extra = "1.1.0"
 getopts = "0.2"
 juniper =  "0.9.2"
 log = "^0.4.0"

--- a/services/app-service/src/main.rs
+++ b/services/app-service/src/main.rs
@@ -17,6 +17,7 @@
 
 #[macro_use]
 extern crate failure;
+extern crate fs_extra;
 extern crate getopts;
 #[macro_use]
 extern crate juniper;
@@ -56,7 +57,7 @@ fn main() -> Result<(), Error> {
         log::LevelFilter::Debug,
         Some("kubos-app-service"),
     ).unwrap();
-        
+
     let args: Vec<String> = env::args().collect();
     let mut opts = Options::new();
 

--- a/services/app-service/src/tests/register_app.rs
+++ b/services/app-service/src/tests/register_app.rs
@@ -118,63 +118,7 @@ fn register_no_manifest() {
             "msg": {
                "register": {
                    "entry": null,
-                   "errors": "Failed to register app: Exactly two files should be present in the app directory",
-                   "success": false,
-               }
-            }
-        }).to_string();
-
-    assert_eq!(service.process(register_query.to_owned()), expected);
-}
-
-#[test]
-fn register_extra_file() {
-    let registry_dir = TempDir::new().unwrap();
-    let service = mock_service!(registry_dir);
-
-    let app_dir = TempDir::new().unwrap();
-    let app_bin = app_dir.path().join("dummy-app");
-
-    fs::create_dir(app_bin.clone()).unwrap();
-
-    // Create dummy app file
-    fs::File::create(app_bin.join("dummy")).unwrap();
-
-    // Create extra app file
-    fs::File::create(app_bin.join("extra")).unwrap();
-
-    // Create manifest file
-    let manifest = r#"
-            name = "dummy"
-            version = "0.0.1"
-            author = "user"
-            "#;
-    fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
-
-    let register_query = format!(
-        r#"mutation {{
-        register(path: "{}") {{
-            success,
-            errors,
-            entry {{
-                active, 
-                app {{
-                    name,
-                    version,
-                    author
-                }}
-            }}
-        }}
-    }}"#,
-        app_bin.to_str().unwrap()
-    );
-
-    let expected = json!({
-            "errs": "",
-            "msg": {
-               "register": {
-                   "entry": null,
-                   "errors": "Failed to register app: Exactly two files should be present in the app directory",
+                   "errors": "IO Error: No such file or directory (os error 2)",
                    "success": false,
                }
             }
@@ -227,6 +171,59 @@ fn register_no_name() {
                "register": {
                    "entry": null,
                    "errors": "Failed to parse manifest.toml: missing field `name`",
+                   "success": false,
+               }
+            }
+        }).to_string();
+
+    assert_eq!(service.process(register_query.to_owned()), expected);
+}
+
+#[test]
+fn register_bad_name() {
+    let registry_dir = TempDir::new().unwrap();
+    let service = mock_service!(registry_dir);
+
+    let app_dir = TempDir::new().unwrap();
+    let app_bin = app_dir.path().join("dummy-app");
+
+    fs::create_dir(app_bin.clone()).unwrap();
+
+    // Create dummy app file
+    fs::File::create(app_bin.join("dummy")).unwrap();
+
+    // Create manifest file
+    let manifest = r#"
+            name = "fake"
+            version = "0.0.1"
+            author = "user"
+            "#;
+    fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
+
+    let register_query = format!(
+        r#"mutation {{
+        register(path: "{}") {{
+            success,
+            errors,
+            entry {{
+                active, 
+                app {{
+                    name,
+                    version,
+                    author
+                }}
+            }}
+        }}
+    }}"#,
+        app_bin.to_str().unwrap()
+    );
+
+    let expected = json!({
+            "errs": "",
+            "msg": {
+               "register": {
+                   "entry": null,
+                   "errors": "Failed to register app: Application file fake not found in given path",
                    "success": false,
                }
             }


### PR DESCRIPTION
Currently, the app service expects exactly two files to be present in the directory used to register an application: the `manifest.toml` file and the executable.

For Python applications, there is no executable, so it's entirely likely that users will want to register an application with more than one file.

This PR changes the registration logic to copy the entire contents of the directory specified when registering an app