### PR TITLE
Migrating to Python3

### DIFF
--- a/apis/app-api/python/app_api.py
+++ b/apis/app-api/python/app_api.py
@@ -50,15 +50,15 @@ class Services:
         if service not in self.config:
             raise KeyError(
                 "Service name invalid. Check config file for service names.")
-        if type(query) not in [str, unicode]:
-            raise TypeError("Query must be str or unicode.")
+        if type(query) not in [str, bytes]:
+            raise TypeError("Query must be str or bytes.")
 
         # Lookup port/ip
         ip = self.config[service]["addr"]["ip"]
         port = self.config[service]["addr"]["port"]
 
         # Talk to the server
-        response = self._udp_query(query, (ip, port), timeout)
+        response = self._udp_query(query, ip, port, timeout)
 
         # Format the response and detect errors
         (data, errors) = self._format(response, service)
@@ -70,7 +70,7 @@ class Services:
 
         return data
 
-    def _udp_query(self, query, (ip, port), timeout):
+    def _udp_query(self, query, ip, port, timeout):
         # Set up the socket
         sock = socket.socket(socket.AF_INET,  # Internet
                              socket.SOCK_DGRAM)  # UDP
@@ -95,8 +95,8 @@ class Services:
         except Exception as e:
             print("Response was unable to be parsed as JSON.")
             print("It is likely incomplete or the endpoint is misbehaving")
-            print("response: ", response)
-            print("error: ", e)
+            print("response: {}".format(response))
+            print("error: {}".format(e))
             raise
 
         # Check that it follows GraphQL format

