### PR TITLE
Updating the app APIs to query via HTTP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         - checkout
         - run:
             name: Cargo check for BBB
-            command: cargo check --target arm-unknown-linux-gnueabihf
+            command: PKG_CONFIG_ALLOW_CROSS=1 cargo check --target arm-unknown-linux-gnueabihf
             environment:
               CC: /usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc
               CXX: /usr/bin/bbb_toolchain/usr/bin/arm-linux-g++
@@ -30,7 +30,7 @@ jobs:
         - checkout
         - run:
             name: Cargo check for iOBC
-            command: cargo check --target armv5te-unknown-linux-gnueabi
+            command: PKG_CONFIG_ALLOW_CROSS=1 cargo check --target armv5te-unknown-linux-gnueabi
             environment:
               CC: /usr/bin/iobc_toolchain/usr/bin/arm-linux-gcc
               CXX: /usr/bin/iobc_toolchain/usr/bin/arm-linux-g++

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     # Run for all PR commits
     rust_check_x86:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: cargo check
@@ -12,12 +12,12 @@ jobs:
     # Run for all PR commits
     rust_check_mbm2:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run:
             name: Cargo check for BBB
-            command: PKG_CONFIG_ALLOW_CROSS=1 cargo check --target arm-unknown-linux-gnueabihf
+            command: cargo check --target arm-unknown-linux-gnueabihf
             environment:
               CC: /usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc
               CXX: /usr/bin/bbb_toolchain/usr/bin/arm-linux-g++
@@ -25,12 +25,12 @@ jobs:
     # Run for all PR commits
     rust_check_iobc:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run:
             name: Cargo check for iOBC
-            command: PKG_CONFIG_ALLOW_CROSS=1 cargo check --target armv5te-unknown-linux-gnueabi
+            command: cargo check --target armv5te-unknown-linux-gnueabi
             environment:
               CC: /usr/bin/iobc_toolchain/usr/bin/arm-linux-gcc
               CXX: /usr/bin/iobc_toolchain/usr/bin/arm-linux-g++
@@ -39,7 +39,7 @@ jobs:
     # Run for all PR commits
     rust_test:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: cargo test -j 8
@@ -48,7 +48,7 @@ jobs:
     # Run for all PR commits
     rust_test_large_upload:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: cargo run --bin large_upload
@@ -57,7 +57,7 @@ jobs:
     # Run for all PR commits
     rust_test_large_download:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: cargo run --bin large_download   
@@ -66,20 +66,20 @@ jobs:
     # Run for all PR commits
     non_rust_tests:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: python3 tools/ci_c.py
-        - run: python3 hal/python-hal/i2c/test_i2c.py
-        - run: cd hal/python-hal/i2c; python3 setup.py install
-        - run: cd apis/pumpkin-mcu-api; python3 test_mcu_api.py
-        - run: cd apis/app-api/python; python3 test_app_api.py
+        - run: python hal/python-hal/i2c/test_i2c.py
+        - run: cd hal/python-hal/i2c; python setup.py install
+        - run: cd apis/pumpkin-mcu-api; python test_mcu_api.py
+        - run: cd apis/app-api/python; python test_app_api.py
 
     # Create and push new git version tag (n.n.n+{new build number})
     # Run when code is merged into master
     deploy:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: pip install semantic-version
@@ -89,7 +89,7 @@ jobs:
     # Run when code is merged into master or when an official release tag is generated
     docs:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: ssh-keyscan docs.kubos.co >> ~/.ssh/known_hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     # Run for all PR commits
     rust_check_x86:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: cargo check
@@ -12,7 +12,7 @@ jobs:
     # Run for all PR commits
     rust_check_mbm2:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run:
@@ -26,7 +26,7 @@ jobs:
     # Run for all PR commits
     rust_check_iobc:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run:
@@ -41,7 +41,7 @@ jobs:
     # Run for all PR commits
     rust_test:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: cargo test -j 8
@@ -50,7 +50,7 @@ jobs:
     # Run for all PR commits
     rust_test_large_upload:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: cargo run --bin large_upload
@@ -59,7 +59,7 @@ jobs:
     # Run for all PR commits
     rust_test_large_download:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: cargo run --bin large_download   
@@ -68,7 +68,7 @@ jobs:
     # Run for all PR commits
     non_rust_tests:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: python3 tools/ci_c.py
@@ -81,7 +81,7 @@ jobs:
     # Run when code is merged into master
     deploy:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: pip install semantic-version
@@ -91,7 +91,7 @@ jobs:
     # Run when code is merged into master or when an official release tag is generated
     docs:
       docker:
