### PR TITLE
Fixing duplicate telemetry service test file name

### DIFF
--- a/services/telemetry-service/tests/test_route.rs
+++ b/services/telemetry-service/tests/test_route.rs
@@ -243,7 +243,7 @@ fn test_route_compress_response() {
     let (handle, sender) = setup(Some(db), Some(port), Some(udp), Some(SQL));
 
     // Use a file that won't have a randomly generated path
-    let output_path = "output";
+    let output_path = "compressed-output";
 
     let query = format!(
         r#"{{
@@ -261,7 +261,7 @@ fn test_route_compress_response() {
     let expected = json!({
         "errors": "",
         "data": {
-            "routedTelemetry": "output.tar.gz"
+            "routedTelemetry": "compressed-output.tar.gz"
         }
     });
 


### PR DESCRIPTION
Two of the tests in `services/telemetry-service/tests/test_route.rs` use a non-temporary file with the same name. This file is then removed at the end of each test so that it can be repeatable.

This is causing problems when run by CircleCI (some sort of timing problem. I was unable to reproduce it locally).

This PR fixes the test cases so they each have a unique test file