### PR TITLE
Moving communications settings into main toml file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,8 +208,11 @@ dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -312,6 +315,7 @@ version = "0.1.0"
 dependencies = [
  "comms-service 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/libs/comms-service/Cargo.toml
+++ b/libs/comms-service/Cargo.toml
@@ -8,5 +8,8 @@ failure = "0.1.3"
 pnet = "0.21.0"
 juniper =  "0.9.2"
 byteorder = "1.2.7"
+serde = "1.0"
+serde_derive = "1.0"
 toml = "0.4.10"
 log = "^0.4.0"
+kubos-system = { path = "../../apis/system-api" }

--- a/libs/comms-service/src/config.rs
+++ b/libs/comms-service/src/config.rs
@@ -19,11 +19,6 @@
 //! TOML parser for the `comms-service`. This module parses a `toml` file and returns a
 //! struct containing configuration information for a `comms-service`.
 
-use failure::Error;
-use std::fs::File;
-use std::io::Read;
-use toml::*;
-
 // Default values for control block configurations.
 const DEFAULT_HANDLER_START: u16 = 13100;
 const DEFAULT_HANDLER_END: u16 = 13149;
@@ -33,7 +28,7 @@ static DEFAULT_SATELLITE_IP: &str = "192.168.8.2";
 
 /// A struct that holds useful configuration options to use in a `comms-service` implementation.
 /// Created by parsing a configuration file in the `toml` file format.
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 pub struct CommsConfig {
     /// Starting port used to define a range of ports that are used in the message handlers
     /// that handle messages received from the ground.
@@ -71,93 +66,8 @@ impl Default for CommsConfig {
 
 impl CommsConfig {
     /// Builds a new configuration for a specific `comms-service`.
-    pub fn new(name: &str, path: String) -> Self {
-        Self::parse_file(name, path).unwrap_or(CommsConfig::default())
+    pub fn new(service_config: kubos_system::Config) -> Self {
+        let config = service_config.get("comms").and_then(|raw| raw.try_into().ok());
+        config.unwrap_or_default()
     }
-
-    // Function used to parse configuration files.
-    fn parse_file(name: &str, path: String) -> ConfigResult<CommsConfig> {
-        // Read file to string.
-        let mut contents = String::new();
-        let mut file = File::open(path)?;
-        file.read_to_string(&mut contents)?;
-
-        // Read contents and place into TOML table.
-        let table: Value = toml::from_str(&contents)?;
-        let mut config = CommsConfig::default();
-
-        // Go through TOML table and replace default if provided.
-        if let Some(service) = table.get(name) {
-            // Get the integer values from TOML file.
-            if let Ok(num) = get_number_u16("handler-port-min", &service) {
-                config.handler_port_min = num;
-            }
-            if let Ok(num) = get_number_u16("handler-port-max", &service) {
-                config.handler_port_max = num;
-            }
-            if let Ok(num) = get_number_u64("timeout", &service) {
-                config.timeout = num;
-            }
-            if let Some(num) = get_number_u16("ground-port", &service).ok() {
-                config.ground_port = Some(num);
-            }
-
-            // Get the `downlink_ports` TOML array.
-            if let Some(array) = service.get("downlink-ports") {
-                if let Some(vector) = array.as_array() {
-                    let mut ports = vec![];
-                    for item in vector {
-                        if let Some(val) = item.as_integer() {
-                            ports.push(val as u16);
-                        }
-                    }
-                    config.downlink_ports = Some(ports);
-                }
-            }
-
-            // Pull strings from the TOML file.
-            if let Some(ground_ip) = service.get("ground-ip") {
-                if let Some(val) = ground_ip.as_str() {
-                    config.ground_ip = val.to_string();
-                }
-            }
-            if let Some(satellite_ip) = service.get("satellite-ip") {
-                if let Some(val) = satellite_ip.as_str() {
-                    config.satellite_ip = val.to_string()
-                }
-            }
-        }
-        Ok(config)
-    }
-}
-
-// Helper function to get a `u16` from a TOML table.
-fn get_number_u16(key: &str, table: &Value) -> ConfigResult<u16> {
-    if let Some(val) = table.get(key) {
-        if let Some(num) = val.as_integer() {
-            return Ok(num as u16);
-        }
-    }
-    Err(ConfigError::IntegerParsing.into())
-}
-
-// Helper function to get a `u64` from a TOML table.
-fn get_number_u64(key: &str, table: &Value) -> ConfigResult<u64> {
-    if let Some(val) = table.get(key) {
-        if let Some(num) = val.as_integer() {
-            return Ok(num as u64);
-        }
-    }
-    Err(ConfigError::IntegerParsing.into())
-}
-
-/// Result returned when creating a `CommsConfig` struct.
-pub type ConfigResult<T> = Result<T, Error>;
-
-/// This enum defines all errors that can occur during configuration parsing.
-#[derive(Fail, Debug, PartialEq)]
-pub enum ConfigError {
-    /// Failure occured during the parsing of integers from the TOML table.
-    #[fail(display = "Unable to parse integers from the configuration file")]
-    IntegerParsing,
 }

--- a/libs/comms-service/src/lib.rs
+++ b/libs/comms-service/src/lib.rs
@@ -39,12 +39,8 @@
 //! let read_conn = Arc::new(UdpSocket::bind(("192.168.8.1", 13000)).unwrap());
 //! let write_conn = Arc::new(UdpSocket::bind(("192.168.8.1", 13001)).unwrap());
 //!
-//! // Putting everything into the control block.
-//! let controls = CommsControlBlock {
-//!     read: Some(Arc::new(read)),
-//!     write: vec![Arc::new(write)],
-//!     read_conn,
-//!     write_conn,
+//! // Setting up the communication settings.
+//! let config = CommsConfig {
 //!     handler_port_min: 13002,
 //!     handler_port_max: 13099,
 //!     timeout: 1500,
@@ -52,6 +48,15 @@
 //!     satellite_ip: Ipv4Addr::new(192, 168, 8, 1),
 //!     downlink_ports: Some(vec![13011]),
 //!     ground_port: Some(9001)
+//! }
+//!
+//! // Putting everything into the control block.
+//! let controls = CommsControlBlock {
+//!     read: Some(Arc::new(read)),
+//!     write: vec![Arc::new(write)],
+//!     read_conn,
+//!     write_conn,
+//!     config
 //! };
 //!
 //! // Get telemetry from communication service.
@@ -64,7 +69,7 @@
 //! ## Comms Service Config File Format
 //!
 //! ```toml
-//! [service-name]
+//! [service-name.comms]
 //! handler_port_min = 13002
 //! handler_port_max = 13010
 //! downlink_ports = [13011]
@@ -82,6 +87,8 @@ extern crate juniper;
 #[macro_use]
 extern crate log;
 extern crate pnet;
+#[macro_use]
+extern crate serde_derive;
 extern crate toml;
 
 mod config;

--- a/libs/comms-service/src/lib.rs
+++ b/libs/comms-service/src/lib.rs
@@ -48,7 +48,7 @@
 //!     satellite_ip: Ipv4Addr::new(192, 168, 8, 1),
 //!     downlink_ports: Some(vec![13011]),
 //!     ground_port: Some(9001)
-//! }
+//! };
 //!
 //! // Putting everything into the control block.
 //! let controls = CommsControlBlock {

--- a/libs/comms-service/src/lib.rs
+++ b/libs/comms-service/src/lib.rs
@@ -39,25 +39,18 @@
 //! let read_conn = Arc::new(UdpSocket::bind(("192.168.8.1", 13000)).unwrap());
 //! let write_conn = Arc::new(UdpSocket::bind(("192.168.8.1", 13001)).unwrap());
 //!
-//! // Setting up the communication settings.
-//! let config = CommsConfig {
-//!     handler_port_min: 13002,
-//!     handler_port_max: 13099,
-//!     timeout: 1500,
-//!     ground_ip: Ipv4Addr::new(192, 168, 8, 40),
-//!     satellite_ip: Ipv4Addr::new(192, 168, 8, 1),
-//!     downlink_ports: Some(vec![13011]),
-//!     ground_port: Some(9001)
-//! };
+//! // Fetching communications settings from the common config.toml file.
+//! let service_config = kubos_system::Config::new("service-name");
+//! let comms_config = CommsConfig::new(service_config);
 //!
 //! // Putting everything into the control block.
-//! let controls = CommsControlBlock {
-//!     read: Some(Arc::new(read)),
-//!     write: vec![Arc::new(write)],
+//! let controls = CommsControlBlock::new(
+//!     Some(Arc::new(read)),
+//!     vec![Arc::new(write)],
 //!     read_conn,
 //!     write_conn,
-//!     config
-//! };
+//!     comms_config
+//! );
 //!
 //! // Get telemetry from communication service.
 //! let telem = Arc::new(Mutex::new(CommsTelemetry::default()));

--- a/services/ethernet-service/Cargo.toml
+++ b/services/ethernet-service/Cargo.toml
@@ -6,5 +6,6 @@ authors = ["William Greer <wgreer184@gmail.com>"]
 [dependencies]
 failure = "0.1.3"
 comms-service = { path = "../../libs/comms-service" }
+kubos-system = { path = "../../apis/system-api" }
 log = "^0.4.0"
 syslog = "4.0"

--- a/services/ethernet-service/src/comms.rs
+++ b/services/ethernet-service/src/comms.rs
@@ -20,8 +20,6 @@ use comms_service::{CommsConfig, CommsResult};
 use std::net::UdpSocket;
 use std::sync::Arc;
 
-use super::CONFIG_PATH;
-
 // Function to allow reading from a UDP socket.
 pub fn read(socket: Arc<UdpSocket>) -> CommsResult<Vec<u8>> {
     let mut buf = [0; 4096];
@@ -31,7 +29,9 @@ pub fn read(socket: Arc<UdpSocket>) -> CommsResult<Vec<u8>> {
 
 // Function to allow writing over a UDP socket.
 pub fn write(socket: Arc<UdpSocket>, data: &[u8]) -> CommsResult<()> {
-    let config = CommsConfig::new("ethernet-service", CONFIG_PATH.to_string());
+    let service_config = kubos_system::Config::new("ethernet-service");
+    let config = CommsConfig::new(service_config);
+    
     socket.send_to(
         data,
         (&*config.ground_ip, config.ground_port.unwrap_or_default()),

--- a/services/ethernet-service/src/main.rs
+++ b/services/ethernet-service/src/main.rs
@@ -40,8 +40,6 @@ use syslog::Facility;
 
 mod comms;
 
-// Path to configuration file.
-const CONFIG_PATH: &'static str = "comms.toml";
 // Read port for the socket used in the 'read' function.
 const READ_PORT: u16 = 13000;
 // Write port for the socket used in the 'write' function.
@@ -59,9 +57,12 @@ fn main() -> EthernetServiceResult<()> {
     )
     .unwrap();
 
-    // Read configuration from config file.
-    let config = CommsConfig::new("ethernet-service", CONFIG_PATH.to_string());
-
+    // Get the main service configuration from the system's config.toml file
+    let service_config = kubos_system::Config::new("ethernet-service");
+    
+    // Pull out our communication settings
+    let config = CommsConfig::new(service_config);
+    
     // Create socket to mock reading from a radio.
     let read_conn = Arc::new(UdpSocket::bind((config.satellite_ip.as_str(), READ_PORT))?);
 


### PR DESCRIPTION
Currently the communication service library expects the comms settings to be established in a custom config.toml file

This PR updates the library to use the standard config.toml file provided by the `kubos-system` crate (apis/system-api)

Also updates the config reading logic to take advantage of `Deserialize` to convert the `toml::Value` into a `CommsConfig` structure, rather than needing to explicitly parse all the args