-        - image: kubos/kubos-dev:cattest
+        - image: kubos/kubos-dev:latest
       steps:
         - checkout
         - run: ssh-keyscan docs.kubos.co >> ~/.ssh/known_hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     # Run for all PR commits
     rust_check_x86:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: cargo check
@@ -12,26 +12,28 @@ jobs:
     # Run for all PR commits
     rust_check_mbm2:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run:
             name: Cargo check for BBB
             command: cargo check --target arm-unknown-linux-gnueabihf
             environment:
+              PKG_CONFIG_ALLOW_CROSS: 1
               CC: /usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc
               CXX: /usr/bin/bbb_toolchain/usr/bin/arm-linux-g++
 
     # Run for all PR commits
     rust_check_iobc:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run:
             name: Cargo check for iOBC
             command: cargo check --target armv5te-unknown-linux-gnueabi
             environment:
+              PKG_CONFIG_ALLOW_CROSS: 1
               CC: /usr/bin/iobc_toolchain/usr/bin/arm-linux-gcc
               CXX: /usr/bin/iobc_toolchain/usr/bin/arm-linux-g++
 
@@ -39,7 +41,7 @@ jobs:
     # Run for all PR commits
     rust_test:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: cargo test -j 8
@@ -48,7 +50,7 @@ jobs:
     # Run for all PR commits
     rust_test_large_upload:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: cargo run --bin large_upload
@@ -57,7 +59,7 @@ jobs:
     # Run for all PR commits
     rust_test_large_download:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: cargo run --bin large_download   
@@ -66,20 +68,20 @@ jobs:
     # Run for all PR commits
     non_rust_tests:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: python3 tools/ci_c.py
-        - run: python hal/python-hal/i2c/test_i2c.py
-        - run: cd hal/python-hal/i2c; python setup.py install
-        - run: cd apis/pumpkin-mcu-api; python test_mcu_api.py
-        - run: cd apis/app-api/python; python test_app_api.py
+        - run: python3 hal/python-hal/i2c/test_i2c.py
+        - run: cd hal/python-hal/i2c; python3 setup.py install
+        - run: cd apis/pumpkin-mcu-api; python3 test_mcu_api.py
+        - run: cd apis/app-api/python; python3 test_app_api.py
 
     # Create and push new git version tag (n.n.n+{new build number})
     # Run when code is merged into master
     deploy:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: pip install semantic-version
@@ -89,7 +91,7 @@ jobs:
     # Run when code is merged into master or when an official release tag is generated
     docs:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: ssh-keyscan docs.kubos.co >> ~/.ssh/known_hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     # Run for all PR commits
     rust_check_x86:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: cargo check
@@ -12,7 +12,7 @@ jobs:
     # Run for all PR commits
     rust_check_mbm2:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run:
@@ -25,7 +25,7 @@ jobs:
     # Run for all PR commits
     rust_check_iobc:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run:
@@ -39,7 +39,7 @@ jobs:
     # Run for all PR commits
     rust_test:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: cargo test -j 8
@@ -48,7 +48,7 @@ jobs:
     # Run for all PR commits
     rust_test_large_upload:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: cargo run --bin large_upload
@@ -57,7 +57,7 @@ jobs:
     # Run for all PR commits
     rust_test_large_download:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: cargo run --bin large_download   
@@ -66,7 +66,7 @@ jobs:
     # Run for all PR commits
     non_rust_tests:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: python3 tools/ci_c.py
@@ -79,7 +79,7 @@ jobs:
     # Run when code is merged into master
     deploy:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: pip install semantic-version
@@ -89,7 +89,7 @@ jobs:
     # Run when code is merged into master or when an official release tag is generated
     docs:
       docker:
-        - image: kubos/kubos-dev:latest
+        - image: kubos/kubos-dev:cattest
       steps:
         - checkout
         - run: ssh-keyscan docs.kubos.co >> ~/.ssh/known_hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,10 @@ jobs:
       steps:
         - checkout
         - run: python3 tools/ci_c.py
-        - run: python hal/python-hal/i2c/test_i2c.py
-        - run: cd hal/python-hal/i2c; python setup.py install
-        - run: cd apis/pumpkin-mcu-api; python test_mcu_api.py
-        - run: cd apis/app-api/python; python test_app_api.py
+        - run: python3 hal/python-hal/i2c/test_i2c.py
+        - run: cd hal/python-hal/i2c; python3 setup.py install
+        - run: cd apis/pumpkin-mcu-api; python3 test_mcu_api.py
+        - run: cd apis/app-api/python; python3 test_app_api.py
 
     # Create and push new git version tag (n.n.n+{new build number})
     # Run when code is merged into master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,12 +1054,13 @@ version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "juniper 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
  "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/apis/app-api/rust/Cargo.toml
