### PR TITLE
Fixing Rust UART HAL doc link

### DIFF
--- a/docs/apis/kubos-hal/uart-hal/rust-uart.rst
+++ b/docs/apis/kubos-hal/uart-hal/rust-uart.rst
@@ -4,5 +4,5 @@ UART Using Rust
 Please refer to the |uart-api| crate documentation for implementation details
 
  .. |uart-api| raw:: html
- 
-    <a href="../rust-docs/rust_uart/index.html" target="_blank">Rust UART API</a>
+
+    <a href="../../../rust-docs/rust_uart/index.html" target="_blank">Rust UART API</a>


### PR DESCRIPTION
The rust uart hal doc link available [here](https://docs.kubos.com/1.11.0/apis/kubos-hal/uart-hal/rust-uart.html) is broken. Fixing it