### PR TITLE
Modify comms-service to allow HTTP transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,14 +280,17 @@ name = "comms-service"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/docs/services/comms-framework.rst
+++ b/docs/services/comms-framework.rst
@@ -53,14 +53,12 @@ Ground Communication
 The communications service maintains a constant read thread which listens for messages from the
 ground via the communications device.
 
-Once a message is received, a message handler thread is spawned and assigned one of the available
-handler UDP ports.
-This message handler examines the destination port embedded in the message's UDP packet header to
-determine the internal message destination and then forwards it on to the appropriate service.
-The handler then waits for a reply (within a specified timeout duration), wraps the response in a
+Once a message is received, a message handler thread is spawned. This message handler examines the destination
+port embedded in the message's UDP packet header to determine the internal message destination
+and then makes a HTTP POST to the appropriate service.
+The handler then waits for a response (within a specified timeout duration), wraps the response in a
 UDP packet, and then sends the packet to the communications device for transmission.
-Once this transaction has completed, the message handler thread exits, freeing up the UDP port for
-future use.
+Once this transaction has completed, the message handler thread exits.
 
 .. uml::
 
@@ -87,7 +85,7 @@ future use.
     
     participant "Kubos Service" as service
     
-    handler -> service : 6. Send GraphQL query/mutation to service
+    handler -> service : 6. Posts GraphQL query/mutation to service
     service -> handler : 7. Return result of query/mutation
     handler -> handler : 8. Wrap result in UDP packet
     handler -> Radio : 9. Send response packet to radio
@@ -146,10 +144,7 @@ configurations.
 
 The service's :doc:`config.toml <../services/service-config>` file should contain the following parameters:
 
-- ``handler_port_min`` - (Default: 13100) Starting port used to define a range of ports that are used in the message
-  handlers that handle messages received from the ground
-- ``handler_port_max`` - (Default: 13149) Ending port used to define a range of ports that are used in the message
-  handlers that handle messages received from the ground
+- ``max_num_handlers`` - (Default: 50) The maximum number of concurrent message handlers allowed
 - ``downlink_ports`` - (Optional) List of ports used by downlink endpoints that send messages to the
   ground. Each port in the list will be used by one downlink endpoint
 - ``timeout`` - (Default: 1500) Length of time a message handler should wait for a reply, in milliseconds
@@ -169,8 +164,7 @@ It contains the following members:
   communications device
 - ``write`` - A list of function pointers for all available ways that messages may be written to
   the communications device
-- ``handler_port_min`` - Should be copied from the corresponding `config.toml` value
-- ``handler_port_max`` - Should be copied from the corresponding `config.toml` value
+- ``max_num_handlers`` - Should be copied from the corresponding `config.toml` value
 - ``downlink_ports`` - Should be copied from the corresponding `config.toml` value or ``None``
 - ``timeout`` - Should be copied from the corresponding `config.toml` value
 - ``ground_ip`` - Should be copied from the corresponding `config.toml` value

--- a/docs/services/comms-framework.rst
+++ b/docs/services/comms-framework.rst
@@ -55,7 +55,7 @@ ground via the communications device.
 
 Once a message is received, a message handler thread is spawned. This message handler examines the destination
 port embedded in the message's UDP packet header to determine the internal message destination
-and then makes a HTTP POST to the appropriate service.
+and then makes an HTTP POST to the appropriate service.
 The handler then waits for a response (within a specified timeout duration), wraps the response in a
 UDP packet, and then sends the packet to the communications device for transmission.
 Once this transaction has completed, the message handler thread exits.

--- a/examples/serial-comms-service/README.md
+++ b/examples/serial-comms-service/README.md
@@ -22,8 +22,7 @@ bus = "/dev/ttyUSB0" -- Serial bus to use
 ip = "127.0.0.1" -- IP to bind GraphQL server to
 port = 8012 -- Port to listen on for GraphQL queries
 [serial-comms-service.comms] -- Communications service configuration
-handler_port_min = 14000 -- Starting port to bind to when creating message handlers
-handler_port_max = 14010 -- Ending port to bind to when creating message handlers
+max_num_handlers = 10 -- Maximum number of concurrent message handlers
 downlink_ports = [14011] -- Ports to listen for local traffic on
 timeout = 1 -- Timeout when listening for packet response
 ground_port = 14020 -- Port to send ground communications on

--- a/libs/comms-service/Cargo.toml
+++ b/libs/comms-service/Cargo.toml
@@ -14,3 +14,8 @@ serde_derive = "1.0"
 toml = "0.4.10"
 log = "^0.4.0"
 kubos-system = { path = "../../apis/system-api" }
+reqwest = "0.9"
+
+[dev-dependencies]
+warp = "0.1.12"
+bytes = "*"

--- a/libs/comms-service/Cargo.toml
+++ b/libs/comms-service/Cargo.toml
@@ -19,3 +19,4 @@ reqwest = "0.9"
 [dev-dependencies]
 warp = "0.1.12"
 bytes = "*"