--- a/examples/pumpkin-mcu-api-example/example_mcu_api.py
+++ b/examples/pumpkin-mcu-api-example/example_mcu_api.py
@@ -22,35 +22,35 @@ MODULES = {
 # Sending commands
 module = "sim"
 address = MODULES[module]['address']
-print('\nModule: ' + module)
-print('Address: ' + str(address))
+print('\nModule: {}'.format(module))
+print('Address: {}'.format(str(address)))
 mcu = mcu_api.MCU(address=address)
 turn_led_on_cmd = "SUP:LED ON"
 turn_led_off_cmd = "SUP:LED OFF"
-print mcu.write(turn_led_on_cmd)
+print(mcu.write(turn_led_on_cmd))
 time.sleep(3)
-print mcu.write(turn_led_off_cmd)
+print(mcu.write(turn_led_off_cmd))
 
 # Read a selection of telemetry items
 module = "sim"
 address = MODULES[module]['address']
 fields = ["firmware_version", "commands_parsed", "scpi_errors", "time"]
-print('\nModule: ' + module)
-print('Address: ' + str(address))
-print('Fields: ' + str(fields) + '\n')
+print('\nModule: {}'.format(module))
+print('Address: {}'.format(str(address)))
+print('Fields: {}\n'.format(str(fields)))
 mcu = mcu_api.MCU(address=address)
 out = mcu.read_telemetry(module=module, fields=fields)
 for field in out:
-    print(field, out[field])
+    print("{}{}".format(field, out[field]))
 
 
 # Read all telemetry from all modules
 for module in MODULES:
     module = str(module)
     address = MODULES[module]['address']
-    print('\nModule: ' + module)
-    print('Address: ' + str(address) + '\n')
+    print('\nModule: {}'.format(module))
+    print('Address: {}\n'.format(str(address)))
     mcu = mcu_api.MCU(address=address)
     out = mcu.read_telemetry(module=module)
     for field in out:
-        print(field, out[field])
+        print("{}{}".format(field, out[field]))

--- a/examples/python-service/service.py
+++ b/examples/python-service/service.py
@@ -13,6 +13,7 @@ import logging
 from service import schema
 from kubos_service.config import Config
 from logging.handlers import SysLogHandler
+import sys
 
 config = Config("example-service")
 
@@ -24,6 +25,11 @@ formatter = logging.Formatter('example-service: %(message)s')
 handler.formatter = formatter
 logger.addHandler(handler)
 
+# Set up a handler for logging to stdout
+stdout = logging.StreamHandler(stream=sys.stdout)
+stdout.setFormatter(formatter)
+logger.addHandler(stdout)
+
 # from kubos_service import http_service
 # Start an http service
 # http_service.start(config, schema.schema)
@@ -34,4 +40,4 @@ from kubos_service import udp_service
 # udp_service.start(config, schema, {'bus': '/dev/ttyS3'})
 
 # Start a udp service
-udp_service.start(config, schema)
+udp_service.start(logger, config, schema)

--- a/examples/python-service/service/app.py
+++ b/examples/python-service/service/app.py
@@ -10,7 +10,7 @@ Boilerplate Flask setup for service application.
 
 from flask import Flask
 from flask_graphql import GraphQLView
-from schema import schema
+from .schema import schema
 
 
 def create_app():

--- a/examples/python-service/service/models.py
+++ b/examples/python-service/service/models.py
@@ -24,7 +24,7 @@ class Subsystem(graphene.ObjectType):
         model based on queries to the actual hardware.
         """
 
-        print "Querying for subsystem status"
+        print("Querying for subsystem status")
         self.power_on = not self.power_on
 
     def set_power_on(self, power_on):
@@ -32,9 +32,9 @@ class Subsystem(graphene.ObjectType):
         Controls the power state of the subsystem
         """
 
-        print "Sending new power state to subsystem"
-        print "Previous State: %s" % self.power_on
-        print "New State: %s" % power_on
+        print("Sending new power state to subsystem")
+        print("Previous State: {}".format(self.power_on))
+        print("New State: {}".format(power_on))
         self.power_on = power_on
         return Status(status=True, subsystem=self)
 

--- a/examples/python-service/service/schema.py
+++ b/examples/python-service/service/schema.py
@@ -9,7 +9,7 @@ Graphene schema setup to enable queries.
 """
 
 import graphene
-from models import Status, Subsystem
+from .models import Status, Subsystem
 
 # Local subsystem instance for tracking state
 # May not be neccesary when tied into actual hardware

--- a/libs/kubos-service/kubos_service/udp_service.py
+++ b/libs/kubos-service/kubos_service/udp_service.py
@@ -14,8 +14,7 @@ import json
 import logging
 
 
-def start(config, schema, context={}):
-    logger = logging.getLogger(config.name)
+def start(logger, config, schema, context={}):
     logger.info("{} starting on {}:{}".format(config.name, config.ip, config.port))
     sock = socket.socket(socket.AF_INET,  # Internet
                          socket.SOCK_DGRAM)  # UDP
@@ -28,12 +27,12 @@ def start(config, schema, context={}):
             errs = None
             msg = None
             try:
-                result = base_schema.execute(data, context_value=context)
+                result = base_schema.execute(data.decode(), context_value=context)
                 msg = result.data
                 if result.errors:
                     errs = []
                     for e in result.errors:
-                        errs.append(e.message)
+                        errs.append(str(e))
 
             except Exception as e:
                 errs = "Exception encountered {}".format(e)
@@ -42,6 +41,6 @@ def start(config, schema, context={}):
                 "data": msg,
                 "errors": errs
             })
-            sock.sendto(result, source)
+            sock.sendto(str.encode(result), source)
         except Exception as e:
             logging.error("Exception encountered {}".format(e))


### PR DESCRIPTION
Migrating all the application-related code and our boiler-plate service code to Python3.5 (this is what's included with our current version of BuildRoot). I tested the new code against both Python3.5 and our current Python2.7 and it seems like the new code is backwards-compatible.

Most of the changes are just updating the `print` syntax.

Most notable is the way strings are declared/handled:
- Python 2.7 `str` -> 3.5 `bytes`
- 2.7 `unicode` -> 3.5 `str`
- `bytes` in 2.7 is just an alias to `str`
- `unicode` does not exist at all in 3.5

The mission app examples didn't need to be updated

Also, tweaking the kubos service framework to correctly set up logging