### PR TITLE
Creating generic service testing utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utils 0.1.0",
  "warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3053,6 +3054,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ members = [
 "test/integration/linux/isis-ants",
 "test/integration/linux/mai400",
 "test/integration/large_download",
-"test/integration/large_upload"
+"test/integration/large_upload",
+"utils"
 ]
 
 [profile.release]

--- a/libs/comms-service/Cargo.toml
+++ b/libs/comms-service/Cargo.toml
@@ -20,3 +20,4 @@ reqwest = "0.9"
 warp = "0.1.12"
 bytes = "*"
 tempfile = "3.0"
+utils = { path = "../../utils" }

--- a/libs/comms-service/tests/concurrent.rs
+++ b/libs/comms-service/tests/concurrent.rs
@@ -29,6 +29,7 @@ use std::thread;
 use std::time::Duration;
 use util::*;
 
+
 // Tests sending concurrent packets from the ground to a service through a handler
 // Service sends back a response via the message handler
 #[test]

--- a/libs/comms-service/tests/concurrent.rs
+++ b/libs/comms-service/tests/concurrent.rs
@@ -29,7 +29,6 @@ use std::thread;
 use std::time::Duration;
 use util::*;
 
-
 // Tests sending concurrent packets from the ground to a service through a handler
 // Service sends back a response via the message handler
 #[test]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "utils"
+version = "0.1.0"
+authors = ["Ryan Plauche <ryan@kubos.co>"]
+edition = "2018"
+
+[dependencies]
+tempfile = "3"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! This crate is a generically named grab bag of utilities for use when
+//! building or testing other crates.
+
+pub mod testing;

--- a/utils/src/testing.rs
+++ b/utils/src/testing.rs
@@ -16,13 +16,13 @@
 
 extern crate tempfile;
 
+use std::cell::RefCell;
 use std::fs::File;
 use std::io::Write;
 use std::process;
 use std::process::{Command, Stdio};
 use std::str;
 use tempfile::tempdir;
-use std::cell::RefCell;
 
 /// This structure allows the creation of an instance
 /// of an actual service/binary crate for use in

--- a/utils/src/testing.rs
+++ b/utils/src/testing.rs
@@ -1,0 +1,106 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+extern crate tempfile;
+
+use std::fs::File;
+use std::io::Write;
+use std::process;
+use std::process::{Command, Stdio};
+use std::str;
+use tempfile::tempdir;
+use std::cell::RefCell;
+
+/// This structure allows the creation of an instance
+/// of an actual service/binary crate for use in
+/// integration tests within the same crate.
+pub struct TestService {
+    config_path: String,
+    // Keep around so the temp file stays alive
+    _config_file: File,
+    // Keep around so the temp dir stays alive
+    _tmp_dir: tempfile::TempDir,
+    name: String,
+    child_handle: RefCell<Box<Option<process::Child>>>,
+}
+
+impl TestService {
+    /// Create config for TestService and return basic struct
+    pub fn new(name: &str, ip: &str, port: u16) -> TestService {
+        let mut config = Vec::new();
+        writeln!(&mut config, "[{}.addr]", name).unwrap();
+        writeln!(&mut config, "ip = \"{}\"", ip).unwrap();
+        writeln!(&mut config, "port = {}", port).unwrap();
+        let config_str = String::from_utf8(config).unwrap();
+
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let mut config_file = File::create(config_path.clone()).unwrap();
+        writeln!(config_file, "{}", config_str).unwrap();
+
+        TestService {
+            config_path: config_path.to_str().unwrap().to_owned(),
+            _config_file: config_file,
+            _tmp_dir: dir,
+            name: String::from(name),
+            child_handle: RefCell::new(Box::new(None)),
+        }
+    }
+
+    /// Ask Cargo to build the service binary.
+    /// This is a *blocking* function. We know when it returns
+    /// that the service is ready to be run.
+    pub fn build(&self) {
+        Command::new("cargo")
+            .arg("build")
+            .arg("--package")
+            .arg(self.name.to_owned())
+            .output()
+            .expect("Failed to build service");
+    }
+
+    /// Ask Cargo to run the service binary.
+    /// This is *not* a blocking function. The service is
+    /// spawned in the background, allowing the test
+    /// to continue on.
+    pub fn spawn(&self) {
+        let child = Command::new("cargo")
+            .arg("run")
+            .arg("--package")
+            .arg(self.name.clone())
+            .arg("--")
+            .arg("-c")
+            .arg(self.config_path.clone())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Failed to start");
+
+        let mut child_handle = self.child_handle.borrow_mut();
+        *child_handle = Box::new(Some(child));
+    }
+}
+
+/// Implement custom drop functionality which
+/// will retrieve handle to child process and kill it.
+impl Drop for TestService {
+    fn drop(&mut self) {
+        let mut borrowed_child = self.child_handle.borrow_mut();
+        if let Some(mut handle) = borrowed_child.take() {
+            handle.kill().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
In the process of #318 we wanted a test against one of our actual services. This was initially done in a way very specific to that service, but seems like a useful thing for other integration tests.

This PR pulls out that work and is the beginning of a method for writing integration tests which interact directly with other binary crates.