+++ b/apis/app-api/rust/Cargo.toml
@@ -11,9 +11,10 @@ kubos-system = { path = "../../system-api" }
 log = "^0.4.0"
 log4rs = "0.8"
 log4rs-syslog = "3.0"
+reqwest = "0.9.9"
 serde_json = "1.0"
 
 [dev-dependencies]
 kubos-service = { path = "../../../services/kubos-service" }
-juniper =  "0.9"
+juniper =  "0.11"
 tempfile = "3"

--- a/apis/app-api/rust/src/lib.rs
+++ b/apis/app-api/rust/src/lib.rs
@@ -70,8 +70,7 @@
 //!
 
 #![deny(missing_docs)]
-// TODO: THIS IS A TEMPORARY THING. DO NOT MERGE INTO MASTER
-//#![deny(warnings)]
+#![deny(warnings)]
 
 #[cfg(test)]
 #[macro_use]

--- a/apis/app-api/rust/src/query.rs
+++ b/apis/app-api/rust/src/query.rs
@@ -17,7 +17,6 @@
 use failure::format_err;
 use kubos_system::Config as ServiceConfig;
 use serde_json;
-use std::net::UdpSocket;
 use std::time::Duration;
 
 /// The result type used by `query`
@@ -79,19 +78,23 @@ pub fn query(
     query: &str,
     timeout: Option<Duration>,
 ) -> AppResult<serde_json::Value> {
-    let socket = UdpSocket::bind("0.0.0.0:0")?;
-    socket.connect(config.hosturl())?;
-    socket.send(query.as_bytes())?;
+    
+    let client = match timeout {
+        Some(time) => reqwest::Client::builder().timeout(time).build()?,
+        None => reqwest::Client::builder().build()?
+    };
+    
+    let uri = format!("http://{}", config.hosturl());
+    
+    let mut map = ::std::collections::HashMap::new();
+    map.insert("query", query);
+    
+    let response: serde_json::Value = client.post(&uri)
+        .json(&map)
+        .send()?
+        .json()?;
 
-    // Allow the caller to set a read timeout on the socket
-    socket.set_read_timeout(timeout).unwrap();
-
-    let mut buf = [0; 4096];
-    let (amt, _) = socket.recv_from(&mut buf)?;
-
-    let v: serde_json::Value = serde_json::from_slice(&buf[0..(amt)])?;
-
-    if let Some(errs) = v.get("errors") {
+    if let Some(errs) = response.get("errors") {
         if errs.is_string() {
             let errs_str = errs.as_str().unwrap();
             if !errs_str.is_empty() {
@@ -109,7 +112,7 @@ pub fn query(
         }
     }
 
-    match v.get(0) {
+    match response.get(0) {
         Some(err) if err.get("message").is_some() => {
             return Err(format_err!(
                 "{}",
@@ -119,11 +122,11 @@ pub fn query(
         _ => {}
     }
 
-    match v.get("data") {
+    match response.get("data") {
         Some(result) => Ok(result.clone()),
         None => Err(format_err!(
             "No result returned in 'data' key: {}",
-            serde_json::to_string(&v).unwrap()
+            serde_json::to_string(&response).unwrap()
         )),
     }
 }

--- a/apis/app-api/rust/src/tests/mod.rs
+++ b/apis/app-api/rust/src/tests/mod.rs
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-// TODO: Temporarily deactivating the unit tests so that CI will pass for the rust http service PR
-// THIS SHOULD BE UPDATED BEFORE MERGING INTO MASTER
-
-/*
 mod mock_service;
 
 macro_rules! mock_service {
@@ -50,4 +46,3 @@ macro_rules! mock_service {
 }
 
 mod query;
-*/

--- a/apis/app-api/rust/src/tests/query.rs
+++ b/apis/app-api/rust/src/tests/query.rs
@@ -65,7 +65,7 @@ fn query_error() {
 
     let result_str = format!("{}", result);
 
-    assert_eq!(result_str, "{\"message\":\"Query failed\",\"locations\":[{\"line\":2,\"column\":13}],\"path\":[\"ping\"]}");
+    assert_eq!(result_str, "[{\"locations\":[{\"column\":13,\"line\":2}],\"message\":\"Query failed\",\"path\":[\"ping\"]}]");
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn query_bad_service() {
 
     let result_str = format!("{}", result);
 
-    assert_eq!(result_str, "Connection refused (os error 111)");
+    assert_eq!(result_str, "http://127.0.0.1:8080/: an error occurred trying to connect: Connection refused (os error 111)");
 }
 
 #[test]
@@ -105,7 +105,7 @@ fn query_bad_file() {
 
     let result_str = format!("{}", result);
 
-    assert_eq!(result_str, "Connection refused (os error 111)");
+    assert_eq!(result_str, "http://127.0.0.1:8080/: an error occurred trying to connect: Connection refused (os error 111)");
 }
 
 #[test]

--- a/apis/pumpkin-mcu-api/mcu_api.py
+++ b/apis/pumpkin-mcu-api/mcu_api.py
@@ -335,12 +335,12 @@ class MCU:
         if parsing == "str":
             # Search for the null terminator,
             # return the leading string in a tuple
-            str_data = data.split(b'\0')[0]
-            return (str_data.decode(),)
+            str_data = data.split('\0')[0]
+            return (str_data,)
         elif parsing == "hex":
             # Store as a hex string. This is so we can return binary data.
             # Return as a single field in a tuple
-            return (binascii.hexlify(data).decode(),)
+            return (binascii.hexlify(str.encode(data)),)
 
         # All others parse directly with the parsing string.
         return struct.unpack(parsing, data)

--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -1,32 +1,28 @@
-# kubos/kubos-dev:0.1.8
+# kubos/kubos-dev:0.1.14
 
 FROM phusion/baseimage:0.9.22
 
-MAINTAINER kyle@kubos.co
-
-RUN add-apt-repository -y ppa:george-edison55/cmake-3.x
+MAINTAINER catherine@kubos.com, ryan@kubos.com
 
 RUN apt-get update -y
 
-RUN apt-get upgrade -y python2.7
-RUN apt-get install -y build-essential libssl-dev libffi-dev libhidapi-hidraw0 clang
-RUN apt-get install -y python-setuptools build-essential ninja-build python-dev libffi-dev libssl-dev
+RUN apt-get upgrade -y python3.5
+RUN apt-get install -y pkg-config
+RUN apt-get install -y build-essential 
+RUN apt-get install -y python-setuptools build-essential 
 RUN apt-get install -y git
 RUN apt-get install -y cmake
 RUN apt-get install -y unzip wget
 RUN apt-get install -y sqlite3 libsqlite3-dev
+RUN apt-get install -y libssl-dev
 
 #do the pip setup and installation things
 RUN easy_install pip
-# Need to install pip<v10 due to this issue: https://github.com/ARMmbed/yotta/issues/835
-# Forcibly controlling version until this is resolved
-RUN pip install pip==9.0.3
+# Set up pip for Python3.5
+RUN apt-get install -y python3-pip
 
 #Kubos Linux setup
 RUN echo "Installing Kubos Linux Toolchain"
-
-RUN apt-get install -y minicom
-RUN apt-get install -y libc6-i386 lib32stdc++6 lib32z1
 
 RUN wget https://s3.amazonaws.com/kubos-world-readable-assets/iobc_toolchain.tar.gz
 RUN tar -xf ./iobc_toolchain.tar.gz -C /usr/bin
@@ -36,16 +32,10 @@ RUN wget https://s3.amazonaws.com/kubos-world-readable-assets/bbb_toolchain.tar.
 RUN tar -xf ./bbb_toolchain.tar.gz -C /usr/bin
 RUN rm ./bbb_toolchain.tar.gz
 
-RUN pip install --upgrade setuptools
-RUN pip install -r https://raw.githubusercontent.com/kubos/kubos-cli/master/requirements.txt
-RUN pip install git+https://github.com/kubos/kubos-cli
-
-RUN mkdir -p /usr/local/lib/yotta_modules
-RUN mkdir -p /usr/local/lib/yotta_targets
-RUN mkdir -p /home/vagrant/.kubos
-
 # Setup Python package dependencies
-RUN pip install toml
+RUN pip3 install toml
+RUN pip3 install mock
+RUN pip3 install responses
 
 # Setup rust stuff
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -1,4 +1,4 @@
-# kubos/kubos-dev:0.1.14
+# kubos/kubos-dev:1.13.0
 
 FROM phusion/baseimage:0.9.22
 


### PR DESCRIPTION
Updated the Rust and Python app APIs to do graphql requests over http instead of udp.

Also in this PR:
- Added a new flag `PKG_CONFIG_ALLOW_CROSS` to circleci. The Rust app API updates brought in a crate which needs the flag in order to be able to cross-compile
- Updated circleci config to use Python3 for everything
- Fixing some python unit tests
- Updating our Dockerfile to include the new python dependency (`responses`)