+tempfile = "3.0"

--- a/libs/comms-service/src/config.rs
+++ b/libs/comms-service/src/config.rs
@@ -22,11 +22,8 @@
 use crate::errors::*;
 use serde_derive::Deserialize;
 
-// Default values for control block configurations.
-/// Default message handler starting port
-pub const DEFAULT_HANDLER_START: u16 = 13100;
-/// Default message handler ending port
-pub const DEFAULT_HANDLER_END: u16 = 13149;
+/// Default maximum number of message handlers
+pub const DEFAULT_MAX_HANDLERS: u16 = 50;
 /// Default message handler timeout
 pub const DEFAULT_TIMEOUT: u64 = 1500;
 
@@ -34,12 +31,9 @@ pub const DEFAULT_TIMEOUT: u64 = 1500;
 /// Created by parsing a configuration file in the `toml` file format.
 #[derive(Clone, Debug, Deserialize)]
 pub struct CommsConfig {
-    /// Starting port used to define a range of ports that are used in the message handlers
-    /// that handle messages received from the ground. Default: 13100
-    pub handler_port_min: Option<u16>,
-    /// Ending port used to define a range of ports that are used in the message handlers
-    /// that handle messages received from the ground. Default: 13149
-    pub handler_port_max: Option<u16>,
+    /// The maximum number of concurrent message handlers allowed
+    /// Default: 50
+    pub max_num_handlers: Option<u16>,
     /// Optional list of ports used by downlink endpoints that send messages to the ground.
     /// Each port in the list will be used by one downlink endpoint.
     pub downlink_ports: Option<Vec<u16>>,

--- a/libs/comms-service/src/lib.rs
+++ b/libs/comms-service/src/lib.rs
@@ -83,6 +83,7 @@ mod config;
 mod errors;
 mod service;
 mod telemetry;
+
 #[cfg(test)]
 mod tests;
 

--- a/libs/comms-service/src/lib.rs
+++ b/libs/comms-service/src/lib.rs
@@ -16,8 +16,8 @@
 // Contributed by: William Greer (wgreer184@gmail.com) and Sam Justice (sam.justice1@gmail.com)
 //
 
-// #![deny(missing_docs)]
-// #![deny(warnings)]
+#![deny(missing_docs)]
+#![deny(warnings)]
 
 //!
 //! This library allows users to define and start communication services within their hardware services.
@@ -64,8 +64,7 @@
 //!
 //! ```toml
 //! [service-name.comms]
-//! handler_port_min = 13002
-//! handler_port_max = 13010
+//! max_num_handlers = 50
 //! downlink_ports = [13011]
 //! ground_port = 9001
 //! timeout = 1500

--- a/libs/comms-service/src/lib.rs
+++ b/libs/comms-service/src/lib.rs
@@ -16,8 +16,8 @@
 // Contributed by: William Greer (wgreer184@gmail.com) and Sam Justice (sam.justice1@gmail.com)
 //
 
-#![deny(missing_docs)]
-#![deny(warnings)]
+// #![deny(missing_docs)]
+// #![deny(warnings)]
 
 //!
 //! This library allows users to define and start communication services within their hardware services.

--- a/libs/comms-service/src/service.rs
+++ b/libs/comms-service/src/service.rs
@@ -300,7 +300,7 @@ fn handle_message<T: Clone>(
         .map_err(|e| e.to_string())?;
 
     let size = res.content_length().unwrap_or(0) as usize;
-    let buf = res.text().unwrap_or("".to_owned());
+    let buf = res.text().unwrap_or_else(|_| "".to_owned());
     let buf = buf.as_bytes();
 
     // Take received message and wrap it in a UDP packet.

--- a/libs/comms-service/src/service.rs
+++ b/libs/comms-service/src/service.rs
@@ -55,12 +55,8 @@ pub struct CommsControlBlock<T: Clone> {
     pub read_conn: T,
     /// Gateway connection to write to.
     pub write_conn: T,
-    /// Starting port used to define a range of ports that are used in the message handlers
-    /// that handle messages received from the ground.
-    pub handler_port_min: u16,
-    /// Ending port used to define a range of ports that are used in the message handlers
-    /// that handle messages received from the ground.
-    pub handler_port_max: u16,
+    /// Maximum number of concurrent message handlers allowed.
+    pub max_num_handlers: u16,
     /// Timeout for the completion of GraphQL operations within message handlers (in milliseconds).
     pub timeout: u64,
     /// IP address of the ground gateway.
@@ -93,14 +89,13 @@ impl<T: Clone + Debug> Debug for CommsControlBlock<T> {
         write!(
             f,
             "CommsControlBlock {{ read: {}, write: {:?}, read_conn: {:?}, write_conn: {:?},
-            handler_port_min: {:?}, handler_port_max: {:?}, timeout: {:?}, ground_ip: {:?},
-            satellite_ip: {:?}, downlink_ports: {:?}, ground_port: {:?} }}",
+            max_num_handlers: {:?}, timeout: {:?}, ground_ip: {:?}, satellite_ip: {:?},
+            downlink_ports: {:?}, ground_port: {:?} }}",
             read,
             write,
             self.read_conn,
             self.write_conn,
-            self.handler_port_min,
-            self.handler_port_max,
+            self.max_num_handlers,
             self.timeout,
             self.ground_ip,
             self.satellite_ip,
@@ -139,8 +134,7 @@ impl<T: Clone> CommsControlBlock<T> {
             write,
             read_conn,
             write_conn,
-            handler_port_min: config.handler_port_min.unwrap_or(DEFAULT_HANDLER_START),
-            handler_port_max: config.handler_port_max.unwrap_or(DEFAULT_HANDLER_END),
+            max_num_handlers: config.max_num_handlers.unwrap_or(DEFAULT_MAX_HANDLERS),
             timeout: config.timeout.unwrap_or(DEFAULT_TIMEOUT),
             ground_ip: Ipv4Addr::from_str(&config.ground_ip)?,
             satellite_ip: Ipv4Addr::from_str(&config.satellite_ip)?,
@@ -202,11 +196,11 @@ fn read_thread<T: Clone + Send + 'static>(
     comms: CommsControlBlock<T>,
     data: &Arc<Mutex<CommsTelemetry>>,
 ) {
-    // Setup port rotation for message handlers.
-    let mut port = comms.handler_port_min;
-
     // Take reader from control block.
     let read = comms.read.unwrap();
+
+    // Initiate counter for handlers
+    let num_handlers: Arc<Mutex<u16>> = Arc::new(Mutex::new(0));
 
     loop {
         // Read bytes from the radio.
@@ -241,20 +235,15 @@ fn read_thread<T: Clone + Send + 'static>(
         log_telemetry(&data, &TelemType::Up).unwrap();
         info!("UDP Packet successfully uplinked");
 
-        // Bind socket to a port and pass to the message handler.
-        let socket = match socket_manager(
-            comms.satellite_ip,
-            &mut port,
-            comms.handler_port_min,
-            comms.handler_port_max,
-        ) {
-            Some(sock) => sock,
-            None => {
+        if let Ok(mut num_handlers) = num_handlers.lock() {
+            if *num_handlers >= comms.max_num_handlers {
                 log_error(&data, CommsServiceError::NoAvailablePorts.to_string()).unwrap();
                 error!("No message handler ports available");
                 continue;
+            } else {
+                *num_handlers = *num_handlers + 1;
             }
-        };
+        }
 
         // Spawn new message handler.
         let conn_ref = comms.write_conn.clone();
@@ -263,37 +252,26 @@ fn read_thread<T: Clone + Send + 'static>(
         let sat_ref = comms.satellite_ip;
         let ground_ref = comms.ground_ip;
         let time_ref = comms.timeout;
+        let num_handlers_ref = num_handlers.clone();
         thread::spawn(move || {
             handle_message(
-                &socket, &data_ref, conn_ref, &write_ref, &packet, time_ref, sat_ref, ground_ref,
+                &data_ref,
+                conn_ref,
+                &write_ref,
+                &packet,
+                time_ref,
+                sat_ref,
+                ground_ref,
+                num_handlers_ref,
             );
         });
     }
-}
-
-// Helper function to manage binding sockets to the next available port if any are available.
-fn socket_manager(ip: Ipv4Addr, port: &mut u16, min: u16, max: u16) -> Option<UdpSocket> {
-    let mut socket = None;
-    let last = *port;
-    while socket.is_none() {
-        if *port < max {
-            *port += 1;
-        } else {
-            *port = min;
-        }
-        socket = UdpSocket::bind((ip, *port)).ok();
-        if last == *port {
-            break;
-        }
-    }
-    socket
 }
 
 // This thread sends a query/mutation to its intended destination and waits for a response.
 // The thread then writes the response to the gateway.
 #[allow(clippy::too_many_arguments)]
 fn handle_message<T: Clone>(
-    _socket: &UdpSocket,
     data: &Arc<Mutex<CommsTelemetry>>,
     write_conn: T,
     write: &Arc<WriteFn<T>>,
@@ -301,6 +279,7 @@ fn handle_message<T: Clone>(
     timeout: u64,
     sat_ip: Ipv4Addr,
     ground_ip: Ipv4Addr,
+    num_handlers: Arc<Mutex<u16>>,
 ) {
     let payload = message.payload().to_vec();
 
@@ -309,7 +288,12 @@ fn handle_message<T: Clone>(
         .build()
     {
         Ok(client) => client,
-        Err(e) => return log_error(&data, e.to_string()).unwrap(),
+        Err(e) => {
+            if let Ok(mut num_handlers) = num_handlers.lock() {
+                *num_handlers = *num_handlers - 1;
+            }
+            return log_error(&data, e.to_string()).unwrap();
+        }
     };
 
     let mut res = match client
@@ -318,7 +302,12 @@ fn handle_message<T: Clone>(
         .send()
     {
         Ok(res) => res,
-        Err(e) => return log_error(&data, e.to_string()).unwrap(),
+        Err(e) => {
+            if let Ok(mut num_handlers) = num_handlers.lock() {
+                *num_handlers = *num_handlers - 1;
+            }
+            return log_error(&data, e.to_string()).unwrap();
+        }
     };
 
     let size = res.content_length().unwrap() as usize;
@@ -335,7 +324,12 @@ fn handle_message<T: Clone>(
         ground_ip,
     ) {
         Ok(packet) => packet,
-        Err(e) => return log_error(&data, e.to_string()).unwrap(),
+        Err(e) => {
+            if let Ok(mut num_handlers) = num_handlers.lock() {
+                *num_handlers = *num_handlers - 1;
+            }
+            return log_error(&data, e.to_string()).unwrap();
+        }
     };
 
     // Write packet to the gateway and update telemetry.
@@ -350,6 +344,9 @@ fn handle_message<T: Clone>(
             error!("UDP packet failed to downlink");
         }
     };
+    if let Ok(mut num_handlers) = num_handlers.lock() {
+        *num_handlers = *num_handlers - 1;
+    }
 }
 
 // This thread reads indefinitely from a UDP socket and then writes received packets to a gateway.

--- a/libs/comms-service/src/service.rs
+++ b/libs/comms-service/src/service.rs
@@ -268,7 +268,7 @@ fn read_thread<T: Clone + Send + 'static>(
                 Err(e) => {
                     log_telemetry(&data_ref, &TelemType::DownFailed).unwrap();
                     log_error(&data_ref, e.to_string()).unwrap();
-                    error!("UDP packet failed to downlink");
+                    error!("UDP packet failed to downlink: {}", e.to_string());
                 }
             }
         });

--- a/libs/comms-service/src/service.rs
+++ b/libs/comms-service/src/service.rs
@@ -241,7 +241,7 @@ fn read_thread<T: Clone + Send + 'static>(
                 error!("No message handler ports available");
                 continue;
             } else {
-                *num_handlers = *num_handlers + 1;
+                *num_handlers += 1;
             }
         }
 
