### PR TITLE
Added CI cross compiling checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       steps:
         - checkout
         - run: ./tools/kubos_link.py
-        - run: cargo kubos -c check -t  kubos-linux-pumpkin-mbm2-gcc
+        - run: CC=/usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc cargo kubos -c check -t  kubos-linux-pumpkin-mbm2-gcc
 
     # Run for all PR commits
     rust_check_iobc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,24 @@ jobs:
         - run: ./tools/kubos_link.py
         - run: cargo kubos -c check
 
+    # Run for all PR commits
+    rust_check_mbm2:
+      docker:
+        - image: kubos/kubos-dev:latest
+      steps:
+        - checkout
+        - run: ./tools/kubos_link.py
+        - run: cargo kubos -c check -t  kubos-linux-pumpkin-mbm2-gcc
+
+    # Run for all PR commits
+    rust_check_iobc:
+      docker:
+        - image: kubos/kubos-dev:latest
+      steps:
+        - checkout
+        - run: ./tools/kubos_link.py
+        - run: CC=/usr/bin/iobc_toolchain/usr/bin/arm-linux-gcc cargo kubos -c check -t kubos-linux-isis-gcc
+
     # Rust testing
     # Run for all PR commits
     rust_test:
@@ -80,6 +98,14 @@ workflows:
   build:
     jobs:
       - rust_check_x86:
+          filters:
+            branches:
+              ignore: master
+      - rust_check_mbm2:
+          filters:
+            branches:
+              ignore: master
+      - rust_check_iobc:
           filters:
             branches:
               ignore: master


### PR DESCRIPTION
This will add `cargo check` for the mbm2 and iobc targets to our CI.