### PR TITLE
Converting TRXVU yotta config options to run-time arguments

### DIFF
--- a/apis/isis-trxvu-api/isis-trxvu-api/trxvu.h
+++ b/apis/isis-trxvu-api/isis-trxvu-api/trxvu.h
@@ -23,83 +23,6 @@
 
 #include <math.h>
 
-/**
- *  @name Radio config.json configuration options and default values
- */
-/**@{*/
-/**
- * I2C bus the TRXVU radio is connected to
- */
-#ifdef YOTTA_CFG_RADIO_TRXVU_I2C_BUS
-#define TRXVU_I2C_BUS YOTTA_CFG_RADIO_TRXVU_I2C_BUS
-#else
-#define TRXVU_I2C_BUS "/dev/i2c-0"
-#endif
-
-/**
- * Transmitter I2C address
- */
-#ifdef YOTTA_CFG_RADIO_TRXVU_TX_ADDR
-#define RADIO_TX_ADDR YOTTA_CFG_RADIO_TRXVU_TX_ADDR
-#else
-#define RADIO_TX_ADDR 0x61
-#endif
-
-/**
- * Receiver I2C address
- */
-#ifdef YOTTA_CFG_RADIO_TRXVU_RX_ADDR
-#define RADIO_RX_ADDR YOTTA_CFG_RADIO_TRXVU_RX_ADDR
-#else
-#define RADIO_RX_ADDR 0x60
-#endif
-
-/**
- * Transmitter maximum message size
- */
-#ifdef YOTTA_CFG_RADIO_TRXVU_TX_MAX_PAYLOAD
-#define TX_MAX_SIZE YOTTA_CFG_RADIO_TRXVU_TX_MAX_PAYLOAD
-#else
-#define TX_MAX_SIZE 235
-#endif
-
-/**
- * Receiver maximum message size
- */
-#ifdef YOTTA_CFG_RADIO_TRXVU_RX_MAX_PAYLOAD
-#define RX_MAX_SIZE YOTTA_CFG_RADIO_TRXVU_RX_MAX_PAYLOAD
-#else
-#define RX_MAX_SIZE 200
-#endif
-
-/**
- * Transmitter buffer slots
- */
-#ifdef YOTTA_CFG_RADIO_TRXVU_TX_MAX_FRAMES
-#define TX_MAX_FRAMES YOTTA_CFG_RADIO_TRXVU_TX_MAX_FRAMES
-#else
-#define TX_MAX_FRAMES 40
-#endif
-
-/**
- * Receive buffer slots
- */
-#ifdef YOTTA_CFG_RADIO_TRXVU_RX_MAX_FRAMES
-#define RX_MAX_FRAMES YOTTA_CFG_RADIO_TRXVU_RX_MAX_FRAMES
-#else
-#define RX_MAX_FRAMES 40
-#endif
-
-/**
- * Watchdog timeout (in seconds)
- */
-#ifdef YOTTA_CFG_RADIO_TRXVU_WATCHDOG_TIMEOUT
-#define TRXVU_WD_TIMEOUT YOTTA_CFG_RADIO_TRXVU_WATCHDOG_TIMEOUT
-#else
-#define TRXVU_WD_TIMEOUT 60
-#endif
-/**@}*/
-
 /** \cond WE DO NOT WANT TO HAVE THESE IN OUR GENERATED DOCS */
 /* Radio command values */
 /* Note: There are some duplicate command values between the TX and RX MCUs */
@@ -124,8 +47,6 @@
 #define HARD_RESET                  0xAB
 #define WATCHDOG_RESET              0xCC
 /** \endcond */
-
-int radio_bus;
 
 /**
  * Radio function return values
@@ -194,6 +115,16 @@ typedef enum {
     RADIO_STATE_RATE_4800     =  0x02,    /**< Transmitter sending at 4800bps */
     RADIO_STATE_RATE_9600     =  0x03     /**< Transmitter sending at 9600bps */
 } RadioTXState;