@@ -290,7 +290,7 @@ fn handle_message<T: Clone>(
         Ok(client) => client,
         Err(e) => {
             if let Ok(mut num_handlers) = num_handlers.lock() {
-                *num_handlers = *num_handlers - 1;
+                *num_handlers -= 1;
             }
             return log_error(&data, e.to_string()).unwrap();
         }
@@ -304,7 +304,7 @@ fn handle_message<T: Clone>(
         Ok(res) => res,
         Err(e) => {
             if let Ok(mut num_handlers) = num_handlers.lock() {
-                *num_handlers = *num_handlers - 1;
+                *num_handlers -= 1;
             }
             return log_error(&data, e.to_string()).unwrap();
         }
@@ -326,7 +326,7 @@ fn handle_message<T: Clone>(
         Ok(packet) => packet,
         Err(e) => {
             if let Ok(mut num_handlers) = num_handlers.lock() {
-                *num_handlers = *num_handlers - 1;
+                *num_handlers -= 1;
             }
             return log_error(&data, e.to_string()).unwrap();
         }
@@ -345,7 +345,7 @@ fn handle_message<T: Clone>(
         }
     };
     if let Ok(mut num_handlers) = num_handlers.lock() {
-        *num_handlers = *num_handlers - 1;
+        *num_handlers -= 1;
     }
 }
 

--- a/libs/comms-service/tests/concurrent.rs
+++ b/libs/comms-service/tests/concurrent.rs
@@ -74,7 +74,7 @@ fn concurrent_uplinks_to_service_with_handler_response() {
         // for the comms service to read from the radio
         mock_comms.lock().unwrap().push_read(&ground_packet);
 
-        // Setup & start http server
+        // Setup & start HTTP server
         let recv_data: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
 
         spawn_http_server(
@@ -92,7 +92,7 @@ fn concurrent_uplinks_to_service_with_handler_response() {
     // Start communication service.
     CommsService::start(controls, &telem).unwrap();
 
-    // Wait until http servers are ready
+    // Wait until HTTP servers are ready
     barrier.wait();
 
     for _ in 0..(num_tests) {
@@ -160,7 +160,7 @@ fn too_many_concurrent_uplinks_to_service_with_handler_response() {
         // for the comms service to read from the radio
         mock_comms.lock().unwrap().push_read(&ground_packet);
 
-        // Setup & start http server
+        // Setup & start HTTP server
         let recv_data: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
         spawn_http_server(
             resp_payload.clone(),

--- a/libs/comms-service/tests/concurrent.rs
+++ b/libs/comms-service/tests/concurrent.rs
@@ -1,0 +1,217 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#[macro_use]
+extern crate failure;
+
+mod util;
+
+use comms_service::*;
+use pnet::packet::udp::UdpPacket;
+use pnet::packet::Packet;
+use std::net::Ipv4Addr;
+use std::net::UdpSocket;
+use std::str;
+use std::str::FromStr;
+use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use util::*;
+use warp::{self, path, Buf, Filter};
+
+// Tests sending concurrent packets from the ground to a service through a handler
+// Service sends back a response via the message handler
+#[test]
+fn concurrent_uplinks_to_service_with_handler_response() {
+    let sat_ip = "127.0.0.9";
+    let ground_ip = "127.0.0.10";
+    let ground_port = 18001;
+    let downlink_port = 18002;
+    let service_port = 18005;
+    let config = comms_config(sat_ip, ground_ip, ground_port, downlink_port);
+    let mock_comms = Arc::new(Mutex::new(MockComms::new()));
+    let payload = vec![0, 1, 4, 5];
+    let resp_payload = vec![9, 8, 7, 6];
+
+    // Control block to configure communication service.
+    let controls = CommsControlBlock::new(
+        Some(Arc::new(read)),
+        vec![Arc::new(write)],
+        mock_comms.clone(),
+        mock_comms.clone(),
+        config,
+    )
+    .unwrap();
+
+    // Initialize new `CommsTelemetry` object.
+    let telem = Arc::new(Mutex::new(CommsTelemetry::default()));
+
+    let num_tests = 10;
+    let mut recv_data_list: Vec<Arc<Mutex<Vec<u8>>>> = vec![];
+    for i in 0..(num_tests) {
+        let ground_packet = build_packet(
+            &payload,
+            ground_port,
+            service_port + i,
+            12,
+            Ipv4Addr::from_str(sat_ip).unwrap(),
+            Ipv4Addr::from_str(ground_ip).unwrap(),
+        )
+        .unwrap();
+
+        // Pretend to be the ground and provide a packet
+        // for the comms service to read from the radio
+        mock_comms.lock().unwrap().push_read(&ground_packet);
+
+        // Setup & start http server
+        let recv_data: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
+
+        spawn_http_server(
+            resp_payload.clone(),
+            recv_data.clone(),
+            &format!("{}:{}", sat_ip, service_port + i),
+        );
+
+        recv_data_list.push(recv_data);
+    }
+
+    // Start communication service.
+    CommsService::start(controls, &telem).unwrap();
+
+    // Let the wheels turn
+    thread::sleep(Duration::from_millis(1000));
+
+    for _ in 0..(num_tests) {
+        let recv_data = recv_data_list.pop().unwrap();
+        // Retrieve the message for the service from shared buffer
+        let rx_data = recv_data.lock().unwrap().to_owned();
+
+        assert_eq!(rx_data, payload);
+    }
+
+    // Let the wheels turn
+    thread::sleep(Duration::from_millis(1000));
+
+    for _ in 0..(num_tests) {
+        // Pretend to be the ground and read the
+        // packet which was written to the radio
+        let data = mock_comms.lock().unwrap().pop_write().unwrap();
+        let packet = UdpPacket::new(&data).unwrap();
+
+        assert_eq!(packet.payload().to_vec(), resp_payload);
+        assert_eq!(packet.get_destination(), ground_port);
+    }
+}
+
+// Tests sending concurrent packets from the ground to a service through a handler
+// Service sends back a response via the message handler
+#[test]
+fn too_many_concurrent_uplinks_to_service_with_handler_response() {
+    let sat_ip = "127.0.0.11";
+    let ground_ip = "127.0.0.12";
+    let ground_port = 19001;
+    let downlink_port = 19002;
+    let service_port = 19005;
+    let config = comms_config(sat_ip, ground_ip, ground_port, downlink_port);
+    let mock_comms = Arc::new(Mutex::new(MockComms::new()));
+    let payload = vec![0, 1, 4, 5];
+    let resp_payload = vec![9, 8, 7, 6];
+
+    // Control block to configure communication service.
+    let controls = CommsControlBlock::new(
+        Some(Arc::new(read)),
+        vec![Arc::new(write)],
+        mock_comms.clone(),
+        mock_comms.clone(),
+        config,
+    )
+    .unwrap();
+
+    // Initialize new `CommsTelemetry` object.
+    let telem = Arc::new(Mutex::new(CommsTelemetry::default()));
+
+    let num_tests = 15;
+    let mut recv_data_list: Vec<Arc<Mutex<Vec<u8>>>> = vec![];
+    for i in 0..(num_tests) {
+        let ground_packet = build_packet(
+            &payload,
+            ground_port,
+            service_port + i,
+            12,
+            Ipv4Addr::from_str(sat_ip).unwrap(),
+            Ipv4Addr::from_str(ground_ip).unwrap(),
+        )
+        .unwrap();
+
+        // Pretend to be the ground and provide a packet
+        // for the comms service to read from the radio
+        mock_comms.lock().unwrap().push_read(&ground_packet);
+
+        // Setup & start http server
+        let recv_data: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
+        spawn_http_server(
+            resp_payload.clone(),
+            recv_data.clone(),
+            &format!("{}:{}", sat_ip, service_port + i),
+        );
+
+        recv_data_list.push(recv_data);
+    }
+
+    // Start communication service.
+    CommsService::start(controls, &telem).unwrap();
+
+    // Let the wheels turn
+    thread::sleep(Duration::from_millis(1000));
+
+    let mut num_rx_correct = 0;
+    let mut num_rx_empty = 0;
+    for _ in 0..(num_tests) {
+        let recv_data = recv_data_list.pop().unwrap();
+        // Retrieve the message for the service from shared buffer
+        let rx_data = recv_data.lock().unwrap().to_owned();
+
+        if rx_data == payload {
+            num_rx_correct += 1;
+        } else {
+            num_rx_empty += 1;
+        }
+    }
+    assert_eq!(num_rx_correct, 10);
+    assert_eq!(num_rx_empty, 5);
+
+    // Let the wheels turn
+    thread::sleep(Duration::from_millis(1000));
+
+    let mut num_packet_correct = 0;
+    let mut num_packet_empty = 0;
+    for _ in 0..(num_tests) {
+        // Pretend to be the ground and read the
+        // packet which was written to the radio
+        let data = mock_comms.lock().unwrap().pop_write();
+        if let Some(data) = data {
+            let packet = UdpPacket::new(&data).unwrap();
+            assert_eq!(packet.payload().to_vec(), resp_payload);
+            assert_eq!(packet.get_destination(), ground_port);
+            num_packet_correct += 1;
+        } else {
+            num_packet_empty += 1;
+        }
+    }
+    assert_eq!(num_packet_correct, 10);
+    assert_eq!(num_packet_empty, 5);
+}

--- a/libs/comms-service/tests/concurrent.rs
+++ b/libs/comms-service/tests/concurrent.rs
@@ -92,9 +92,6 @@ fn concurrent_uplinks_to_service_with_handler_response() {
     // Start communication service.
     CommsService::start(controls, &telem).unwrap();
 
-    // Let the wheels turn
-    // thread::sleep(Duration::from_millis(5000));
-
     // Wait until http servers are ready
     barrier.wait();
 
@@ -180,9 +177,7 @@ fn too_many_concurrent_uplinks_to_service_with_handler_response() {
     // Start communication service.
     CommsService::start(controls, &telem).unwrap();
 
-    // Let the wheels turn
-    // thread::sleep(Duration::from_millis(5000));
-
+    // Wait for HTTP server to get ready
     barrier.wait();
 
     let mut num_rx_correct = 0;

--- a/libs/comms-service/tests/concurrent.rs
+++ b/libs/comms-service/tests/concurrent.rs
@@ -23,15 +23,11 @@ use comms_service::*;
 use pnet::packet::udp::UdpPacket;
 use pnet::packet::Packet;
 use std::net::Ipv4Addr;
-use std::net::UdpSocket;
-use std::str;
 use std::str::FromStr;
-use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use util::*;
-use warp::{self, path, Buf, Filter};
 
 // Tests sending concurrent packets from the ground to a service through a handler
 // Service sends back a response via the message handler

--- a/libs/comms-service/tests/downlink.rs
+++ b/libs/comms-service/tests/downlink.rs
@@ -59,7 +59,7 @@ fn downlink_to_ground() {
     let downlink_writer = UdpSocket::bind((sat_ip, 0)).unwrap();
 
     // Let the wheels turn
-    thread::sleep(Duration::from_millis(1));
+    thread::sleep(Duration::from_millis(10));
 
     // Send packet to comm service's downlink port
     downlink_writer
@@ -67,7 +67,7 @@ fn downlink_to_ground() {
         .unwrap();
 
     // Let the wheels turn
-    thread::sleep(Duration::from_millis(1));
+    thread::sleep(Duration::from_millis(10));
 
     // Pretend to be the ground and read the
     // packet which was written to the radio

--- a/libs/comms-service/tests/query_service.rs
+++ b/libs/comms-service/tests/query_service.rs
@@ -1,0 +1,136 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#[macro_use]
+extern crate failure;
+
+extern crate tempfile;
+
+mod util;
+
+use comms_service::*;
+use pnet::packet::udp::UdpPacket;
+use pnet::packet::Packet;
+use std::fs::File;
+use std::io::Write;
+use std::net::Ipv4Addr;
+use std::process;
+use std::process::{Command, Stdio};
+use std::str::FromStr;
+use std::sync::mpsc::{channel, Receiver};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tempfile::tempdir;
+use util::*;
+
+// Tests sending a packet from the ground to a service through a handler
+// No response is sent from the service
+#[test]
+fn query_monitor_service() {
+    let sat_ip = "127.0.0.5";
+    let ground_ip = "127.0.0.6";
+    let ground_port = 15001;
+    let downlink_port = 15002;
+    let service_port = 15005;
+    let config = comms_config(sat_ip, ground_ip, ground_port, downlink_port);
+    let mock_comms = Arc::new(Mutex::new(MockComms::new()));
+    let query = "{\"query\":\"{ping}\"}".as_bytes();
+    let response = "{\"data\":{\"ping\":\"pong\"}}".as_bytes();
+
+    // Start up monitor service
+    let service_handle_rx = spawn_monitor_service();
+
+    thread::sleep(Duration::from_millis(500));
+
+    // Control block to configure communication service.
+    let controls = CommsControlBlock::new(
+        Some(Arc::new(read)),
+        vec![Arc::new(write)],
+        mock_comms.clone(),
+        mock_comms.clone(),
+        config,
+    )
+    .unwrap();
+
+    // Initialize new `CommsTelemetry` object.
+    let telem = Arc::new(Mutex::new(CommsTelemetry::default()));
+
+    let ground_packet = build_packet(
+        &query,
+        ground_port,
+        service_port,
+        12,
+        Ipv4Addr::from_str(sat_ip).unwrap(),
+        Ipv4Addr::from_str(ground_ip).unwrap(),
+    )
+    .unwrap();
+
+    // Pretend to be the ground and provide a packet
+    // for the comms service to read from the radio
+    mock_comms.lock().unwrap().push_read(&ground_packet);
+
+    // Start communication service.
+    CommsService::start(controls, &telem).unwrap();
+
+    // Let the wheels turn
+    thread::sleep(Duration::from_millis(500));
+
+    // Pretend to be the ground and read the
+    // packet which was written to the radio
+    let data = mock_comms.lock().unwrap().pop_write().unwrap();
+    let packet = UdpPacket::new(&data).unwrap();
+
+    assert_eq!(packet.payload().to_vec(), response);
+    assert_eq!(packet.get_destination(), ground_port);
+
+    // Kill off the service process
+    let mut service_handle = service_handle_rx.recv().unwrap();
+    service_handle.kill().unwrap();
+}
+
+fn spawn_monitor_service() -> Receiver<process::Child> {
+    let (sender, receiver) = channel();
+
+    let config = r#"[monitor-service.addr]
+ip = "127.0.0.5"
+port = 15005"#;
+
+    thread::spawn(move || {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("config.toml");
+        let mut file = File::create(file_path.clone()).unwrap();
+        writeln!(file, "{}", config).unwrap();
+
+        let child = Command::new("cargo")
+            .arg("run")
+            .arg("--package")
+            .arg("monitor-service")
+            .arg("--")
+            .arg("-c")
+            .arg(file_path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to start");
+
+        sender.send(child).unwrap();
+
+        thread::sleep(Duration::from_secs(2));
+    });
+
+    receiver
+}

--- a/libs/comms-service/tests/query_service.rs
+++ b/libs/comms-service/tests/query_service.rs
@@ -37,8 +37,8 @@ use std::time::Duration;
 use tempfile::tempdir;
 use util::*;
 
-// Tests sending a packet from the ground to a service through a handler
-// No response is sent from the service
+// Tests sending a ping from the ground to an instance of the actual
+// monitor service and reading back the response.
 #[test]
 fn query_monitor_service() {
     let sat_ip = "127.0.0.5";

--- a/libs/comms-service/tests/query_service.rs
+++ b/libs/comms-service/tests/query_service.rs
@@ -135,7 +135,7 @@ port = 15005"#;
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .expect("failed to start");
+            .expect("Failed to start");
 
         sender.send(child).unwrap();
 

--- a/libs/comms-service/tests/query_service.rs
+++ b/libs/comms-service/tests/query_service.rs
@@ -54,7 +54,7 @@ fn query_monitor_service() {
     // Start up monitor service
     let service_handle_rx = spawn_monitor_service();
 
-    thread::sleep(Duration::from_millis(500));
+    thread::sleep(Duration::from_millis(1000));
 
     // Control block to configure communication service.
     let controls = CommsControlBlock::new(
@@ -87,7 +87,7 @@ fn query_monitor_service() {
     CommsService::start(controls, &telem).unwrap();
 
     // Let the wheels turn
-    thread::sleep(Duration::from_millis(500));
+    thread::sleep(Duration::from_millis(1000));
 
     // Pretend to be the ground and read the
     // packet which was written to the radio
@@ -108,6 +108,16 @@ fn spawn_monitor_service() -> Receiver<process::Child> {
     let config = r#"[monitor-service.addr]
 ip = "127.0.0.5"
 port = 15005"#;
+
+    // Block on building the service before we start it
+    // Otherwise we might run through the test before it
+    // is built and running.
+    Command::new("cargo")
+        .arg("build")
+        .arg("--package")
+        .arg("monitor-service")
+        .output()
+        .expect("Failed to build monitor-service");
 
     thread::spawn(move || {
         let dir = tempdir().unwrap();

--- a/libs/comms-service/tests/uplink.rs
+++ b/libs/comms-service/tests/uplink.rs
@@ -70,7 +70,7 @@ fn uplink_to_service_no_response() {
     // for the comms service to read from the radio
     mock_comms.lock().unwrap().push_read(&ground_packet);
 
-    // Setup & start http server
+    // Setup & start HTTP server
     let barrier = Arc::new(Barrier::new(2));
     let recv_data: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
     let thread_data = recv_data.clone();
@@ -134,7 +134,7 @@ fn uplink_to_service_with_handler_response() {
     // for the comms service to read from the radio
     mock_comms.lock().unwrap().push_read(&ground_packet);
 
-    // Setup & start http server
+    // Setup & start HTTP server
     let barrier = Arc::new(Barrier::new(2));
     let recv_data: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
     let thread_data = recv_data.clone();
@@ -210,7 +210,7 @@ fn uplink_to_service_with_downlink_response() {
     // for the comms service to read from the radio
     mock_comms.lock().unwrap().push_read(&ground_packet);
 
-    // Setup & start http server
+    // Setup & start HTTP server
     let barrier = Arc::new(Barrier::new(2));
     let recv_data: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
     spawn_http_server(

--- a/libs/comms-service/tests/uplink.rs
+++ b/libs/comms-service/tests/uplink.rs
@@ -24,14 +24,11 @@ use pnet::packet::udp::UdpPacket;
 use pnet::packet::Packet;
 use std::net::Ipv4Addr;
 use std::net::UdpSocket;
-use std::str;
 use std::str::FromStr;
-use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use util::*;
-use warp::{self, path, Buf, Filter};
 
 // Tests sending a packet from the ground to a service through a handler
 // No response is sent from the service

--- a/libs/comms-service/tests/util/mod.rs
+++ b/libs/comms-service/tests/util/mod.rs
@@ -94,8 +94,7 @@ pub fn comms_config(
     downlink_port: u16,
 ) -> CommsConfig {
     CommsConfig {
-        handler_port_min: Some(18000),
-        handler_port_max: Some(18100),
+        max_num_handlers: Some(10),
         downlink_ports: Some(vec![downlink_port]),
         timeout: Some(1000),
         ground_ip: ground_ip.to_owned(),

--- a/libs/comms-service/tests/util/mod.rs
+++ b/libs/comms-service/tests/util/mod.rs
@@ -16,7 +16,12 @@
 
 use comms_service::*;
 use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::str;
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use warp::{self, path, Buf, Filter};
 
 // This MockComms structure allows for easy integration testing
 // of the comms_service crate by giving direct access to the
@@ -30,8 +35,8 @@ pub struct MockComms {
 impl MockComms {
     pub fn new() -> Self {
         MockComms {
-            read_buff: RefCell::new(vec![]),
-            write_buff: RefCell::new(vec![]),
+            read_buff: RefCell::new(Vec::<Vec<u8>>::with_capacity(50)),
+            write_buff: RefCell::new(Vec::<Vec<u8>>::with_capacity(50)),
         }
     }
 
@@ -63,7 +68,8 @@ impl MockComms {
     // "Ground is reading a packet from the radio"
     pub fn pop_write(&self) -> Option<Vec<u8>> {
         let mut buffer = self.write_buff.borrow_mut();
-        buffer.pop()
+        let ret_data = buffer.pop();
+        ret_data
     }
 }
 
@@ -101,4 +107,30 @@ pub fn comms_config(
         ground_port: Some(ground_port),
         satellite_ip: sat_ip.to_owned(),
     }
+}
+
+pub fn spawn_http_server(payload: Vec<u8>, thread_data: Arc<Mutex<Vec<u8>>>, service_ip: &str) {
+    let routes = warp::post2()
+        .and(warp::any())
+        .and(warp::body::concat())
+        .map(move |mut body: warp::body::FullBody| {
+            let mut data = vec![];
+            let mut remaining = body.remaining();
+            while remaining != 0 {
+                let cnt = body.bytes().len();
+                let mut body_bytes = body.bytes().to_vec();
+                data.append(&mut body_bytes);
+                body.advance(cnt);
+                remaining -= cnt;
+            }
+
+            if let Ok(mut thread_data_handle) = thread_data.lock() {
+                thread_data_handle.append(&mut data);
+            }
+
+            // Send a response back to the ground via the handler port
+            str::from_utf8(&payload).unwrap().to_owned()
+        });
+    let service_ip: std::net::SocketAddrV4 = service_ip.parse().unwrap();
+    thread::spawn(move || warp::serve(routes).run(service_ip));
 }

--- a/libs/comms-service/tests/util/mod.rs
+++ b/libs/comms-service/tests/util/mod.rs
@@ -16,12 +16,10 @@
 
 use comms_service::*;
 use std::cell::RefCell;
-use std::collections::VecDeque;
 use std::str;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
-use warp::{self, path, Buf, Filter};
+use warp::{self, Buf, Filter};
 
 // This MockComms structure allows for easy integration testing
 // of the comms_service crate by giving direct access to the


### PR DESCRIPTION
- Adds integration tests around uplink and downlink behaviour
- Modifies uplink behaviour to allow communication with HTTP-based services
- Removes `handler_port_min/max` in favor of `max_num_handlers`