### PR TITLE
Adding pkg-config to Docker

### DIFF
--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -7,6 +7,7 @@ MAINTAINER catherine@kubos.com, ryan@kubos.com
 RUN apt-get update -y
 
 RUN apt-get upgrade -y python2.7
+RUN apt-get install -y pkg-config
 RUN apt-get install -y build-essential 
 RUN apt-get install -y python-setuptools build-essential 
 RUN apt-get install -y git

--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get install -y git
 RUN apt-get install -y cmake
 RUN apt-get install -y unzip wget
 RUN apt-get install -y sqlite3 libsqlite3-dev
+RUN apt-get install -y libssl-dev
 
 #do the pip setup and installation things
 RUN easy_install pip


### PR DESCRIPTION
We need `pkg-config` and `libssl-dev` for the new HTTP services

(Both are already available in our Vagrant image)