+
+/**
+ * TX/RX properties
+ */
+typedef struct
+{
+    uint8_t addr;       /**< I2C address of component */
+    uint16_t max_size;  /**< Maximum frame message size */
+    uint16_t max_frames; /**< Maximum number of frames that can be in the buffer */
+} trx_prop;
 
 /**
  * Transmitter raw telemetry fields returned from ::RADIO_TX_TELEM_ALL and ::RADIO_TX_TELEM_LAST requests
@@ -282,8 +213,7 @@ typedef struct
     uint16_t msg_size;              /**< Size of the frame payload */
     uint16_t doppler_offset;        /**< ADC value of doppler shift at receive time (convert with ::get_doppler_offset)*/
     uint16_t signal_strength;       /**< ADC value of signal strength at receive time (convert with ::get_signal_strength)*/
-    uint8_t message[RX_MAX_SIZE];   /**< Frame payload */
-} radio_rx_message;
+} radio_rx_header;
 
 /*
  * Public Functions
@@ -381,7 +311,7 @@ inline float get_rf_power_mw(uint16_t raw) {return raw * raw * powf(10, -2) * 0.
  * Initialize the radio interface
  * @return KRadioStatus RADIO_OK if OK, error otherwise
  */
-KRadioStatus k_radio_init(void);
+KRadioStatus k_radio_init(char * bus, trx_prop tx, trx_prop rx, uint16_t timeout);
 /**
  * Terminate the radio interface
  */
@@ -414,7 +344,7 @@ KRadioStatus k_radio_send(char * buffer, int len, uint8_t * response);
  * @param [out] len Length of the received message
  * @return KRadioStatus RADIO_OK if a message was received successfully, RADIO_RX_EMPTY if there are no messages to receive, error otherwise
  */
-KRadioStatus k_radio_recv(radio_rx_message * buffer, uint8_t * len);
+KRadioStatus k_radio_recv(radio_rx_header * frame, uint8_t * message, uint8_t * len);
 /**
  * Read radio telemetry values
  * @note See specific radio API documentation for available telemetry types
@@ -506,7 +436,7 @@ KRadioStatus kprv_radio_rx_remove_frame(void);
  * @param[out] len Pointer to storage are for length of frame payload
  * @return KRadioStatus `RADIO_OK` if OK, error otherwise
  */
-KRadioStatus kprv_radio_rx_get_frame(radio_rx_message * buffer, uint8_t * len);
+KRadioStatus kprv_radio_rx_get_frame(radio_rx_header * frame, uint8_t * message, uint8_t * len);
 /**
  * Get telemetry from receiver
  *
@@ -526,5 +456,9 @@ KRadioStatus kprv_radio_rx_watchdog_kick(void);
  * @return KRadioStatus `RADIO_OK` if OK, error otherwise
  */
 KRadioStatus kprv_radio_rx_reset(KRadioReset type);
+
+int radio_bus;
+trx_prop radio_tx;
+trx_prop radio_rx;
 
 /* @} */

--- a/apis/isis-trxvu-api/isis-trxvu-api/trxvu.h
+++ b/apis/isis-trxvu-api/isis-trxvu-api/trxvu.h
@@ -309,6 +309,10 @@ inline float get_rf_power_mw(uint16_t raw) {return raw * raw * powf(10, -2) * 0.
 
 /**
  * Initialize the radio interface
+ * @param [in] bus The I2C bus device the radio is connected to
+ * @param [in] tx The transmitter's properties
+ * @param [in] rx The receiver's properties
+ * @param [in] timeout The radio's watchdog timeout (in seconds)
  * @return KRadioStatus RADIO_OK if OK, error otherwise
  */
 KRadioStatus k_radio_init(char * bus, trx_prop tx, trx_prop rx, uint16_t timeout);
@@ -340,7 +344,8 @@ KRadioStatus k_radio_reset(KRadioReset type);
 KRadioStatus k_radio_send(char * buffer, int len, uint8_t * response);
 /**
  * Receive a message from the radio's receive buffer
- * @param [in] buffer Pointer where the message should be copied to
+ * @param [out] frame Pointer where the header properties should be stored
+ * @param [out] message Pointer to where the message payload should be stored
  * @param [out] len Length of the received message
  * @return KRadioStatus RADIO_OK if a message was received successfully, RADIO_RX_EMPTY if there are no messages to receive, error otherwise
  */
@@ -432,8 +437,9 @@ KRadioStatus kprv_radio_rx_get_count(uint8_t * count);
 KRadioStatus kprv_radio_rx_remove_frame(void);
 /**
  * Retrieve oldest frame from receive buffer
- * @param[out] buffer Pointer to storage area for frame
- * @param[out] len Pointer to storage are for length of frame payload
+ * @param [out] frame Pointer where the header properties should be stored
+ * @param [out] message Pointer to where the message payload should be stored
+ * @param [out] len Pointer to storage are for length of frame payload
  * @return KRadioStatus `RADIO_OK` if OK, error otherwise
  */
 KRadioStatus kprv_radio_rx_get_frame(radio_rx_header * frame, uint8_t * message, uint8_t * len);

--- a/apis/isis-trxvu-api/source/radio_core.c
+++ b/apis/isis-trxvu-api/source/radio_core.c
@@ -26,6 +26,11 @@ trx_prop radio_rx;
 
 KRadioStatus k_radio_init(char * bus, trx_prop tx, trx_prop rx, uint16_t timeout)
 {
+    if (bus == NULL)
+    {
+        return RADIO_ERROR_CONFIG;
+    }
+
     KI2CStatus status;
     status = k_i2c_init(bus, &radio_bus);
     if (status != I2C_OK)

--- a/apis/isis-trxvu-api/source/radio_rx.c
+++ b/apis/isis-trxvu-api/source/radio_rx.c
@@ -17,10 +17,11 @@
 #include <kubos-hal/i2c.h>
 #include <isis-trxvu-api/trxvu.h>
 #include <stdio.h>
+#include <string.h>
 
-KRadioStatus k_radio_recv(radio_rx_message * buffer, uint8_t * len)
+KRadioStatus k_radio_recv(radio_rx_header * frame, uint8_t * message, uint8_t * len)
 {
-    if (buffer == NULL)
+    if (frame == NULL || message == NULL)
     {
         return RADIO_ERROR_CONFIG;
     }
@@ -46,7 +47,7 @@ KRadioStatus k_radio_recv(radio_rx_message * buffer, uint8_t * len)
         return RADIO_RX_EMPTY;
     }
 
-    status = kprv_radio_rx_get_frame(buffer, len);
+    status = kprv_radio_rx_get_frame(frame, message, len);
     if (status != RADIO_OK)
     {
         fprintf(stderr, "Failed to receive frame from radio\n");
@@ -91,7 +92,7 @@ KRadioStatus kprv_radio_rx_get_telemetry(radio_telem *  buffer,
     }
 
     KI2CStatus status
-        = k_i2c_write(radio_bus, RADIO_RX_ADDR, (uint8_t *) &cmd, 1);
+        = k_i2c_write(radio_bus, radio_rx.addr, (uint8_t *) &cmd, 1);
 
     if (status != I2C_OK)
     {
@@ -100,7 +101,7 @@ KRadioStatus kprv_radio_rx_get_telemetry(radio_telem *  buffer,
         return RADIO_ERROR;
     }
 
-    status = k_i2c_read(radio_bus, RADIO_RX_ADDR, (char *) buffer, len);
+    status = k_i2c_read(radio_bus, radio_rx.addr, (char *) buffer, len);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to retrieve radio RX telemetry type %d: %d\n",
@@ -116,7 +117,7 @@ KRadioStatus kprv_radio_rx_watchdog_kick(void)
     uint8_t cmd = WATCHDOG_RESET;
 
     KI2CStatus status
-        = k_i2c_write(radio_bus, RADIO_RX_ADDR, (uint8_t *) &cmd, 1);
+        = k_i2c_write(radio_bus, radio_rx.addr, (uint8_t *) &cmd, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to kick radio RX watchdog: %d\n", status);
@@ -144,7 +145,7 @@ KRadioStatus kprv_radio_rx_reset(KRadioReset type)
             return RADIO_ERROR_CONFIG;
     }
 
-    status = k_i2c_write(radio_bus, RADIO_RX_ADDR, (uint8_t *) &cmd, 1);
+    status = k_i2c_write(radio_bus, radio_rx.addr, (uint8_t *) &cmd, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to reset RX radio: %d\n", status);
@@ -164,14 +165,14 @@ KRadioStatus kprv_radio_rx_get_count(uint8_t * count)
     uint8_t    cmd = GET_RX_FRAME_COUNT;
     KI2CStatus status;
 
-    status = k_i2c_write(radio_bus, RADIO_RX_ADDR, (uint8_t *) &cmd, 1);
+    status = k_i2c_write(radio_bus, radio_rx.addr, (uint8_t *) &cmd, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to request radio frame count: %d\n", status);
         return RADIO_ERROR;
     }
 
-    status = k_i2c_read(radio_bus, RADIO_RX_ADDR, count, 2);
+    status = k_i2c_read(radio_bus, radio_rx.addr, count, 2);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to read radio frame count: %d\n", status);
@@ -186,7 +187,7 @@ KRadioStatus kprv_radio_rx_remove_frame(void)
     uint8_t    cmd = REMOVE_RX_FRAME;
     KI2CStatus status;
 
-    status = k_i2c_write(radio_bus, RADIO_RX_ADDR, (uint8_t *) &cmd, 1);
+    status = k_i2c_write(radio_bus, radio_rx.addr, (uint8_t *) &cmd, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to remove radio frame: %d\n", status);
@@ -196,9 +197,9 @@ KRadioStatus kprv_radio_rx_remove_frame(void)
     return RADIO_OK;
 }
 
-KRadioStatus kprv_radio_rx_get_frame(radio_rx_message * buffer, uint8_t * len)
+KRadioStatus kprv_radio_rx_get_frame(radio_rx_header * frame, uint8_t * message, uint8_t * len)
 {
-    if (buffer == NULL)
+    if (frame == NULL || message == NULL)
     {
         return RADIO_ERROR_CONFIG;
     }
@@ -207,26 +208,38 @@ KRadioStatus kprv_radio_rx_get_frame(radio_rx_message * buffer, uint8_t * len)
 
     KI2CStatus status;
 
-    status = k_i2c_write(radio_bus, RADIO_RX_ADDR, (uint8_t *) &cmd, 1);
+    status = k_i2c_write(radio_bus, radio_rx.addr, (uint8_t *) &cmd, 1);
     if (status != I2C_OK)
     {
-        fprintf(stderr, "Failed to request radio RX frame's length: %d\n",
+        fprintf(stderr, "Failed to request radio RX frame: %d\n",
                 status);
         return RADIO_ERROR;
     }
 
-    status = k_i2c_read(radio_bus, RADIO_RX_ADDR, (char *) buffer,
-                        sizeof(radio_rx_message));
+    uint8_t * buffer = malloc(sizeof(radio_rx_header) + radio_rx.max_size);
+
+    status = k_i2c_read(radio_bus, radio_rx.addr, (char *) buffer,
+            sizeof(radio_rx_header) + radio_rx.max_size);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to read radio RX frame: %d\n", status);
+        free(buffer);
         return RADIO_ERROR;
     }
 
+    radio_rx_header * temp = (radio_rx_header *) buffer;
+
+    frame->msg_size = temp->msg_size;
+    frame->doppler_offset = temp->doppler_offset;
+    frame->signal_strength = temp->signal_strength;
+
+    memcpy(message, buffer+sizeof(radio_rx_header), frame->msg_size);
+
     if (len != NULL)
     {
-        *len = buffer->msg_size;
+        *len = frame->msg_size;
     }
 
+    free(buffer);
     return RADIO_OK;
 }

--- a/apis/isis-trxvu-api/source/radio_tx.c
+++ b/apis/isis-trxvu-api/source/radio_tx.c
@@ -24,17 +24,19 @@
 /* Send a message to the transmission buffer */
 KRadioStatus k_radio_send(char * buffer, int len, uint8_t * response)
 {
-    char packet[TX_MAX_SIZE + 1] = { 0 };
-    packet[0]                    = SEND_FRAME;
-
-    if (buffer == NULL || len < 1 || len > TX_MAX_SIZE || response == NULL)
+    if (buffer == NULL || len < 1 || len > radio_tx.max_size || response == NULL)
     {
         return RADIO_ERROR_CONFIG;
     }
 
+    char * packet   = malloc(len + 1);
+    packet[0]       = SEND_FRAME;
+
     memcpy(packet + 1, buffer, len);
 
-    KI2CStatus status = k_i2c_write(radio_bus, RADIO_TX_ADDR, packet, len + 1);
+    KI2CStatus status = k_i2c_write(radio_bus, radio_tx.addr, packet, len + 1);
+    free(packet);
+
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to send radio TX frame: %d\n", status);
@@ -42,7 +44,7 @@ KRadioStatus k_radio_send(char * buffer, int len, uint8_t * response)
     }
 
     /* Read number of remaining TX buffer slots available */
-    status = k_i2c_read(radio_bus, RADIO_TX_ADDR, response, 1);
+    status = k_i2c_read(radio_bus, radio_tx.addr, response, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to read radio TX slots remaining: %d\n",
@@ -59,20 +61,22 @@ KRadioStatus k_radio_send_override(ax25_callsign to, ax25_callsign from,
                                    char * buffer, int len, uint8_t * response)
 {
 
-    if (buffer == NULL || len < 1 || len > TX_MAX_SIZE || response == NULL)
+    if (buffer == NULL || len < 1 || len > radio_tx.max_size || response == NULL)
     {
         return RADIO_ERROR_CONFIG;
     }
 
-    char packet[TX_MAX_SIZE + 15] = { 0 };
-    packet[0]                     = SEND_AX25_OVERRIDE;
+    char * packet   = malloc(len + 15);
+    packet[0]       = SEND_AX25_OVERRIDE;
 
     memcpy(packet + 1, &to, sizeof(ax25_callsign));
     memcpy(packet + 8, &from, sizeof(ax25_callsign));
     memcpy(packet + 15, buffer, len);
 
-    KI2CStatus status = k_i2c_write(radio_bus, RADIO_TX_ADDR, packet,
+    KI2CStatus status = k_i2c_write(radio_bus, radio_tx.addr, packet,
                                     len + sizeof(ax25_callsign) * 2 + 1);
+    free(packet);
+
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to send radio TX frame (override): %d\n",
@@ -81,7 +85,7 @@ KRadioStatus k_radio_send_override(ax25_callsign to, ax25_callsign from,
     }
 
     /* Read number of remaining TX buffer slots available */
-    status = k_i2c_read(radio_bus, RADIO_TX_ADDR, response, 1);
+    status = k_i2c_read(radio_bus, radio_tx.addr, response, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to read radio TX slots remaining: %d\n",
@@ -103,7 +107,7 @@ KRadioStatus k_radio_set_beacon_override(ax25_callsign to, ax25_callsign from,
     }
 
     KI2CStatus status;
-    char       packet[TX_MAX_SIZE + sizeof(ax25_callsign) * 2 + 3] = { 0 };
+    char * packet   = malloc(beacon.len + sizeof(ax25_callsign) * 2 + 3);
     packet[0] = SET_AX25_BEACON_OVERRIDE;
 
     memcpy(packet + 1, (void *) &beacon.interval, sizeof(beacon.interval));
@@ -111,8 +115,11 @@ KRadioStatus k_radio_set_beacon_override(ax25_callsign to, ax25_callsign from,
     memcpy(packet + 10, &from, sizeof(ax25_callsign));
     memcpy(packet + 17, beacon.msg, beacon.len);
 
-    status = k_i2c_write(radio_bus, RADIO_TX_ADDR, packet,
+    status = k_i2c_write(radio_bus, radio_tx.addr, packet,
                          beacon.len + sizeof(ax25_callsign) * 2 + 3);
+
+    free(packet);
+
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to set radio TX beacon (override): %d\n",
@@ -129,7 +136,7 @@ KRadioStatus k_radio_clear_beacon(void)
     KI2CStatus status;
     uint8_t    cmd = CLEAR_BEACON;
 
-    status = k_i2c_write(radio_bus, RADIO_TX_ADDR, (uint8_t *) &cmd, 1);
+    status = k_i2c_write(radio_bus, radio_tx.addr, (uint8_t *) &cmd, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to clear radio TX beacon: %d\n", status);
@@ -177,7 +184,7 @@ KRadioStatus kprv_radio_tx_get_telemetry(radio_telem *  buffer,
     }
 
     KI2CStatus status
-        = k_i2c_write(radio_bus, RADIO_TX_ADDR, (uint8_t *) &cmd, 1);
+        = k_i2c_write(radio_bus, radio_tx.addr, (uint8_t *) &cmd, 1);
 
     if (status != I2C_OK)
     {
@@ -185,7 +192,7 @@ KRadioStatus kprv_radio_tx_get_telemetry(radio_telem *  buffer,
         return RADIO_ERROR;
     }
 
-    status = k_i2c_read(radio_bus, RADIO_TX_ADDR, (char *) buffer, len);
+    status = k_i2c_read(radio_bus, radio_tx.addr, (char *) buffer, len);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to read radio TX telemetry: %d\n", status);
@@ -200,7 +207,7 @@ KRadioStatus kprv_radio_tx_watchdog_kick(void)
     KI2CStatus status;
     uint8_t    cmd = WATCHDOG_RESET;
 
-    status = k_i2c_write(radio_bus, RADIO_TX_ADDR, (uint8_t *) &cmd, 1);
+    status = k_i2c_write(radio_bus, radio_tx.addr, (uint8_t *) &cmd, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to kick radio TX watchdog: %d\n", status);
@@ -228,7 +235,7 @@ KRadioStatus kprv_radio_tx_reset(KRadioReset type)
             return RADIO_ERROR_CONFIG;
     }
 
-    status = k_i2c_write(radio_bus, RADIO_TX_ADDR, (uint8_t *) &cmd, 1);
+    status = k_i2c_write(radio_bus, radio_tx.addr, (uint8_t *) &cmd, 1);
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to reset TX radio: %d\n", status);
@@ -246,13 +253,16 @@ KRadioStatus kprv_radio_tx_set_beacon(uint16_t rate, char * buffer, int len)
         return RADIO_ERROR_CONFIG;
     }
 
-    char packet[TX_MAX_SIZE + 3] = { 0 };
-    packet[0]                    = SET_BEACON;
+    char * packet   = malloc(len + 3);
+    packet[0]       = SET_BEACON;
 
     memcpy(packet + 1, (void *) &rate, 2);
     memcpy(packet + 3, buffer, len);
 
-    KI2CStatus status = k_i2c_write(radio_bus, RADIO_TX_ADDR, packet, len + 3);
+    KI2CStatus status = k_i2c_write(radio_bus, radio_tx.addr, packet, len + 3);
+
+    free(packet);
+
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to set radio TX beacon: %d\n", status);
@@ -270,7 +280,7 @@ KRadioStatus kprv_radio_tx_set_default_to(ax25_callsign to)
     memcpy(packet + 1, &to, sizeof(ax25_callsign));
 
     KI2CStatus status
-        = k_i2c_write(radio_bus, RADIO_TX_ADDR, packet, sizeof(packet));
+        = k_i2c_write(radio_bus, radio_tx.addr, packet, sizeof(packet));
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to set radio TX destination callsign: %d\n",
@@ -289,7 +299,7 @@ KRadioStatus kprv_radio_tx_set_default_from(ax25_callsign from)
     memcpy(packet + 1, &from, sizeof(ax25_callsign));
 
     KI2CStatus status
-        = k_i2c_write(radio_bus, RADIO_TX_ADDR, packet, sizeof(packet));
+        = k_i2c_write(radio_bus, radio_tx.addr, packet, sizeof(packet));
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to set radio TX sender callsign: %d\n", status);
@@ -318,7 +328,7 @@ KRadioStatus kprv_radio_tx_set_idle(RadioIdleState state)
     }
 
     KI2CStatus status
-        = k_i2c_write(radio_bus, RADIO_TX_ADDR, packet, sizeof(packet));
+        = k_i2c_write(radio_bus, radio_tx.addr, packet, sizeof(packet));
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to set radio TX idle state: %d\n", status);
@@ -336,7 +346,7 @@ KRadioStatus kprv_radio_tx_set_rate(RadioTXRate rate)
     packet[1]      = (uint8_t) rate;
 
     KI2CStatus status
-        = k_i2c_write(radio_bus, RADIO_TX_ADDR, packet, sizeof(packet));
+        = k_i2c_write(radio_bus, radio_tx.addr, packet, sizeof(packet));
     if (status != I2C_OK)
     {
         fprintf(stderr, "Failed to set radio TX data rate: %d\n", status);

--- a/test/integration/linux/isis-trxvu/radio-test/source/main.c
+++ b/test/integration/linux/isis-trxvu/radio-test/source/main.c
@@ -19,6 +19,7 @@
 
 #include <errno.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -34,6 +35,9 @@
             exit(-1);            \
         }                        \
     })
+
+#define RX_SIZE 200
+#define TX_SIZE 235
 
 KRadioStatus get_tx_telem()
 {
@@ -242,10 +246,12 @@ KRadioStatus send_override()
 KRadioStatus read_message()
 {
     KRadioStatus status;
-    radio_rx_message buffer;
+    radio_rx_header header;
+    uint8_t message[RX_SIZE];
+
     uint8_t len;
 
-    status = k_radio_recv(&buffer, &len);
+    status = k_radio_recv(&header, message, &len);
     if (status == RADIO_RX_EMPTY)
     {
         printf("No messages to receive\n");
@@ -253,8 +259,8 @@ KRadioStatus read_message()
     else if (status == RADIO_OK)
     {
         printf("Received message(%d %fHz %fdBm): %s\n",
-                len, get_doppler_offset(buffer.doppler_offset), get_signal_strength(buffer.signal_strength),
-                buffer.message);
+                len, get_doppler_offset(header.doppler_offset), get_signal_strength(header.signal_strength),
+                message);
     }
     else
     {
@@ -269,21 +275,22 @@ KRadioStatus set_options()
     radio_config config = {0};
     char beacon_msg[] = "Radio Beacon Message";
     char option[1] = {0};
+    int rc;
 
     printf("Set new 'to' callsign? (y/n)\n");
-    scanf("%s", option);
+    rc = scanf("%s", option);
 
     if (option[0] == 'y' || option[0] == 'Y')
     {
-        strcpy(config.to.ascii,"MJRTOM");
+        strncpy(config.to.ascii,"MJRTOM", 6);
     }
 
     printf("Set new 'from' callsign? (y/n)\n");
-    scanf("%s", option);
+    rc = scanf("%s", option);
 
     if (option[0] == 'y' || option[0] == 'Y')
     {
-        strcpy(config.from.ascii,"HMLTN1");
+        strncpy(config.from.ascii,"HMLTN1", 6);
     }
 
     printf("Enter a data rate: \n\t"
@@ -292,7 +299,7 @@ KRadioStatus set_options()
             "3 - 4800\n\t"
             "4 - 9600\n\t"
             "5 - Don't change data rate\n\t");
-    scanf("%s", option);
+    rc = scanf("%s", option);
 
     switch (option[0])
     {
@@ -313,7 +320,7 @@ KRadioStatus set_options()
     }
 
     printf("Turn on beacon? (y/n)\n");
-    scanf("%s", option);
+    rc = scanf("%s", option);
 
     if (option[0] == 'y' || option[0] == 'Y')
     {
@@ -323,7 +330,7 @@ KRadioStatus set_options()
     }
 
     printf("Idle On? (y/n/*)\n");
-    scanf("%s", option);
+    rc = scanf("%s", option);
 
     if (option[0] == 'y' || option[0] == 'Y')
     {
@@ -364,8 +371,20 @@ int main(int argc, char * argv[])
     action.sa_handler = sigint_handler;
     sigaction(SIGINT, &action, NULL);
 
+
+    trx_prop tx = {
+            .addr = 0x60,
+            .max_size = TX_SIZE,
+            .max_frames = 40,
+    };
+    trx_prop rx = {
+                .addr = 0x61,
+                .max_size = RX_SIZE,
+                .max_frames = 40,
+    };
+
     KRadioStatus status;
-    status = k_radio_init();
+    status = k_radio_init("/dev/i2c-0", tx, rx, 10);
     check_status();
 
     status = k_radio_watchdog_start();
@@ -375,7 +394,7 @@ int main(int argc, char * argv[])
     while (running)
     {
         printf("Enter a command option (enter 'h' to see list of commands): \n");
-        scanf("%s", option);
+        int rc = scanf("%s", option);
 
         switch (option[0])
         {


### PR DESCRIPTION
The TRXVU API is the last place where the old YOTTA_CONFIG_* options are used. Converting them to run-time arguments instead