### PR TITLE
Clyde 3G EPS NOS3 Sim support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -445,6 +445,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "display_derive"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1590,6 +1600,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nosengine-rust"
+version = "0.1.0"
+dependencies = [
+ "cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "novatel-oem6-api"
 version = "0.1.0"
 dependencies = [
@@ -2125,6 +2143,8 @@ name = "rust-i2c"
 version = "0.1.0"
 dependencies = [
  "i2c-linux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nosengine-rust 0.1.0",
+ "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2141,8 +2161,11 @@ dependencies = [
 name = "rust-uart"
 version = "0.2.0"
 dependencies = [
+ "display_derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nosengine-rust 0.1.0",
  "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2355,7 +2378,7 @@ name = "sha-1"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2518,6 +2541,15 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3210,7 +3242,7 @@ dependencies = [
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-"checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
+"checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
@@ -3238,6 +3270,7 @@ dependencies = [
 "checksum diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a2469cbcf1dfb9446e491cac4c493c2554133f87f7d041e892ac82e5cd36e863"
 "checksum diesel_derives 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62a27666098617d52c487a41f70de23d44a1dc1f3aa5877ceba2790fb1f1cab4"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum display_derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bba5dcd6d2855639fcf65a9af7bbad0bfb6dbf6fe68fba70bab39a6eb973ef4"
 "checksum double 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e4145e7ee9d4fca6a0a0961e0860ab15173f1319562ad29145c08e11c931a7e"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
@@ -3422,6 +3455,7 @@ dependencies = [
 "checksum syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)" = "525bd55255f03c816e5d7f615587bd13030c7103354fadb104993dcee6a788ec"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a30b08a6b383a22e5f6edc127d169670d48f905bb00ca79a00ea3e442ebe317"
 "checksum syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646"
 "checksum syntex_pos 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd49988e52451813c61fecbe9abb5cfd4e1b7bb6cdbb980a6fbcbab859171a6"

--- a/apis/clyde-3g-eps-api/Cargo.toml
+++ b/apis/clyde-3g-eps-api/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Ryan Plauche <ryan@kubos.co>"]
 edition = "2018"
 
+[features]
+nos3 = ["rust-i2c/nos3"]
+
 [dependencies]
 bitflags = "1.0"
 eps-api = { path = "../eps-api" }

--- a/apis/nosengine-rust/Cargo.toml
+++ b/apis/nosengine-rust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "nosengine-rust"
+version = "0.1.0"
+authors = ["Timothy Scott <tmscott@mix.wvu.edu>"]
+build = "build.rs"
+
+[dependencies]
+libc = "0.2.0"
+
+[build-dependencies]
+cmake = "0.1"

--- a/apis/nosengine-rust/build.rs
+++ b/apis/nosengine-rust/build.rs
@@ -1,0 +1,9 @@
+extern crate cmake;
+
+fn main() {
+    // This runs the CMake file in nos3_c_interface.
+    // See the comments in that file for an explanation of why it's necessary.
+    // The important thing is that it doesn't actually build anything, so all I
+    // have to do is run this one command.
+    cmake::build("nosengine_c_interface");
+}

--- a/apis/nosengine-rust/nosengine_c_interface/CMakeLists.txt
+++ b/apis/nosengine-rust/nosengine_c_interface/CMakeLists.txt
@@ -35,8 +35,7 @@ foreach(lib ${NOSENGINE_LIBRARIES})
 endforeach(lib)
 
 # This script doesn't actually build anything; all it has to do is print out the libraries.
-# However, the CMake crate expects an install target.
-# So I just make this meaningless installation that does nothing.
+# However, the CMake crate expects an install target, so I just make this meaningless installation that does nothing.
 
 file(WRITE __lib.c)
 set(nosengine_src __lib.c)

--- a/apis/nosengine-rust/nosengine_c_interface/CMakeLists.txt
+++ b/apis/nosengine-rust/nosengine_c_interface/CMakeLists.txt
@@ -1,0 +1,45 @@
+# NOSEngine is distributed as a CMake module. This CMake file just gathers up all of the
+# components of NOSEngine into one shared object, which can be linked to from Rust.
+
+cmake_minimum_required(VERSION 3.5)
+project(nosengine_c_interface C)
+
+# CMake has no way of printing text to stdout, except for message(STATUS ...),
+# Which adds two leading dashes.
+# This function just prints to stdout with no leading dashes.
+# Source: https://stackoverflow.com/questions/15842828/is-there-a-good-way-to-display-clean-text-on-stdout-in-cmake
+function(CleanMessage)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E echo "${ARGN}")
+endfunction()
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} /usr/cmake/modules)
+
+find_package(NOSENGINE REQUIRED COMPONENTS common transport client server i2c spi uart)
+
+# Iterate over all of the NOSEngine libraries, and print them out so that Cargo can find them.
+foreach(lib ${NOSENGINE_LIBRARIES})
+    # NOSENGINE_LIBRARIES is a list of absolute paths to shared objects.
+    # Here, the filename is split from the path and extension
+    get_filename_component(lib_filename "${lib}" NAME_WE)
+    # Remove the "lib" at the beginning of the filename
+    string(REPLACE "lib" "" lib_name ${lib_filename})
+    # After the above, something like "/usr/lib/libnosengine.so" will become "nosengine"
+    # Cargo expects the linked libraries to be printed to stdout in a specific format.
+    # See: https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script
+    CleanMessage("cargo:rustc-link-lib=${lib_name}")
+
+    # The following isn't necessary, because NOSEngine is normally installed in a normal
+    # location for shared libraries (/usr/lib), so they are found automatically.
+    # get_filename_component(lib_dir "${lib}" DIRECTORY)
+    # CleanMessage("cargo:rustc-link-search=${lib_dir}")
+endforeach(lib)
+
+# This script doesn't actually build anything; all it has to do is print out the libraries.
+# However, the CMake crate expects an install target.
+# So I just make this meaningless installation that does nothing.
+
+file(WRITE __lib.c)
+set(nosengine_src __lib.c)
+
+add_library(nosengine_c_interface SHARED ${nosengine_src})
+install(TARGETS nosengine_c_interface LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)

--- a/apis/nosengine-rust/src/client/i2c.rs
+++ b/apis/nosengine-rust/src/client/i2c.rs
@@ -1,0 +1,291 @@
+//! Wraps the I2C functionality of NOSEngine.
+//!
+//! # Examples
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::client::i2c::*;
+//! # use nosengine_rust::ffi::i2c::I2CDirection;
+//! # use std::slice;
+//! let master = I2CMaster::new(9u16, "tcp://localhost:12001", "i2c19").unwrap();
+//!
+//! extern "C" fn callback(dir: I2CDirection, buffer: *mut u8, len: usize) -> usize {
+//!     let data = unsafe{ slice::from_raw_parts_mut(buffer, len) };
+//!     match dir {
+//!         I2CDirection::Read => {
+//!             for i in 0..len {
+//!                 data[i] = (i + 5) as u8;
+//!             }
+//!             len
+//!         },
+//!         I2CDirection::Write => {
+//!             assert_eq!(data, &[1u8, 2, 3, 4]);
+//!             len
+//!         }
+//!     }
+//! }
+//!
+//! let slave = I2CSlave::new(8u16, "tcp://localhost:12001", "i2c19", callback).unwrap();
+//!
+//! assert_eq!(master.write(8u16, &[1u8, 2, 3, 4]), Ok(()));
+//! assert_eq!(master.read(8u16, 4), Ok(vec![5u8, 6, 7, 8]));
+//! ```
+
+use super::ffi::i2c;
+use std::error::Error;
+use std::ffi;
+use std::ffi::CString;
+use std::fmt;
+
+/// This enum represents any type of error that can occur when interacting with I2C
+#[derive(Debug, Clone, PartialEq)]
+pub enum I2CError {
+    /// An error occurred when converting a Rust string to a C string.
+    /// Specifically, the Rust string contained a null character, which cannot be represented
+    /// in C strings.
+    StringError {
+        /// Description from the underlying std::ffi::NulError
+        description: String,
+        /// Index in the original string of the problematic null character
+        position: usize,
+    },
+    /// There was an error when creating the I2C.
+    I2CCreationError,
+    /// This error is raised when an I2C device is created with an invalid address.
+    InvalidAddress {
+        /// The address which was attempted
+        address: u16,
+    },
+    /// Attempted to read or write to an address that doesn't exist.
+    UnknownAddress {
+        /// The address which was not found
+        address: u16,
+    },
+}
+
+impl Error for I2CError {
+    fn description(&self) -> &str {
+        unimplemented!()
+    }
+}
+
+impl From<ffi::NulError> for I2CError {
+    fn from(err: ffi::NulError) -> Self {
+        I2CError::StringError {
+            description: String::from(err.description()),
+            position: err.nul_position(),
+        }
+    }
+}
+
+impl fmt::Display for I2CError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            I2CError::StringError {
+                description,
+                position,
+            } => write!(f, "Null character at index {}: {}", position, description),
+            I2CError::I2CCreationError => write!(f, "Error while creating I2C node"),
+            I2CError::InvalidAddress { address } => write!(
+                f,
+                "Invalid address {}: Must be between 8 and 127, inclusive.",
+                address
+            ),
+            I2CError::UnknownAddress { address } => {
+                write!(f, "Address {} not found on this bus.", address)
+            }
+        }
+    }
+}
+
+/// This struct represents a master on an I2C bus.
+pub struct I2CMaster<'a> {
+    i2c_ptr: *mut i2c::I2CHandle,
+    /// NOSEngine connection string
+    pub connection: &'a str,
+    /// Name of this bus to which this master is connected
+    pub bus: &'a str,
+    /// Address of this master
+    pub address: u16,
+}
+
+impl<'a> I2CMaster<'a> {
+    /// Creates a new I2C master on the given bus. There can be only one: If you attempt to create
+    /// another master with the same address on the same bus, this function will return `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `address`: Address of this I2C master
+    /// * `connection`: NOSEngine connection string
+    /// * `bus`: Name of the bus on which to create the master
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::i2c::*;
+    /// let master = I2CMaster::new(9u16, "tcp://localhost:12001", "i2c20");
+    /// assert!(master.is_ok());
+    /// // 2 masters on a bus is OK as long as they have different addresses
+    /// let master = I2CMaster::new(10u16, "tcp://localhost:12001", "i2c20");
+    /// assert!(master.is_ok());
+    /// // This fails because the address 10u16 is already taken.
+    /// let master = I2CMaster::new(10u16, "tcp://localhost:12001", "i2c20");
+    /// assert!(master.is_err());
+    /// ```
+    pub fn new(address: u16, connection: &'a str, bus: &'a str) -> Result<I2CMaster<'a>, I2CError> {
+        if address < 8 || address > 127 {
+            return Err(I2CError::InvalidAddress { address });
+        }
+        let c_connection = CString::new(connection)?;
+        let c_bus = CString::new(bus)?;
+
+        let i2c_ptr = i2c::i2c_init_master(address, c_connection.as_ptr(), c_bus.as_ptr());
+
+        if i2c_ptr.is_null() {
+            Err(I2CError::I2CCreationError)
+        } else {
+            Ok(I2CMaster {
+                i2c_ptr,
+                connection,
+                bus,
+                address,
+            })
+        }
+    }
+
+    /// This function reads bytes from the given address.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_bytes`: How many bytes to read from the device
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client::i2c`](../i2c/index.html#examples)
+    pub fn read(&self, address: u16, num_bytes: usize) -> Result<Vec<u8>, I2CError> {
+        if address < 8 || address > 127 {
+            return Err(I2CError::InvalidAddress { address });
+        }
+        let mut rbuf: Vec<u8> = Vec::with_capacity(num_bytes);
+        rbuf.resize(num_bytes, 0u8);
+        match i2c::i2c_read(self.i2c_ptr, address, rbuf.as_mut_ptr(), num_bytes) {
+            i2c::I2CStatus::Success => Ok(rbuf),
+            i2c::I2CStatus::Failure => Err(I2CError::UnknownAddress { address }),
+        }
+    }
+
+    /// This function writes bytes to the given address.
+    ///
+    /// # Arguments
+    ///
+    /// * `data`: Bytes to write to the device
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client::i2c`](../i2c/index.html#examples)
+    pub fn write(&self, address: u16, data: &[u8]) -> Result<(), I2CError> {
+        if address < 8 || address > 127 {
+            return Err(I2CError::InvalidAddress { address });
+        }
+        match i2c::i2c_write(self.i2c_ptr, address, data.as_ptr(), data.len()) {
+            i2c::I2CStatus::Success => {
+                println!("i2c.write: {:?}", data);
+                Ok(())
+            }
+            i2c::I2CStatus::Failure => Err(I2CError::UnknownAddress { address }),
+        }
+    }
+
+    /// This function writes bytes to the given address followed by a read
+    /// # Arguments
+    ///
+    /// * `tx_data`: Bytes to write to the device
+    /// * `rx_len`: Number of bytes expected to be read
+    pub fn transaction(
+        &self,
+        address: u16,
+        tx_data: &[u8],
+        rx_len: usize,
+    ) -> Result<Vec<u8>, I2CError> {
+        let mut rbuf: Vec<u8> = Vec::with_capacity(rx_len);
+        rbuf.resize(rx_len, 0u8);
+        match i2c::i2c_transaction(
+            self.i2c_ptr,
+            address,
+            tx_data.as_ptr(),
+            tx_data.len(),
+            rbuf.as_mut_ptr(),
+            rx_len,
+        ) {
+            i2c::I2CStatus::Success => Ok(rbuf),
+            i2c::I2CStatus::Failure => Err(I2CError::UnknownAddress { address }),
+        }
+    }
+}
+
+impl<'a> Drop for I2CMaster<'a> {
+    fn drop(&mut self) {
+        i2c::i2c_close(&mut self.i2c_ptr as *mut *mut i2c::I2CHandle);
+    }
+}
+
+/// This struct represents an I2C Slave.
+pub struct I2CSlave<'a> {
+    i2c_ptr: *mut i2c::I2CHandle,
+    /// The NOSEngine connection string
+    pub connection: &'a str,
+    /// Name of the bus to which this slave is connected
+    pub bus: &'a str,
+    /// Address of this slave
+    pub address: u16,
+}
+
+impl<'a> I2CSlave<'a> {
+    /// Constructs a new I2C slave. The given callback will run every time the master reads
+    /// from or writes to this slave. If a slave with the given address already exists on
+    /// this bus, this function returns `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `address`: Address for this slave. Must be unique on a bus
+    /// * `connection`: NOSEngine connection string
+    /// * `bus`: Name of the bus to connect to
+    /// * `callback`: Callback that runs every time the master reads from or writes to this device.
+    ///     The callback is responsible for checking whether it is reading or writing, performing
+    ///     the appropriate action, then returning the number of bytes read or written. The
+    ///     arguments to the callback are:
+    ///     * `I2CDirection`: Specifies whether this is a read or write
+    ///     * `*mut u8`: The buffer which either contains the data being written to this device, or
+    ///         to which this device should write data. It is guaranteed to have enough bytes of
+    ///         valid memory based on the length argument
+    ///     * `usize`: The number of bytes being read or written
+    pub fn new(
+        address: u16,
+        connection: &'a str,
+        bus: &'a str,
+        callback: extern "C" fn(i2c::I2CDirection, *mut u8, usize) -> usize,
+    ) -> Result<I2CSlave<'a>, I2CError> {
+        let c_connection = CString::new(connection)?;
+        let c_bus = CString::new(bus)?;
+
+        let i2c_ptr = i2c::i2c_init_slave(address, c_connection.as_ptr(), c_bus.as_ptr(), callback);
+
+        if i2c_ptr.is_null() {
+            Err(I2CError::I2CCreationError)
+        } else {
+            Ok(I2CSlave {
+                i2c_ptr,
+                connection,
+                bus,
+                address,
+            })
+        }
+    }
+}
+
+impl<'a> Drop for I2CSlave<'a> {
+    fn drop(&mut self) {
+        i2c::i2c_close(&mut self.i2c_ptr as *mut *mut i2c::I2CHandle);
+    }
+}

--- a/apis/nosengine-rust/src/client/i2c.rs
+++ b/apis/nosengine-rust/src/client/i2c.rs
@@ -167,7 +167,7 @@ impl<'a> I2CMaster<'a> {
         if address < 8 || address > 127 {
             return Err(I2CError::InvalidAddress { address });
         }
-        let mut rbuf: Vec<u8> = Vec::with_capacity(num_bytes);
+        let mut rbuf: Vec<u8> = vec![0; num_bytes];
         rbuf.resize(num_bytes, 0u8);
         match i2c::i2c_read(self.i2c_ptr, address, rbuf.as_mut_ptr(), num_bytes) {
             i2c::I2CStatus::Success => Ok(rbuf),
@@ -208,7 +208,7 @@ impl<'a> I2CMaster<'a> {
         tx_data: &[u8],
         rx_len: usize,
     ) -> Result<Vec<u8>, I2CError> {
-        let mut rbuf: Vec<u8> = Vec::with_capacity(rx_len);
+        let mut rbuf: Vec<u8> = vec![0; rx_len];
         rbuf.resize(rx_len, 0u8);
         match i2c::i2c_transaction(
             self.i2c_ptr,

--- a/apis/nosengine-rust/src/client/mod.rs
+++ b/apis/nosengine-rust/src/client/mod.rs
@@ -1,0 +1,453 @@
+//! This module contains wrappers around all of the FFI code to make a cleaner API.
+//!
+//! This module contains three main data types:
+//!
+//! * `Bus`: Represents one communication channel, over which `Message`s are sent.
+//! * `DataNode`: Any number of `DataNode`s can connect to a `Bus`, and any `DataNode` can send
+//!     and receive `Message`s with any other `DataNode` on the same `Bus`.
+//! * `Message`: One discrete piece of data, which is passed from one `DataNode` to another.
+//!
+//! # Examples
+//!
+//! Using multithreading to send and receive messages. Note that multiple instances of the
+//! same `Bus` can be created.
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::client::*;
+//! # use std::thread;
+//! # use std::time::Duration;
+//! let join_handle = thread::spawn(||{
+//!     let bus = Bus::new("testbus2", "tcp://localhost:12001").unwrap();
+//!     let node = DataNode::new(&bus, "node2").unwrap();
+//!     let message = node.receive_message().unwrap();
+//!     assert_eq!(message.get_contents(), &[1u8, 2, 3, 4]);
+//!     node.send_reply_message(&message, &[5u8, 6, 7, 8]);
+//! });
+//! thread::sleep(Duration::from_millis(100));
+//! let bus = Bus::new("testbus2", "tcp://localhost:12001").unwrap();
+//! let node = DataNode::new(&bus, "node1").unwrap();
+//! let response = node.send_request_message("node2", &[1u8, 2, 3, 4]).unwrap();
+//! assert_eq!(response.get_contents(), &[5u8, 6, 7, 8]);
+//! join_handle.join().unwrap();
+//! ```
+//!
+//! Sending and receiving messages on one thread.
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::client::*;
+//! let bus = Bus::new("testbus2", "tcp://localhost:12001").unwrap();
+//! let node1 = DataNode::new(&bus, "node3").unwrap();
+//! let node2 = DataNode::new(&bus, "node4").unwrap();
+//!
+//! node1.send_message("node4", &[1u8, 2, 3, 4]).unwrap();
+//! let msg = node2.receive_message().unwrap();
+//! assert_eq!(msg.get_contents(), &[1u8, 2, 3, 4]);
+//! ```
+//!
+//! Sending and receiving messages using a callback.
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::client::*;
+//! # use nosengine_rust::ffi;
+//! let bus = Bus::new("testbus2", "tcp://localhost:12001").unwrap();
+//! let node1 = DataNode::new(&bus, "node5").unwrap();
+//! let node2 = DataNode::new(&bus, "node6").unwrap();
+//!
+//! extern "C" fn callback(node_ptr: *mut ffi::DataNodeHandle, msg_ptr: *mut ffi::MessageHandle){
+//!     assert_eq!(unsafe{Message::get_contents_from_ptr(msg_ptr)}, &[1u8, 2, 3, 4]);
+//!     DataNode::send_reply_message_ptr(node_ptr, msg_ptr, &[5u8, 6, 7, 8]);
+//! }
+//! node2.set_message_callback(callback);
+//! let response = node1.send_request_message("node6", &[1u8, 2, 3, 4]).unwrap();
+//! assert_eq!(response.get_contents(), &[5u8, 6, 7, 8]);
+//! ```
+
+pub mod i2c;
+pub mod spi;
+pub mod uart;
+
+use super::ffi;
+use std;
+use std::error::Error;
+use std::fmt;
+use std::sync::Arc;
+
+/// This function returns the most recent NOSEngine error in the current thread.
+fn get_nos_error() -> NosError {
+    let err_str = unsafe { std::ffi::CStr::from_ptr(ffi::error_string()) };
+    match err_str.to_str() {
+        Ok(err_cstr) => NosError::NosEngineError {
+            error_code: ffi::error(),
+            description: String::from(err_cstr),
+        },
+        Err(_) => NosError::NosEngineError {
+            error_code: ffi::ErrorCode::Unknown,
+            description: String::from("Unknown error"),
+        },
+    }
+}
+
+/// This enum represents any type of error that can occur when interacting with NOSEngine.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NosError {
+    /// An error occurred when converting a Rust string to a C string.
+    /// Specifically, the Rust string contained a null character, which cannot be represented
+    /// in C strings.
+    StringError {
+        /// Description from the underlying std::ffi::NulError
+        description: String,
+        /// Index in the original string of the problematic null character
+        position: usize,
+    },
+    /// An error was raised by NOSEngine.
+    NosEngineError {
+        /// What kind of error did NOSEngine raise
+        error_code: ffi::ErrorCode,
+        /// Description of error, from NOSEngine
+        description: String,
+    },
+}
+
+impl From<std::ffi::NulError> for NosError {
+    fn from(err: std::ffi::NulError) -> Self {
+        NosError::StringError {
+            description: String::from(err.description()),
+            position: err.nul_position(),
+        }
+    }
+}
+
+impl fmt::Display for NosError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NosError::StringError {
+                description,
+                position,
+            } => write!(f, "Null character at index {}: {}", position, description),
+            NosError::NosEngineError {
+                error_code,
+                description,
+            } => write!(
+                f,
+                "NOSEngine internal error {:?}: {}",
+                error_code, description
+            ),
+        }
+    }
+}
+
+impl Error for NosError {
+    fn description(&self) -> &str {
+        match self {
+            NosError::StringError {
+                description,
+                position: _,
+            } => &description,
+            NosError::NosEngineError {
+                error_code: _,
+                description,
+            } => &description,
+        }
+    }
+}
+
+/// This struct represents one bus on the NOSEngine server.
+pub struct Bus {
+    /// Pointer to the C struct for the bus.
+    bus_ptr: *mut ffi::BusHandle,
+    /// Name of this bus
+    pub name: String,
+    /// Connection string to the server
+    pub connection: String,
+}
+
+impl Bus {
+    /// This function constructs a new bus. If the server at the given connection string already has a bus
+    /// with the given name, then this new bus simply connects to that same bus. However,
+    /// it still references its own memory, independent from the original bus.
+    ///
+    /// # Arguments
+    ///
+    /// * `name`: The name of this bus
+    /// * `connection`: The NOSEngine connection string. This will generally be of the format
+    ///     `tcp://<domain>:<port>`, but can take other forms. See the NOSEngine user manual for
+    ///     more information about connection strings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::*;
+    /// #
+    /// let bus = Bus::new("testbus2", "tcp://localhost:12001").expect("Error creating bus");
+    /// ```
+    pub fn new(name: &str, connection: &str) -> Result<Arc<Bus>, NosError> {
+        let c_name = std::ffi::CString::new(name)?;
+        let c_connection = std::ffi::CString::new(connection)?;
+
+        let c_bus = ffi::create_bus2(c_name.as_ptr(), c_connection.as_ptr());
+
+        match ffi::error() {
+            ffi::ErrorCode::Ok => Ok(Arc::new(Bus {
+                bus_ptr: c_bus,
+                name: name.to_owned(),
+                connection: connection.to_owned(),
+            })),
+            _ => Err(get_nos_error()),
+        }
+    }
+}
+
+/// When a `Bus` is dropped, it frees the associated pointer to the C struct
+impl Drop for Bus {
+    fn drop(&mut self) {
+        if !self.bus_ptr.is_null() {
+            ffi::destroy_bus(&mut self.bus_ptr as *mut *mut ffi::BusHandle);
+        }
+    }
+}
+
+unsafe impl Send for Bus {}
+
+/// This struct is one discrete message passed between data nodes. This struct can only be obtained by
+/// using one of the functions in this file for receiving messages.
+pub struct Message {
+    msg_ptr: *mut ffi::MessageHandle,
+}
+
+impl Message {
+    /// This function returns the data stored in this message.
+    pub fn get_contents(&self) -> &[u8] {
+        // This is fine, because Message objects are only constructed within this module,
+        // in situations where self.msg_pointer is valid indefinitely
+        unsafe { Message::get_contents_from_ptr(self.msg_ptr) }
+    }
+
+    /// This function returns the data stored in a `*mut ffi::Message`. This function should only be used
+    /// from within a callback set with `DataNode::set_message_callback`.
+    ///
+    /// # Safety
+    ///
+    /// The returned slice is only guaranteed to be valid within the scope of the callback from
+    /// which this function was called.
+    pub unsafe fn get_contents_from_ptr<'a>(msg_ptr: *mut ffi::MessageHandle) -> &'a [u8] {
+        std::slice::from_raw_parts(
+            ffi::message_get_user_data(msg_ptr),
+            ffi::message_get_user_data_length(msg_ptr),
+        )
+    }
+}
+
+impl Drop for Message {
+    fn drop(&mut self) {
+        if !self.msg_ptr.is_null() {
+            ffi::destroy_message(&mut self.msg_ptr as *mut *mut ffi::MessageHandle);
+        }
+    }
+}
+
+/// `DataNode`s send data to each other over buses.
+pub struct DataNode {
+    node_ptr: *mut ffi::DataNodeHandle,
+    bus_ptr: Arc<Bus>,
+    /// Name of this data node
+    pub name: String,
+}
+
+impl DataNode {
+    /// Creates a data node on the supplied bus. Data node names need to be unique, but no error will be
+    /// thrown if they are not unique! For example, the following code will result in an invalid
+    /// memory access:
+    ///
+    /// ```ignore
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::*;
+    /// let bus = Bus::new("testbus2", "tcp://localhost:12001").unwrap();
+    /// let node1 = DataNode::new(&bus, "node").unwrap();
+    /// let node2 = DataNode::new(&bus, "node2").unwrap();
+    /// {
+    ///     let node3 = DataNode::new(&bus, "node").unwrap();
+    /// }
+    /// node1.send_message("node2", &[1u8, 2, 3]).unwrap();
+    /// ```
+    ///
+    /// This is because, when a `DataNode` is dropped, it destroys the associated C struct. Then,
+    /// when the duplicate `DataNode` tries to use its pointer to this same C struct, it is now
+    /// an invalid pointer.
+    ///
+    /// # Arguments
+    /// * `name`: Name of the node to be created. Must be unique on a bus.
+    ///
+    /// # Examples
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::*;
+    /// let bus = Bus::new("testbus2", "tcp://localhost:12001").unwrap();
+    /// let node = DataNode::new(&bus, "testnode").unwrap();
+    /// ```
+    pub fn new(bus: &Arc<Bus>, name: &str) -> Result<DataNode, NosError> {
+        let c_name = std::ffi::CString::new(name)?;
+
+        let c_node = ffi::create_data_node(bus.bus_ptr, c_name.as_ptr());
+
+        match ffi::error() {
+            ffi::ErrorCode::Ok => Ok(DataNode {
+                node_ptr: c_node,
+                bus_ptr: bus.clone(),
+                name: name.to_owned(),
+            }),
+            _ => Err(get_nos_error()),
+        }
+    }
+
+    /// Sends a message to the specified node. The recipient node does not need to have been created
+    /// in the same thread, in the same program, or even at all. If the recipient node does
+    /// not exist, the message will simply be lost.
+    ///
+    /// # Arguments
+    ///
+    /// * `destination`: The (case-sensitive) name of the recipient node
+    /// * `data`: The bytes to be sent to the recipient
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::*;
+    /// let bus = Bus::new("testbus2", "tcp://localhost:12001").unwrap();
+    /// let node1 = DataNode::new(&bus, "node9").unwrap();
+    /// node1.send_message("nowhere", &[1u8, 2, 3, 4]).unwrap();
+    /// ```
+    ///
+    /// See [`nosengine-rust::client`](../client/index.html#examples) for more.
+    pub fn send_message(&self, destination: &str, data: &[u8]) -> Result<(), NosError> {
+        let destination = std::ffi::CString::new(destination)?;
+
+        ffi::data_node_send_message_sync(
+            self.node_ptr,
+            destination.as_ptr(),
+            data.len(),
+            data.as_ptr(),
+        );
+        match ffi::error() {
+            ffi::ErrorCode::Ok => Ok(()),
+            _ => Err(get_nos_error()),
+        }
+    }
+
+    /// This function sends a message to the specified node, and blocks until it receives a response. The
+    /// recipient must respond with `DataNode::send_reply_message_ptr` or `DataNode::send_reply_message`, or
+    /// else this function will block indefinitely.
+    ///
+    /// # Arguments
+    /// * `destination`: Name of the recipient node
+    /// * `data`: Data to be sent
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client`](../client/index.html#examples)
+    pub fn send_request_message(
+        &self,
+        destination: &str,
+        data: &[u8],
+    ) -> Result<Message, NosError> {
+        let destination = std::ffi::CString::new(destination)?;
+
+        let mut msg_ptr: *mut ffi::MessageHandle = std::ptr::null_mut();
+        ffi::data_node_send_request_message_sync(
+            self.node_ptr,
+            destination.as_ptr(),
+            data.len(),
+            data.as_ptr(),
+            &mut msg_ptr as *mut *mut ffi::MessageHandle,
+        );
+        match ffi::error() {
+            ffi::ErrorCode::Ok => Ok(Message { msg_ptr }),
+            _ => Err(get_nos_error()),
+        }
+    }
+
+    /// This function sends a reply to a message that was originally sent using `DataNode::send_request_message()`.
+    /// This function uses raw pointers instead of the `DataNode` and `Message` types because this
+    /// function is usually needed from within a callback, and inside the callback, the Rust
+    /// structs are not available.
+    ///
+    /// # Arguments
+    ///
+    /// * `node`: Pointer to a data node, which was received as an argument in a callback
+    /// * `message`: The message which is being replied to. Also received as an argument to a callback.
+    /// * `data`: Bytes to be sent in the reply
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client`](../client/index.html#examples).
+    pub fn send_reply_message_ptr(
+        node: *mut ffi::DataNodeHandle,
+        message: *mut ffi::MessageHandle,
+        data: &[u8],
+    ) {
+        ffi::data_node_send_reply_message_sync(node, message, data.len(), data.as_ptr());
+    }
+
+    /// This function replies to a message that was originally sent using `DataNode::send_request_message`.
+    /// If this function is used to respond to a message that was not sent using that function, an
+    /// error will occur.
+    ///
+    /// # Arguments
+    /// * `message`: The message to which you are responding
+    /// * `data`: Data to be sent
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client`](../client/index.html#examples)
+    pub fn send_reply_message(&self, message: &Message, data: &[u8]) {
+        DataNode::send_reply_message_ptr(self.node_ptr, message.msg_ptr, data);
+    }
+
+    /// This function blocks until a message is received.
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client`](../client/index.html#examples)
+    pub fn receive_message(&self) -> Result<Message, NosError> {
+        let msg_ptr = ffi::data_node_receive_message_sync(self.node_ptr);
+        match ffi::error() {
+            ffi::ErrorCode::Ok => Ok(Message { msg_ptr }),
+            _ => Err(get_nos_error()),
+        }
+    }
+
+    /// Sets a callback which will be called each time this node receives a message.
+    /// Due to limitations of the NOSEngine C API, this callback cannot be a closure, and must
+    /// receive inputs as raw pointers. To interact with these pointers, use functions in
+    /// this module:
+    ///
+    /// * To get data from message: [`Message::get_contents_from_ptr`](struct.Message.html#method.get_contents_from_ptr)
+    /// * To reply to a request message: [`DataNode::send_reply_message_ptr`](struct.DataNode.html#method.send_reply_message_ptr)
+    ///
+    /// # Safety
+    ///
+    /// Do NOT call `ffi::destroy_message` on `msg_pointer`, or a memory error will occur. NOSEngine
+    /// handles the deallocation of this message pointer.
+    pub fn set_message_callback(
+        &self,
+        func: extern "C" fn(node_ptr: *mut ffi::DataNodeHandle, msg_ptr: *mut ffi::MessageHandle),
+    ) {
+        ffi::data_node_set_message_received_callback(self.node_ptr, func);
+    }
+}
+
+impl Drop for DataNode {
+    fn drop(&mut self) {
+        if !self.node_ptr.is_null() {
+            ffi::destroy_data_node(
+                self.bus_ptr.bus_ptr,
+                &mut self.node_ptr as *mut *mut ffi::DataNodeHandle,
+            );
+        }
+    }
+}
+
+unsafe impl Send for DataNode {}

--- a/apis/nosengine-rust/src/client/mod.rs
+++ b/apis/nosengine-rust/src/client/mod.rs
@@ -141,14 +141,8 @@ impl fmt::Display for NosError {
 impl Error for NosError {
     fn description(&self) -> &str {
         match self {
-            NosError::StringError {
-                description,
-                position: _,
-            } => &description,
-            NosError::NosEngineError {
-                error_code: _,
-                description,
-            } => &description,
+            NosError::StringError { description, .. } => &description,
+            NosError::NosEngineError { description, .. } => &description,
         }
     }
 }

--- a/apis/nosengine-rust/src/client/spi.rs
+++ b/apis/nosengine-rust/src/client/spi.rs
@@ -1,0 +1,241 @@
+//! This module contains the SPI functionality from NOSEngine.
+//!
+//! # Examples
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::client::spi::*;
+//! # use nosengine_rust::ffi::spi::SPIDirection;
+//! # use std::slice;
+//! let master = SPIMaster::new("tcp://localhost:12001", "spi19").unwrap();
+//!
+//! extern "C" fn callback(dir: SPIDirection, buffer: *mut u8, len: usize) -> usize {
+//!     let data = unsafe{ slice::from_raw_parts_mut(buffer, len) };
+//!     match dir {
+//!         SPIDirection::Read => {
+//!             for i in 0..len {
+//!                 data[i] = (i + 5) as u8;
+//!             }
+//!             len
+//!         },
+//!         SPIDirection::Write => {
+//!             assert_eq!(data, &[1u8, 2, 3, 4]);
+//!             len
+//!         }
+//!     }
+//! }
+//!
+//! let slave = SPISlave::new(1, "tcp://localhost:12001", "spi19", callback).unwrap();
+//!
+//! assert_eq!(master.write(&[1u8, 2, 3, 4]), Err(SPIError::ChipSelectionError));
+//! master.chip_select(1);
+//! assert_eq!(master.write(&[1u8, 2, 3, 4]), Ok(()));
+//! assert_eq!(master.read(4), Ok(vec![5u8, 6, 7, 8]));
+//! ```
+
+use super::ffi::spi;
+use std::error::Error;
+use std::ffi;
+use std::ffi::CString;
+use std::fmt;
+
+/// This enum represents any type of error that can occur when interacting with SPI.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SPIError {
+    /// An error occurred when converting a Rust string to a C string.
+    /// Specifically, the Rust string contained a null character, which cannot be represented
+    /// in C strings.
+    StringError {
+        /// Description from the underlying std::ffi::NulError
+        description: String,
+        /// Index in the original string of the problematic null character
+        position: usize,
+    },
+    /// There was an error when creating the SPI.
+    SPICreationError,
+    /// This error is raised when a read or write is attempted when either no chip is selected,
+    /// or the selected chip is not found on this bus
+    ChipSelectionError,
+}
+
+impl From<ffi::NulError> for SPIError {
+    fn from(err: ffi::NulError) -> Self {
+        SPIError::StringError {
+            description: String::from(err.description()),
+            position: err.nul_position(),
+        }
+    }
+}
+
+impl fmt::Display for SPIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SPIError::StringError {
+                description,
+                position,
+            } => write!(f, "Null character at index {}: {}", position, description),
+            SPIError::SPICreationError => write!(f, "Error while creating SPI node"),
+            SPIError::ChipSelectionError => write!(f, "No SPI chip selected"),
+        }
+    }
+}
+
+/// Represents a master on an SPI bus.
+pub struct SPIMaster<'a> {
+    spi_ptr: *mut spi::SPIHandle,
+    /// NOSEngine connection string
+    pub connection: &'a str,
+    /// Name of this bus to which this master is connected
+    pub bus: &'a str,
+}
+
+impl<'a> SPIMaster<'a> {
+    /// This function creates a new SPI master on the given bus. There can be only one: If you attempt to create
+    /// another master on the same bus, this function will return `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `connection`: NOSEngine connection string
+    /// * `bus`: Name of the bus on which to create the master
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::spi::*;
+    /// let master = SPIMaster::new("tcp://localhost:12001", "spi20");
+    /// assert!(master.is_ok());
+    /// ```
+    pub fn new(connection: &'a str, bus: &'a str) -> Result<SPIMaster<'a>, SPIError> {
+        let c_connection = CString::new(connection)?;
+        let c_bus = CString::new(bus)?;
+
+        let spi_ptr = spi::spi_init_master(c_connection.as_ptr(), c_bus.as_ptr());
+
+        if spi_ptr.is_null() {
+            Err(SPIError::SPICreationError)
+        } else {
+            Ok(SPIMaster {
+                spi_ptr,
+                connection,
+                bus,
+            })
+        }
+    }
+
+    /// This function reads bytes from the currently-selected chip. If no chip is selected, then
+    /// this will return `Err`.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_bytes`: How many bytes to read from the device
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client::spi`](../spi/index.html#examples)
+    pub fn read(&self, num_bytes: usize) -> Result<Vec<u8>, SPIError> {
+        let mut rbuf: Vec<u8> = Vec::with_capacity(num_bytes);
+        rbuf.resize(num_bytes, 0u8);
+        match spi::spi_read(self.spi_ptr, rbuf.as_mut_ptr(), num_bytes) {
+            spi::SPIStatus::Success => Ok(rbuf),
+            spi::SPIStatus::Failure => Err(SPIError::ChipSelectionError),
+        }
+    }
+
+    /// This function writes bytes to the currently-selected chip. If no chip is selected, then this will
+    /// return `Err`.
+    ///
+    /// # Arguments
+    ///
+    /// * `data`: Bytes to write to the device
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client::spi`](../spi/index.html#examples)
+    pub fn write(&self, data: &[u8]) -> Result<(), SPIError> {
+        match spi::spi_write(self.spi_ptr, data.as_ptr(), data.len()) {
+            spi::SPIStatus::Success => Ok(()),
+            spi::SPIStatus::Failure => Err(SPIError::ChipSelectionError),
+        }
+    }
+
+    /// Select the device to communicate with.
+    ///
+    /// # Examples
+    ///
+    /// See [`nosengine-rust::client::spi`](../spi/index.html#examples)
+    pub fn chip_select(&self, cs: u8) {
+        spi::spi_select_chip(self.spi_ptr, cs);
+    }
+
+    /// Unselect the current device.
+    pub fn chip_unselect(&self) {
+        spi::spi_unselect_chip(self.spi_ptr);
+    }
+}
+
+impl<'a> Drop for SPIMaster<'a> {
+    fn drop(&mut self) {
+        spi::spi_close(&mut self.spi_ptr as *mut *mut spi::SPIHandle);
+    }
+}
+
+/// This struct represents an SPI Slave.
+pub struct SPISlave<'a> {
+    spi_ptr: *mut spi::SPIHandle,
+    /// The NOSEngine connection string
+    pub connection: &'a str,
+    /// Name of the bus to which this slave is connected
+    pub bus: &'a str,
+    /// Chip select number of this slave
+    pub cs: u8,
+}
+
+impl<'a> SPISlave<'a> {
+    /// Construct a new SPI slave. The given callback will be run every time the master reads
+    /// from or writes to this slave. If a slave with the given chip select already exists on
+    /// this bus, this function returns `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `cs`: Chip select number for this slave. Must be unique on a bus
+    /// * `connection`: NOSEngine connection string
+    /// * `bus`: Name of the bus to connect to
+    /// * `callback`: Callback that runs every time the master reads from or writes to this device.
+    ///     The callback is responsible for checking whether it is reading or writing, performing
+    ///     the appropriate action, then returning the number of bytes read or written. The
+    ///     arguments to the callback are:
+    ///     * `SPIDirection`: Specifies whether this is a read or write
+    ///     * `*mut u8`: The buffer which either contains the data being written to this device, or
+    ///         to which this device should write data. It is guaranteed to have enough bytes of
+    ///         valid memory based on the length argument
+    ///     * `usize`: The number of bytes being read or written
+    pub fn new(
+        cs: u8,
+        connection: &'a str,
+        bus: &'a str,
+        callback: extern "C" fn(spi::SPIDirection, *mut u8, usize) -> usize,
+    ) -> Result<SPISlave<'a>, SPIError> {
+        let c_connection = CString::new(connection)?;
+        let c_bus = CString::new(bus)?;
+
+        let spi_ptr = spi::spi_init_slave(cs, c_connection.as_ptr(), c_bus.as_ptr(), callback);
+
+        if spi_ptr.is_null() {
+            Err(SPIError::SPICreationError)
+        } else {
+            Ok(SPISlave {
+                spi_ptr,
+                connection,
+                bus,
+                cs,
+            })
+        }
+    }
+}
+
+impl<'a> Drop for SPISlave<'a> {
+    fn drop(&mut self) {
+        spi::spi_close(&mut self.spi_ptr as *mut *mut spi::SPIHandle);
+    }
+}

--- a/apis/nosengine-rust/src/client/spi.rs
+++ b/apis/nosengine-rust/src/client/spi.rs
@@ -134,7 +134,7 @@ impl<'a> SPIMaster<'a> {
     ///
     /// See [`nosengine-rust::client::spi`](../spi/index.html#examples)
     pub fn read(&self, num_bytes: usize) -> Result<Vec<u8>, SPIError> {
-        let mut rbuf: Vec<u8> = Vec::with_capacity(num_bytes);
+        let mut rbuf: Vec<u8> = vec![0; num_bytes];
         rbuf.resize(num_bytes, 0u8);
         match spi::spi_read(self.spi_ptr, rbuf.as_mut_ptr(), num_bytes) {
             spi::SPIStatus::Success => Ok(rbuf),

--- a/apis/nosengine-rust/src/client/uart.rs
+++ b/apis/nosengine-rust/src/client/uart.rs
@@ -1,0 +1,286 @@
+//! Provides functionality for communicating using UART on NOSEngine.
+//!
+
+use super::ffi::uart;
+use libc;
+use std::error::Error;
+use std::ffi;
+use std::ffi::CString;
+use std::fmt;
+use std::slice;
+
+/// This enum represents any type of error that can occur when interacting with UART.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UARTError {
+    /// An error occurred when converting a Rust string to a C string.
+    /// Specifically, the Rust string contained a null character, which cannot be represented
+    /// in C strings.
+    StringError {
+        /// Description from the underlying std::ffi::NulError
+        description: String,
+        /// Index in the original string of the problematic null character
+        position: usize,
+    },
+    /// There was an error when creating the UART.
+    UARTCreationError,
+}
+
+impl From<ffi::NulError> for UARTError {
+    fn from(err: ffi::NulError) -> Self {
+        UARTError::StringError {
+            description: String::from(err.description()),
+            position: err.nul_position(),
+        }
+    }
+}
+
+impl fmt::Display for UARTError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            UARTError::StringError {
+                description,
+                position,
+            } => write!(f, "Null character at index {}: {}", position, description),
+            UARTError::UARTCreationError => write!(f, "Error while creating UART node"),
+        }
+    }
+}
+
+/// This struct represents one UART connection.
+#[derive(Clone)]
+pub struct UART {
+    uart_ptr: *mut uart::UARTHandle,
+    /// The name of this UART port. Must be unique on a bus
+    pub name: String,
+    /// The connection string to the server
+    pub connection: String,
+    /// The port number for this UART connection
+    pub port: u8,
+}
+
+unsafe impl Sync for UART {}
+
+impl UART {
+    /// Create a new UART connection. If there are already two connections on the given
+    /// port on the given bus, then this function returns `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `name`: Name of this UART connection. Must be unique on a bus.
+    /// * `connection`: Connection string to server. Usually of the form `tcp://<domain>:<port>`,
+    ///     but can take other forms. See the connection string section of the NOSEngine
+    ///     user manual for more.
+    /// * `bus`: Name of the bus to which this UART should connect. If the bus does not already
+    ///     exist, it will be created automatically.
+    /// * `port`: A number to identify a unique port. Multiple ports can exist on the same bus,
+    ///     but only two UART connections can be opened on a given port on a given bus.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// let uart = UART::new("uart1", "tcp://localhost:12001", "uart2", 10);
+    /// assert!(uart.is_ok());
+    /// ```
+    ///
+    /// If there is already a node on the bus with the same name, this function returns `None`.
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// let uart = UART::new("uart14", "tcp://localhost:12001", "uart2", 10);
+    /// assert!(uart.is_ok());
+    /// let uart2 = UART::new("uart14", "tcp://localhost:12001", "uart2", 10);
+    /// assert!(uart2.is_err());
+    /// ```
+    ///
+    /// However, once a UART is dropped, you can create another node with the same name.
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// {
+    ///     let uart = UART::new("uart15", "tcp://localhost:12001", "uart2", 10);
+    ///     assert!(uart.is_ok());
+    /// } // uart is dropped here
+    /// let uart2 = UART::new("uart15", "tcp://localhost:12001", "uart2", 10);
+    /// assert!(uart2.is_ok());
+    /// ```
+    pub fn new(name: &str, connection: &str, bus: &str, port: u8) -> Result<UART, UARTError> {
+        let c_name = CString::new(name)?;
+        let c_connection = CString::new(connection)?;
+        let c_bus = CString::new(bus)?;
+
+        let uart_ptr =
+            uart::uart_open(c_name.as_ptr(), c_connection.as_ptr(), c_bus.as_ptr(), port);
+
+        if uart_ptr.is_null() {
+            Err(UARTError::UARTCreationError)
+        } else {
+            Ok(UART {
+                uart_ptr,
+                name: String::from(name),
+                connection: String::from(connection),
+                port,
+            })
+        }
+    }
+
+    /// Read bytes from this UART's buffer. Will read at most `num_bytes` bytes, but if
+    /// fewer bytes are available (including 0), the resulting vector will be smaller
+    /// than `num_bytes`.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_bytes`: The maximum number of bytes to read
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// let uart1 = UART::new("uart2", "tcp://localhost:12001", "uart2", 11).unwrap();
+    /// let uart2 = UART::new("uart3", "tcp://localhost:12001", "uart2", 11).unwrap();
+    ///
+    /// uart1.write(&[1u8, 2, 3, 4]);
+    /// let result = uart2.read(100);
+    /// assert_eq!(result, &[1u8, 2, 3, 4]);
+    /// ```
+    pub fn read(&self, num_bytes: usize) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::with_capacity(num_bytes);
+        let len = uart::uart_read(self.uart_ptr, buffer.as_mut_ptr(), num_bytes);
+        assert!(len <= num_bytes);
+        unsafe {
+            buffer.set_len(len);
+        }
+        buffer
+    }
+
+    /// Write the given bytes to the UART port.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// let uart1 = UART::new("uart4", "tcp://localhost:12001", "uart2", 12).unwrap();
+    /// let uart2 = UART::new("uart5", "tcp://localhost:12001", "uart2", 12).unwrap();
+    ///
+    /// uart1.write(&[1u8, 2, 3, 4]);
+    /// let result = uart2.read(100);
+    /// assert_eq!(result, &[1u8, 2, 3, 4]);
+    /// ```
+    pub fn write(&self, data: &[u8]) -> usize {
+        uart::uart_write(self.uart_ptr, data.as_ptr(), data.len())
+    }
+
+    /// Write one individual byte to the UART port.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// let uart1 = UART::new("uart6", "tcp://localhost:12001", "uart2", 13).unwrap();
+    /// let uart2 = UART::new("uart7", "tcp://localhost:12001", "uart2", 13).unwrap();
+    /// uart1.putc(12u8);
+    /// let result = uart2.getc();
+    /// assert_eq!(result, Some(12u8));
+    /// ```
+    pub fn putc(&self, c: u8) {
+        uart::uart_putc(self.uart_ptr, c)
+    }
+
+    /// Retrieve one individual byte from the UART port. If no bytes are available, then
+    /// `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// let uart1 = UART::new("uart8", "tcp://localhost:12001", "uart2", 14).unwrap();
+    /// let uart2 = UART::new("uart9", "tcp://localhost:12001", "uart2", 14).unwrap();
+    ///
+    /// uart1.putc(12u8);
+    /// let result = uart2.getc();
+    /// assert_eq!(result, Some(12u8));
+    /// let result = uart2.getc();
+    /// assert_eq!(result, None);
+    /// ```
+    pub fn getc(&self) -> Option<u8> {
+        let mut c = 0u8;
+        match uart::uart_getc(self.uart_ptr, &mut c as *mut u8) {
+            uart::UARTStatus::Success => Some(c),
+            uart::UARTStatus::Failure => None,
+        }
+    }
+
+    /// Set a callback which will run whenever this UART port receives data.
+    ///
+    /// # Arguments
+    ///
+    /// * `func`: A callback with the following parameters:
+    ///     * `&[u8]`: The data that was just written to this port
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// let uart1 = UART::new("uart10", "tcp://localhost:12001", "uart2", 15).unwrap();
+    /// let mut uart2 = UART::new("uart11", "tcp://localhost:12001", "uart2", 15).unwrap();
+    ///
+    /// uart2.set_callback(move |data: &[u8]|{
+    ///     assert_eq!(data, &[1u8, 2, 3, 4]);
+    /// });
+    ///
+    /// uart1.write(&[1u8, 2, 3, 4]);
+    /// ```
+    pub fn set_callback<F>(&mut self, func: F)
+    where
+        F: FnMut(&[u8]) -> (),
+        F: 'static,
+    {
+        extern "C" fn c_callback(data: *const u8, len: usize, user: *mut libc::c_void) {
+            unsafe {
+                let func = user as *mut Box<FnMut(&[u8])>;
+                let data = slice::from_raw_parts(data, len);
+                (*func)(data);
+            }
+        }
+
+        let func = Box::new(func) as Box<FnMut(&[u8])>;
+        let func = Box::into_raw(Box::new(func));
+
+        uart::uart_set_read_callback(self.uart_ptr, c_callback, func as *mut libc::c_void);
+    }
+
+    /// Return the number of bytes waiting to be read by this UART.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate nosengine_rust;
+    /// # use nosengine_rust::client::uart::*;
+    /// let uart1 = UART::new("uart12", "tcp://localhost:12001", "uart2", 16).unwrap();
+    /// let uart2 = UART::new("uart13", "tcp://localhost:12001", "uart2", 16).unwrap();
+    ///
+    /// uart1.write(&[1u8, 2, 3, 4]);
+    /// assert_eq!(uart2.available(), 4);
+    /// uart2.read(2);
+    /// assert_eq!(uart2.available(), 2);
+    /// ```
+    pub fn available(&self) -> usize {
+        uart::uart_available(self.uart_ptr) as usize
+    }
+}
+
+impl Drop for UART {
+    fn drop(&mut self) {
+        uart::uart_close(&mut self.uart_ptr as *mut *mut uart::UARTHandle);
+    }
+}
+
+unsafe impl Send for UART {}

--- a/apis/nosengine-rust/src/ffi/i2c.rs
+++ b/apis/nosengine-rust/src/ffi/i2c.rs
@@ -1,0 +1,293 @@
+//! This module contains thin wrappers over the NOSEngine I2C API.
+//!
+//! # Examples
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::ffi::i2c::*;
+//! # use std::ffi::CString;
+//! # use std::slice;
+//! let connection = CString::new("tcp://localhost:12001").unwrap();
+//! let bus = CString::new("i2c10").unwrap();
+//! let mut master = i2c_init_master(9u16, connection.as_ptr(), bus.as_ptr());
+//!
+//! extern "C" fn callback(dir: I2CDirection, buffer: *mut u8, len: usize) -> usize {
+//!     let mut buffer = unsafe { slice::from_raw_parts_mut(buffer, len) };
+//!     match dir {
+//!         I2CDirection::Read => {
+//!             for i in 0u8..4u8 {
+//!                 buffer[i as usize] = i + 5;
+//!             }
+//!             len
+//!         },
+//!         I2CDirection::Write => {
+//!             assert_eq!(buffer, &[1u8, 2, 3, 4]);
+//!             len
+//!         }
+//!     }
+//! }
+//! let mut slave = i2c_init_slave(10u16, connection.as_ptr(), bus.as_ptr(), callback);
+//!
+//! let mut wbuf = vec![1u8, 2u8, 3u8, 4u8];
+//! let mut rbuf = vec![0u8, 0u8, 0u8, 0u8];
+//!
+//! let result = i2c_transaction(master, 10u16, wbuf.as_ptr(), 4, rbuf.as_mut_ptr(), 4);
+//! assert_eq!(result, I2CStatus::Success);
+//! assert_eq!(rbuf, &[5u8, 6, 7, 8]);
+//!
+//! i2c_close(&mut slave as *mut *mut I2CHandle);
+//! i2c_close(&mut master as *mut *mut I2CHandle);
+//! ```
+
+use libc::c_char;
+
+/// This function initializes an I2C master on the given bus, with the given address.
+/// Only one master can exist per bus.
+///
+/// # Arguments
+///
+/// * `address`: Address of the master. Must be between 8 and 127, inclusive.
+/// * `connection`: NOSEngine connection string
+/// * `bus`: Name of bus to use for I2C
+///
+/// # Examples
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::i2c::*;
+/// # use std::ffi::CString;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("i2c1").unwrap();
+/// let mut master = i2c_init_master(9u16, connection.as_ptr(), bus.as_ptr());
+/// assert!(!master.is_null());
+/// let mut master2 = i2c_init_master(9u16, connection.as_ptr(), bus.as_ptr());
+/// assert!(master2.is_null());
+/// i2c_close(&mut master as *mut *mut I2CHandle);
+/// i2c_close(&mut master2 as *mut *mut I2CHandle);
+/// ```
+pub fn i2c_init_master(
+    address: u16,
+    connection: *const c_char,
+    bus: *const c_char,
+) -> *mut I2CHandle {
+    unsafe { NE_i2c_init_master(address, connection, bus) }
+}
+
+/// This function initializes an I2C slave on the given bus, with the given address.
+///
+/// # Arguments
+///
+/// * `address`: Unique address of the slave. Must be unique, and must be between
+///     8 and 127, inclusive.
+/// * `connection`: NOSEngine connection string
+/// * `bus`: Name of the bus to use for I2C
+/// * `callback`: Function which will be called every time a master reads or writes to this slave.
+///     This callback should return the number of bytes it has read or written.
+///     The callback's parameters are:
+///     * `I2CDirection`: Indicates whether the master is reading or writing
+///     * `*mut u8`: This is a buffer. If the master is writing, then the slave should read the
+///         data from this buffer. If the master is reading, then the slave should write into
+///         this buffer.
+///     * `usize`: The number of bytes that should be read or written
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::i2c::*;
+/// # use std::ffi::CString;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("i2c2").unwrap();
+///
+/// extern "C" fn callback(dir: I2CDirection, buffer: *mut u8, len: usize) -> usize {0}
+///
+/// let mut slave = i2c_init_slave(10u16, connection.as_ptr(), bus.as_ptr(), callback);
+/// assert!(!slave.is_null());
+/// i2c_close(&mut slave as *mut *mut I2CHandle);
+/// ```
+pub fn i2c_init_slave(
+    address: u16,
+    connection: *const c_char,
+    bus: *const c_char,
+    callback: extern "C" fn(I2CDirection, *mut u8, usize) -> usize,
+) -> *mut I2CHandle {
+    unsafe { NE_i2c_init_slave(address, connection, bus, callback) }
+}
+
+/// This function closes an I2C connection and frees up all associated memory.
+///
+/// # Arguments
+///
+/// * `i2c`: A pointer to a pointer to an I2C handle. This handle will be made null by this
+///     function.
+///
+/// # Examples
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::i2c::*;
+/// # use std::ffi::CString;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("i2c3").unwrap();
+/// let mut master = i2c_init_master(9u16, connection.as_ptr(), bus.as_ptr());
+/// assert!(!master.is_null());
+/// i2c_close(&mut master as *mut *mut I2CHandle);
+/// assert!(master.is_null());
+/// ```
+pub fn i2c_close(i2c: *mut *mut I2CHandle) {
+    unsafe { NE_i2c_close(i2c) }
+}
+
+/// This function reads from the specified address.
+///
+/// # Arguments
+///
+/// * `i2c`: Handle to an I2C master
+/// * `address`: Address from which you are reading
+/// * `rbuf`: A buffer in which the read data will be stored. Must contain at lease `rlen`
+///     consecutive bytes of valid memory.
+/// * `rlen`: Maximum number of bytes to read
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::i2c::*;
+/// # use std::ffi::CString;
+/// # use std::slice;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("i2c4").unwrap();
+/// let mut master = i2c_init_master(9u16, connection.as_ptr(), bus.as_ptr());
+///
+/// extern "C" fn callback(dir: I2CDirection, buffer: *mut u8, len: usize) -> usize {
+///     assert_eq!(dir, I2CDirection::Read);
+///     let mut buffer = unsafe { slice::from_raw_parts_mut(buffer, len) };
+///     for i in 1u8..5u8 {
+///         buffer[(i - 1) as usize] = i;
+///     }
+///     len
+/// }
+/// let mut slave = i2c_init_slave(10u16, connection.as_ptr(), bus.as_ptr(), callback);
+///
+/// let mut buffer = vec![0u8, 0u8, 0u8, 0u8];
+///
+/// let result = i2c_read(master, 10u16, buffer.as_mut_ptr(), 4);
+/// // Expect a failure because no chip was selected.
+/// // assert_eq!(result, I2CStatus::Failure);
+///
+/// i2c_close(&mut master as *mut *mut I2CHandle);
+/// i2c_close(&mut slave as *mut *mut I2CHandle);
+/// ```
+pub fn i2c_read(i2c: *mut I2CHandle, address: u16, rbuf: *mut u8, rlen: usize) -> I2CStatus {
+    unsafe { NE_i2c_read(i2c, address, rbuf, rlen) }
+}
+
+/// This function writes to the specified address.
+///
+/// # Arguments
+///
+/// * `i2c`: Handle to an I2C master
+/// * `address`: Address to which you are writing
+/// * `wbuf`: A buffer from which the slave will read data. Must contain at lease `wlen`
+///     consecutive bytes of valid memory.
+/// * `wlen`: Number of bytes to write
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::i2c::*;
+/// # use std::ffi::CString;
+/// # use std::slice;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("i2c5").unwrap();
+/// let mut master = i2c_init_master(9u16, connection.as_ptr(), bus.as_ptr());
+///
+/// extern "C" fn callback(dir: I2CDirection, buffer: *mut u8, len: usize) -> usize {
+///     assert_eq!(dir, I2CDirection::Write);
+///     let mut buffer = unsafe { slice::from_raw_parts_mut(buffer, len) };
+///     assert_eq!(buffer, [1u8, 2, 3, 4]);
+///     len
+/// }
+/// let mut slave = i2c_init_slave(10u16, connection.as_ptr(), bus.as_ptr(), callback);
+///
+/// let data = &[1u8, 2, 3, 4];
+///
+/// let result = i2c_write(master, 10u16, data.as_ptr(), 4);
+/// assert_eq!(result, I2CStatus::Success);
+///
+/// i2c_close(&mut slave as *mut *mut I2CHandle);
+/// i2c_close(&mut master as *mut *mut I2CHandle);
+/// ```
+pub fn i2c_write(i2c: *mut I2CHandle, address: u16, wbuf: *const u8, wlen: usize) -> I2CStatus {
+    unsafe { NE_i2c_write(i2c, address, wbuf, wlen) }
+}
+
+/// This function performs an I2C transaction, which consists of a write followed by a read.
+///
+/// # Arguments
+///
+/// * `i2c`: Handle to an I2C master
+/// * `address`: Address of the slave in this transaction
+/// * `wbuf`: A buffer from which the slave will read data. Must contain at lease `wlen`
+///     consecutive bytes of valid memory.
+/// * `wlen`: Number of bytes to write
+/// * `rbuf`: A buffer in which the read data will be stored. Must contain at lease `rlen`
+///     consecutive bytes of valid memory.
+/// * `rlen`: Maximum number of bytes to read
+///
+/// # Examples
+///
+/// See [`nosengine-rust::ffi::i2c`](../i2c/index.html#examples)
+pub fn i2c_transaction(
+    i2c: *mut I2CHandle,
+    address: u16,
+    wbuf: *const u8,
+    wlen: usize,
+    rbuf: *mut u8,
+    rlen: usize,
+) -> I2CStatus {
+    unsafe { NE_i2c_transaction(i2c, address, wbuf, wlen, rbuf, rlen) }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[repr(C)]
+#[allow(missing_docs)]
+pub enum I2CStatus {
+    Success,
+    Failure,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[repr(C)]
+#[allow(missing_docs)]
+pub enum I2CDirection {
+    Write,
+    Read,
+}
+
+/// This enum represents a handle to an opaque C struct.
+pub enum I2CHandle {}
+
+extern "C" {
+    fn NE_i2c_init_master(
+        address: u16,
+        connection: *const c_char,
+        bus: *const c_char,
+    ) -> *mut I2CHandle;
+    fn NE_i2c_init_slave(
+        address: u16,
+        connection: *const c_char,
+        bus: *const c_char,
+        callback: extern "C" fn(I2CDirection, *mut u8, usize) -> usize,
+    ) -> *mut I2CHandle;
+    fn NE_i2c_close(i2c: *mut *mut I2CHandle);
+    fn NE_i2c_read(i2c: *mut I2CHandle, address: u16, rbuf: *mut u8, rlen: usize) -> I2CStatus;
+    fn NE_i2c_write(i2c: *mut I2CHandle, address: u16, wbuf: *const u8, wlen: usize) -> I2CStatus;
+    fn NE_i2c_transaction(
+        i2c: *mut I2CHandle,
+        address: u16,
+        wbuf: *const u8,
+        wlen: usize,
+        rbuf: *mut u8,
+        rlen: usize,
+    ) -> I2CStatus;
+}

--- a/apis/nosengine-rust/src/ffi/mod.rs
+++ b/apis/nosengine-rust/src/ffi/mod.rs
@@ -1,0 +1,508 @@
+//! This module wraps the C interface of NOSEngine. It provides the basic functionality
+//! for base buses and communication. All functions that are prefixed by `NE_` are the unsafe
+//! C functions. All others are safe wrappers around the C functions.
+//!
+//! # Examples
+//!
+//! This example demonstrates the use of a callback to asynchronously reply to a message.
+//!
+//! ```
+//! extern crate nosengine_rust;
+//! use std::ffi::CString;
+//! use nosengine_rust::ffi::*;
+//! use std::{slice, ptr};
+//!
+//! let busname = CString::new("testbus").unwrap();
+//! let connection = CString::new("tcp://localhost:12001").unwrap();
+//! let node1_name = CString::new("node1").unwrap();
+//! let node2_name = CString::new("node2").unwrap();
+//!
+//! let mut bus: *mut BusHandle = create_bus2(busname.as_ptr(), connection.as_ptr());
+//!
+//! let mut data_node1: *mut DataNodeHandle = create_data_node(bus,node1_name.as_ptr());
+//!
+//! let mut data_node2: *mut DataNodeHandle = create_data_node(bus,node2_name.as_ptr());
+//!
+//! extern "C" fn callback(node: *mut DataNodeHandle, msg: *mut MessageHandle){
+//! let data = unsafe {
+//!     slice::from_raw_parts(
+//!     message_get_user_data(msg),
+//!     message_get_user_data_length(msg)
+//! )};
+//! assert_eq!(data, &[1u8, 2, 3, 4]);
+//!     data_node_send_reply_message_sync(node, msg, 4, [5u8, 6, 7, 8].as_ptr());
+//! }
+//! data_node_set_message_received_callback(data_node2, callback);
+//!
+//! let data = &[1u8, 2, 3, 4];
+//! let mut msg: *mut MessageHandle = ptr::null_mut();
+//! data_node_send_request_message_sync(
+//!     data_node1,
+//!     node2_name.as_ptr(),
+//!     data.len(),
+//!     data.as_ptr(),
+//!     &mut msg as *mut *mut MessageHandle
+//! );
+//!
+//! let response = unsafe {
+//!     slice::from_raw_parts(
+//!         message_get_user_data(msg),
+//!         message_get_user_data_length(msg)
+//!     )
+//! };
+//! assert_eq!(response, &[5u8, 6, 7, 8]);
+//!
+//! destroy_message(&mut msg as *mut *mut MessageHandle);
+//! destroy_data_node(bus, &mut data_node1 as *mut *mut DataNodeHandle);
+//! destroy_data_node(bus, &mut data_node2 as *mut *mut DataNodeHandle);
+//! destroy_bus(&mut bus as *mut *mut BusHandle);
+//! ```
+//!
+//! This example uses a separate thread with a second data node synchronously waiting for a message.
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use std::ffi::CString;
+//! # use nosengine_rust::ffi::*;
+//! # use std::{slice, ptr, thread, time};
+//!
+//! let bus_name = CString::new("testbus").unwrap();
+//! let connection = CString::new("tcp://localhost:12001").unwrap();
+//! let mut bus: *mut BusHandle = create_bus2(bus_name.as_ptr(), connection.as_ptr());
+//!
+//! let node1_name = CString::new("node3").unwrap();
+//! let mut node1: *mut DataNodeHandle = create_data_node(bus, node1_name.as_ptr());
+//!
+//! let node2_name = CString::new("node4").unwrap();
+//!
+//!
+//! let join_handle = thread::spawn( move ||{
+//!     let mut bus: *mut BusHandle = create_bus2(bus_name.as_ptr(), connection.as_ptr());
+//!
+//!     let node2_name = CString::new("node4").unwrap();
+//!     let mut node2: *mut DataNodeHandle = create_data_node(bus, node2_name.as_ptr());
+//!
+//!     println!("I'm in the thread now!");
+//!
+//!     let mut msg = data_node_receive_message_sync(node2);
+//!     let data = unsafe {
+//!         slice::from_raw_parts(
+//!             message_get_user_data(msg),
+//!             message_get_user_data_length(msg)
+//!         )
+//!     };
+//!     assert_eq!(data, [1u8, 2, 3, 4]);
+//!     destroy_message(&mut msg as *mut *mut MessageHandle);
+//!     destroy_data_node(bus, &mut node2 as *mut *mut DataNodeHandle);
+//!     destroy_bus(&mut bus as *mut *mut BusHandle);
+//! });
+//!
+//! // Wait to make sure the other node has been created
+//! thread::sleep(time::Duration::from_millis(100));
+//!
+//! let data = [1u8, 2, 3, 4];
+//! data_node_send_message_sync(node1, node2_name.as_ptr(), data.len(), data.as_ptr());
+//!
+//! join_handle.join().unwrap();
+//!
+//! destroy_data_node(bus, &mut node1 as *mut *mut DataNodeHandle);
+//! destroy_bus(&mut bus as *mut *mut BusHandle);
+//! ```
+
+pub mod i2c;
+pub mod spi;
+pub mod uart;
+
+use libc::c_char;
+
+/// This represents a pointer to an opaque C struct.
+pub enum BusHandle {}
+
+/// This represents a pointer to an opaque C struct.
+pub enum DataNodeHandle {}
+
+/// This represents a pointer to an opaque C struct.
+pub enum MessageHandle {}
+
+/// This returns the most recent error encountered by NOSEngine.
+pub fn error() -> ErrorCode {
+    unsafe { NE_error() }
+}
+
+/// This returns a string describing the most recent error encountered by NOSEngine.
+/// Note: No guarantees can be made about the lifetime of this pointer, so if needed, make a copy
+/// of the contents as soon as possible.
+pub fn error_string() -> *const c_char {
+    unsafe { NE_error_string() }
+}
+
+/// Creates a new bus, or connects to an existing bus.
+///
+/// # Arguments
+///
+/// * `name`: Name of the bus to create, as a null-terminated C string
+/// * `server_uri`: Connection string to server, as null-terminated C string
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use std::ffi::CString;
+/// # use nosengine_rust::ffi::*;
+/// #
+/// let bus_name = CString::new("testbus").unwrap();
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+///
+/// let mut bus: *mut BusHandle = create_bus2(bus_name.as_ptr(), connection.as_ptr());
+/// assert!(!bus.is_null());
+/// # destroy_bus(&mut bus as *mut *mut BusHandle);
+/// ```
+pub fn create_bus2(name: *const c_char, server_uri: *const c_char) -> *mut BusHandle {
+    unsafe { NE_create_bus2(name, server_uri) }
+}
+
+/// This function cleans up the memory of a `*mut BusHandle`.
+///
+/// # Arguments
+///
+/// * `bus`: Mutable pointer to the pointer to the bus. After this function is run, the
+///     pointer to the bus will be made `null`.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use std::ffi::CString;
+/// # use nosengine_rust::ffi::*;
+/// #
+/// let bus_name = CString::new("testbus").unwrap();
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+///
+/// let mut bus: *mut BusHandle = create_bus2(bus_name.as_ptr(), connection.as_ptr());
+///
+/// destroy_bus(&mut bus as *mut *mut BusHandle);
+/// assert!(bus.is_null());
+/// ```
+pub fn destroy_bus(bus: *mut *mut BusHandle) {
+    unsafe { NE_destroy_bus(bus) }
+}
+
+/// This function creates a pointer to an opaque data node struct.
+///
+/// Note: If a node with the given name already exists on the given bus, then this function
+/// returns a pointer to the existing node. Therefore, if two nodes are created with the same
+/// name, and one is freed, then the other becomes invalid.
+///
+/// # Arguments
+///
+/// * `bus`: Mutable pointer to the bus on which this node is to be created
+/// * `name`: Name of the data node, as null-terminated C string
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::*;
+/// # use std::ffi::CString;
+/// #
+/// # let bus_name = CString::new("testbus").unwrap();
+/// # let connection = CString::new("tcp://localhost:12001").unwrap();
+/// #
+/// # let mut bus: *mut BusHandle = create_bus2(bus_name.as_ptr(), connection.as_ptr());
+/// #
+/// let node1_name = CString::new("node5").unwrap();
+///
+/// let mut node1: *mut DataNodeHandle = create_data_node(bus, node1_name.as_ptr());
+///
+/// assert!(!node1.is_null());
+/// #
+/// # destroy_data_node(bus, &mut node1 as *mut *mut DataNodeHandle);
+/// # destroy_bus(&mut bus as *mut *mut BusHandle);
+/// ```
+pub fn create_data_node(bus: *mut BusHandle, name: *const c_char) -> *mut DataNodeHandle {
+    unsafe { NE_create_data_node(bus, name) }
+}
+
+/// This function frees up the memory associated with a data node pointer.
+///
+/// Note: If another node with the same name was created on the same bus, then it will share
+/// the same memory as this data node. Therefore, after this data node is destroyed, the other
+/// data node pointer will become invalid.
+///
+/// # Arguments
+///
+/// * `bus`: Mutable pointer to the bus on which this node was created
+/// * `node`: Mutable pointer to the mutable pointer to the data node. After this function is
+///     called, the pointer is made to be null.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::*;
+/// # use std::ffi::CString;
+/// #
+/// # let bus_name = CString::new("testbus").unwrap();
+/// # let connection = CString::new("tcp://localhost:12001").unwrap();
+/// #
+/// # let mut bus: *mut BusHandle = create_bus2(bus_name.as_ptr(), connection.as_ptr());
+/// #
+/// let node1_name = CString::new("node6").unwrap();
+///
+/// let mut node1: *mut DataNodeHandle = create_data_node(bus, node1_name.as_ptr());
+///
+/// destroy_data_node(bus, &mut node1 as *mut *mut DataNodeHandle);
+/// assert!(node1.is_null());
+/// # destroy_bus(&mut bus as *mut *mut BusHandle);
+/// ```
+pub fn destroy_data_node(bus: *mut BusHandle, node: *mut *mut DataNodeHandle) {
+    unsafe { NE_destroy_data_node(bus, node) }
+}
+
+/// This function synchronously sends a message from one data node to another on the same bus.
+///
+/// # Arguments
+///
+/// * `node`: Pointer to a node created using the `create_data_node` function
+/// * `dest`: Name of the node to which this message should be sent, as a null-terminated C string
+/// * `length`: Size of the message to be sent, in bytes
+/// * `data`: Pointer to the array of bytes to be sent. There must be at least `length` bytes of
+///     valid memory after this pointer
+///
+/// # Examples
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::*;
+/// # use std::ffi::CString;
+/// #
+/// # let bus_name = CString::new("testbus").unwrap();
+/// # let connection = CString::new("tcp://localhost:12001").unwrap();
+/// #
+/// # let mut bus: *mut BusHandle = create_bus2(bus_name.as_ptr(), connection.as_ptr());
+/// #
+/// let node1_name = CString::new("node7").unwrap();
+/// let mut node1: *mut DataNodeHandle = create_data_node(bus, node1_name.as_ptr());
+///
+/// let node2_name = CString::new("node8").unwrap();
+/// let mut node2: *mut DataNodeHandle = create_data_node(bus, node2_name.as_ptr());
+///
+/// let data = &[1u8, 2, 3, 4];
+/// data_node_send_message_sync(
+///     node1,
+///     node2_name.as_ptr(),
+///     data.len(),
+///     data.as_ptr()
+///  );
+///
+/// assert_eq!(error(), ErrorCode::Ok);
+/// #
+/// # destroy_data_node(bus, &mut node1 as *mut *mut DataNodeHandle);
+/// # destroy_data_node(bus, &mut node2 as *mut *mut DataNodeHandle);
+/// # destroy_bus(&mut bus as *mut *mut BusHandle);
+/// ```
+pub fn data_node_send_message_sync(
+    node: *mut DataNodeHandle,
+    dest: *const c_char,
+    length: usize,
+    data: *const u8,
+) {
+    unsafe { NE_data_node_send_message_sync(node, dest, length, data) }
+}
+
+/// This function synchronously sends a message, and blocks until the recipient replies using
+/// `data_node_send_reply_message_sync`
+///
+/// # Arguments
+///
+/// * `node`: Pointer to a node created using the `create_data_node` function
+/// * `destination`: Name of the node to which this message should be sent, as a null-terminated C string
+/// * `length`: Size of the message to be sent, in bytes
+/// * `data`: Pointer to the array of bytes to be sent. There must be at least `length` bytes of
+///     valid memory after this pointer
+/// * `response`: Pointer to an empty pointer to a MessageHandle. This pointer is modified to point
+///     to a valid `MessageHandle` by this function
+///
+/// # Safety
+///
+/// You MUST eventually call `destroy_message` on the response message placed into the
+/// `response` pointer, or it will be a memory leak.
+///
+/// # Examples
+///
+/// See [`nosengine-rust::ffi`](../ffi/index.html#examples)
+pub fn data_node_send_request_message_sync(
+    node: *mut DataNodeHandle,
+    destination: *const c_char,
+    length: usize,
+    data: *const u8,
+    response: *mut *mut MessageHandle,
+) {
+    unsafe {
+        NE_data_node_send_request_message_sync(node, destination, length, data, response);
+    }
+}
+
+/// This function sends a reply message. When a node sends a message using `data_node_send_request_message_sync`,
+/// it will block until the recipient replies using this function.
+///
+/// # Arguments
+///
+/// * `node`: Pointer to a node created using the `create_data_node` function
+/// * `original_message`: Pointer to the message which this node received, and which is awaiting
+///     a response.
+/// * `length`: Size of the message to be sent, in bytes
+/// * `data`: Pointer to the array of bytes to be sent. There must be at least `length` bytes of
+///     valid memory after this pointer
+///
+/// # Examples
+///
+/// See [`nosengine-rust::ffi`](../ffi/index.html#examples)
+pub fn data_node_send_reply_message_sync(
+    node: *mut DataNodeHandle,
+    original_message: *const MessageHandle,
+    length: usize,
+    data: *const u8,
+) {
+    unsafe { NE_data_node_send_reply_message_sync(node, original_message, length, data) }
+}
+
+/// This function sets a callback function which will be called when this node receives a message.
+///
+/// # Safety
+///
+/// You must NOT call any `destroy_` functions on the two pointers passed to this callback.
+/// NOSEngine takes care of freeing them after the callback returns.
+///
+/// # Arguments
+///
+/// * `node`: Pointer to the node with which this callback will be associated
+/// * `callback`: The function which will be called when a message is received.
+///     * Callback parameters:
+///         * `*mut DataNodeHandle`: Pointer to the node to which this callback is attached, which just
+///             received a message
+///         * `*mut MessageHandle`: Pointer to the message this node just received. Do NOT call
+///             `destroy_message()` on this pointer within this callback.
+///
+/// # Examples
+///
+/// See [`nosengine-rust::ffi`](../ffi/index.html#examples)
+pub fn data_node_set_message_received_callback(
+    node: *mut DataNodeHandle,
+    callback: extern "C" fn(*mut DataNodeHandle, *mut MessageHandle),
+) {
+    unsafe { NE_data_node_set_message_received_callback(node, callback) }
+}
+
+/// This function blocks until a message is received. If a message is waiting in the queue, then this function
+/// returns it immediately.
+///
+/// # Arguments
+///
+/// * `node`: Node to wait for messages on
+///
+/// # Examples
+///
+/// See [`nosengine-rust::ffi`](../ffi/index.html#examples)
+pub fn data_node_receive_message_sync(node: *mut DataNodeHandle) -> *mut MessageHandle {
+    unsafe { NE_data_node_receive_message_sync(node) }
+}
+
+/// This function returns the number of bytes of data in a message.
+///
+/// # Arguments
+///
+/// * `message`: Pointer to a message returned by one of the communication functions
+///
+/// # Example
+///
+/// See [`nosengine-rust::ffi`](../ffi/index.html#examples)
+pub fn message_get_user_data_length(message: *const MessageHandle) -> usize {
+    unsafe { NE_message_get_user_data_length(message) }
+}
+
+/// This function returns a pointer to the first byte of data in the message.
+///
+/// # Arguments
+///
+/// * `message`: Pointer to a message returned by one of the communication functions
+///
+/// # Example
+///
+/// See [`nosengine-rust::ffi`](../ffi/index.html#examples)
+pub fn message_get_user_data(message: *const MessageHandle) -> *const u8 {
+    unsafe { NE_message_get_user_data(message) }
+}
+
+/// This function destroys a message and frees the associated data.
+///
+/// # Arguments
+///
+/// * `message`: Pointer to a pointer to a message. This function makes the pointer null.
+///
+/// # Example
+///
+/// See [`nosengine-rust::ffi`](../ffi/index.html#examples)
+pub fn destroy_message(message: *mut *mut MessageHandle) {
+    unsafe { NE_destroy_message(message) }
+}
+
+/// This enum represents all of the different possible errors returned by NOSEngine.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[repr(C)]
+#[allow(missing_docs)]
+pub enum ErrorCode {
+    Ok,
+    InvalidArg,
+    InvalidDest,
+    Rejected,
+    RoutingFailed,
+    InvalidResponseCode,
+    Timeout,
+    Exception,
+    NonException,
+    Unimplemented,
+    Unknown,
+    Count,
+}
+
+extern "C" {
+    fn NE_error() -> ErrorCode;
+    fn NE_error_string() -> *const c_char;
+    //    fn NE_exception_string() -> *const c_char;
+    //    fn NE_ok() -> i32;
+    //    fn NE_failed() -> i32;
+
+    fn NE_create_bus2(name: *const c_char, server_uri: *const c_char) -> *mut BusHandle;
+    fn NE_destroy_bus(bus: *mut *mut BusHandle);
+    fn NE_create_data_node(bus: *mut BusHandle, name: *const c_char) -> *mut DataNodeHandle;
+    fn NE_destroy_data_node(bus: *mut BusHandle, node: *mut *mut DataNodeHandle);
+    fn NE_data_node_send_message_sync(
+        node: *mut DataNodeHandle,
+        dest: *const c_char,
+        length: usize,
+        data: *const u8,
+    );
+    // You MUST destroy the message returned by this function.
+    fn NE_data_node_send_request_message_sync(
+        node: *mut DataNodeHandle,
+        destination: *const c_char,
+        length: usize,
+        data: *const u8,
+        response: *mut *mut MessageHandle,
+    );
+    fn NE_data_node_send_reply_message_sync(
+        node: *mut DataNodeHandle,
+        original_message: *const MessageHandle,
+        length: usize,
+        data: *const u8,
+    );
+    // Must NOT destroy message passed to this callback
+    fn NE_data_node_set_message_received_callback(
+        node: *mut DataNodeHandle,
+        callback: extern "C" fn(*mut DataNodeHandle, *mut MessageHandle),
+    );
+    fn NE_data_node_receive_message_sync(node: *mut DataNodeHandle) -> *mut MessageHandle;
+    fn NE_message_get_user_data_length(message: *const MessageHandle) -> usize;
+    fn NE_message_get_user_data(message: *const MessageHandle) -> *const u8;
+    fn NE_destroy_message(message: *mut *mut MessageHandle);
+}

--- a/apis/nosengine-rust/src/ffi/spi.rs
+++ b/apis/nosengine-rust/src/ffi/spi.rs
@@ -1,0 +1,317 @@
+//! Contains thin wrappers over the NOSEngine SPI API.
+//!
+//! # Examples
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::ffi::spi::*;
+//! # use std::ffi::CString;
+//! # use std::slice;
+//! let connection = CString::new("tcp://localhost:12001").unwrap();
+//! let bus = CString::new("spi10").unwrap();
+//! let mut master = spi_init_master(connection.as_ptr(), bus.as_ptr());
+//!
+//! extern "C" fn callback(dir: SPIDirection, buffer: *mut u8, len: usize) -> usize {
+//!     let mut buffer = unsafe { slice::from_raw_parts_mut(buffer, len) };
+//!     match dir {
+//!         SPIDirection::Read => {
+//!             for i in 0u8..4u8 {
+//!                 buffer[i as usize] = i + 5;
+//!             }
+//!             len
+//!         },
+//!         SPIDirection::Write => {
+//!             assert_eq!(buffer, &[1u8, 2, 3, 4]);
+//!             len
+//!         }
+//!     }
+//! }
+//! let mut slave = spi_init_slave(1, connection.as_ptr(), bus.as_ptr(), callback);
+//!
+//! let mut wbuf = vec![1u8, 2u8, 3u8, 4u8];
+//! let mut rbuf = vec![0u8, 0u8, 0u8, 0u8];
+//!
+//! spi_select_chip(master, 1u8);
+//! let result = spi_transaction(master, wbuf.as_ptr(), 4, rbuf.as_mut_ptr(), 4);
+//! assert_eq!(result, SPIStatus::Success);
+//! assert_eq!(rbuf, &[5u8, 6, 7, 8]);
+//!
+//! spi_close(&mut slave as *mut *mut SPIHandle);
+//! spi_close(&mut master as *mut *mut SPIHandle);
+//! ```
+
+use libc::c_char;
+
+/// Initializes an SPI master on the given bus. Only one SPI master can exist on a bus.
+///
+/// # Arguments
+///
+/// * `connection`: NOSEngine connection string
+/// * `bus`: Name of bus to use for SPI
+///
+/// # Examples
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::spi::*;
+/// # use std::ffi::CString;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("spi1").unwrap();
+/// let mut master = spi_init_master(connection.as_ptr(), bus.as_ptr());
+/// assert!(!master.is_null());
+/// let mut master2 = spi_init_master(connection.as_ptr(), bus.as_ptr());
+/// assert!(master2.is_null());
+/// spi_close(&mut master as *mut *mut SPIHandle);
+/// spi_close(&mut master2 as *mut *mut SPIHandle);
+/// ```
+pub fn spi_init_master(connection: *const c_char, bus: *const c_char) -> *mut SPIHandle {
+    unsafe { NE_spi_init_master(connection, bus) }
+}
+
+/// Initializes an SPI slave on the given bus, with the given chip select.
+///
+/// # Arguments
+///
+/// * `cs`: Chip select number. Each SPI slave on a bus must have a unique CS number
+/// * `connection`: NOSEngine connection string
+/// * `bus`: Name of the bus to use for SPI
+/// * `callback`: Function which will be called every time a master reads or writes to this slave.
+///     This callback should return the number of bytes it has read or written.
+///     The callback's parameters are:
+///     * `SPIDirection`: Indicates whether the master is reading or writing
+///     * `*mut u8`: This is a buffer. If the master is writing, then the slave should read the
+///         data from this buffer. If the master is reading, then the slave should write into
+///         this buffer.
+///     * `usize`: The number of bytes that should be read or written
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::spi::*;
+/// # use std::ffi::CString;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("spi2").unwrap();
+///
+/// extern "C" fn callback(dir: SPIDirection, buffer: *mut u8, len: usize) -> usize {0}
+///
+/// let mut slave = spi_init_slave(1, connection.as_ptr(), bus.as_ptr(), callback);
+/// assert!(!slave.is_null());
+/// spi_close(&mut slave as *mut *mut SPIHandle);
+/// ```
+pub fn spi_init_slave(
+    cs: u8,
+    connection: *const c_char,
+    bus: *const c_char,
+    callback: extern "C" fn(SPIDirection, *mut u8, usize) -> usize,
+) -> *mut SPIHandle {
+    unsafe { NE_spi_init_slave(cs, connection, bus, callback) }
+}
+
+/// Closes an SPI connection and frees up all associated memory.
+///
+/// # Arguments
+///
+/// * `spi`: A pointer to a pointer to an SPI handle. This handle will be made null by this
+///     function.
+///
+/// # Examples
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::spi::*;
+/// # use std::ffi::CString;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("spi3").unwrap();
+/// let mut master = spi_init_master(connection.as_ptr(), bus.as_ptr());
+/// assert!(!master.is_null());
+/// spi_close(&mut master as *mut *mut SPIHandle);
+/// assert!(master.is_null());
+/// ```
+pub fn spi_close(spi: *mut *mut SPIHandle) {
+    unsafe { NE_spi_close(spi) }
+}
+
+/// When an SPI master writes, it only writes to the currently-selected chip. If no chip is
+/// selected, the write does nothing.
+///
+/// # Arguments
+///
+/// * `spi`: Handle to and SPI master
+/// * `cs`: The number of the chip you want to select
+pub fn spi_select_chip(spi: *mut SPIHandle, cs: u8) {
+    unsafe { NE_spi_select_chip(spi, cs) }
+}
+
+/// De-selects the currently-selected chip
+///
+/// # Arguments
+///
+/// * `spi`: Handle to and SPI master
+pub fn spi_unselect_chip(spi: *mut SPIHandle) {
+    unsafe { NE_spi_unselect_chip(spi) }
+}
+
+/// Reads from the currently-selected chip. Does nothing and returns an error if there is no
+/// currently-selected chip.
+///
+/// # Arguments
+///
+/// * `spi`: Handle to an SPI master
+/// * `rbuf`: A buffer in which the read data will be stored. Must contain at least `rlen`
+///     consecutive bytes of valid memory.
+/// * `rlen`: Maximum number of bytes to read
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::spi::*;
+/// # use std::ffi::CString;
+/// # use std::slice;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("spi4").unwrap();
+/// let mut master = spi_init_master(connection.as_ptr(), bus.as_ptr());
+///
+/// extern "C" fn callback(dir: SPIDirection, buffer: *mut u8, len: usize) -> usize {
+///     assert_eq!(dir, SPIDirection::Read);
+///     let mut buffer = unsafe { slice::from_raw_parts_mut(buffer, len) };
+///     for i in 1u8..5u8 {
+///         buffer[(i - 1) as usize] = i;
+///     }
+///     len
+/// }
+/// let mut slave = spi_init_slave(1, connection.as_ptr(), bus.as_ptr(), callback);
+///
+/// let mut buffer = vec![0u8, 0u8, 0u8, 0u8];
+///
+/// let result = spi_read(master, buffer.as_mut_ptr(), 4);
+/// // Expect a failure because no chip was selected.
+/// assert_eq!(result, SPIStatus::Failure);
+///
+/// spi_select_chip(master, 1u8);
+/// let result = spi_read(master, buffer.as_mut_ptr(), 4);
+/// assert_eq!(result, SPIStatus::Success);
+/// assert_eq!(buffer, &[1u8, 2, 3, 4]);
+///
+/// spi_close(&mut slave as *mut *mut SPIHandle);
+/// spi_close(&mut master as *mut *mut SPIHandle);
+/// ```
+pub fn spi_read(spi: *mut SPIHandle, rbuf: *mut u8, rlen: usize) -> SPIStatus {
+    unsafe { NE_spi_read(spi, rbuf, rlen) }
+}
+
+/// Writes to the currently-selected chip. Does nothing and returns an error if there is no
+/// currently-selected chip.
+///
+/// # Arguments
+///
+/// * `spi`: Handle to an SPI master
+/// * `wbuf`: A buffer from which the slave will read data. Must contain at least `wlen`
+///     consecutive bytes of valid memory.
+/// * `wlen`: Number of bytes to write
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::spi::*;
+/// # use std::ffi::CString;
+/// # use std::slice;
+/// let connection = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("spi5").unwrap();
+/// let mut master = spi_init_master(connection.as_ptr(), bus.as_ptr());
+///
+/// extern "C" fn callback(dir: SPIDirection, buffer: *mut u8, len: usize) -> usize {
+///     assert_eq!(dir, SPIDirection::Write);
+///     let mut buffer = unsafe { slice::from_raw_parts_mut(buffer, len) };
+///     assert_eq!(buffer, [1u8, 2, 3, 4]);
+///     len
+/// }
+/// let mut slave = spi_init_slave(1, connection.as_ptr(), bus.as_ptr(), callback);
+///
+/// let data = &[1u8, 2, 3, 4];
+///
+/// let result = spi_write(master, data.as_ptr(), 4);
+/// // Expect a failure because no chip was selected.
+/// assert_eq!(result, SPIStatus::Failure);
+///
+/// spi_select_chip(master, 1u8);
+/// let result = spi_write(master, data.as_ptr(), 4);
+/// assert_eq!(result, SPIStatus::Success);
+///
+/// spi_close(&mut slave as *mut *mut SPIHandle);
+/// spi_close(&mut master as *mut *mut SPIHandle);
+/// ```
+pub fn spi_write(spi: *mut SPIHandle, wbuf: *const u8, wlen: usize) -> SPIStatus {
+    unsafe { NE_spi_write(spi, wbuf, wlen) }
+}
+
+/// Performs an SPI transaction, which consists of a write followed by a read.
+///
+/// # Arguments
+///
+/// * `spi`: Handle to an SPI master
+/// * `wbuf`: A buffer from which the slave will read data. Must contain at least `wlen`
+///     consecutive bytes of valid memory.
+/// * `wlen`: Number of bytes to write
+/// * `rbuf`: A buffer in which the read data will be stored. Must contain at least `rlen`
+///     consecutive bytes of valid memory.
+/// * `rlen`: Maximum number of bytes to read
+///
+/// # Examples
+///
+/// See [`nosengine-rust::ffi::spi`](../spi/index.html#examples)
+pub fn spi_transaction(
+    spi: *mut SPIHandle,
+    wbuf: *const u8,
+    wlen: usize,
+    rbuf: *mut u8,
+    rlen: usize,
+) -> SPIStatus {
+    unsafe { NE_spi_transaction(spi, wbuf, wlen, rbuf, rlen) }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[repr(C)]
+/// This enum represents the success or failure of an SPI action.
+pub enum SPIStatus {
+    /// Success
+    Success,
+    /// Failure
+    Failure,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[repr(C)]
+/// This enum represents the type of SPI operation.
+pub enum SPIDirection {
+    /// Write to slave
+    Write,
+    /// Read from slave
+    Read,
+}
+
+/// This enum represents an opaque handle to either an SPI slave or and SPI master. You must keep track
+/// of where you got this handle from to know whether it is a master or slave.
+pub enum SPIHandle {}
+
+extern "C" {
+    fn NE_spi_init_master(connection: *const c_char, bus: *const c_char) -> *mut SPIHandle;
+    fn NE_spi_init_slave(
+        cs: u8,
+        connection: *const c_char,
+        bus: *const c_char,
+        callback: extern "C" fn(SPIDirection, *mut u8, usize) -> usize,
+    ) -> *mut SPIHandle;
+    fn NE_spi_close(spi: *mut *mut SPIHandle);
+    fn NE_spi_select_chip(spi: *mut SPIHandle, cs: u8);
+    fn NE_spi_unselect_chip(spi: *mut SPIHandle);
+    fn NE_spi_read(spi: *mut SPIHandle, rbuf: *mut u8, rlen: usize) -> SPIStatus;
+    fn NE_spi_write(spi: *mut SPIHandle, wbuf: *const u8, wlen: usize) -> SPIStatus;
+    fn NE_spi_transaction(
+        spi: *mut SPIHandle,
+        wbuf: *const u8,
+        wlen: usize,
+        rbuf: *mut u8,
+        rlen: usize,
+    ) -> SPIStatus;
+}

--- a/apis/nosengine-rust/src/ffi/uart.rs
+++ b/apis/nosengine-rust/src/ffi/uart.rs
@@ -1,0 +1,327 @@
+//! This module contains the wrappers around the C functions associated with UART.
+
+use libc::{c_char, c_void};
+
+/// This enum represents a pointer to an opaque C struct.
+pub enum UARTHandle {}
+
+/// This function creates a new UART connection. Only two UART connections can be created on the same port
+/// on the same bus. If a third is attempted, this function will return a null pointer.
+///
+/// # Arguments
+///
+/// * `name`: Name of this UART connection. Must be unique on a bus
+/// * `connection`: Connection string to the NOSEngine server
+/// * `bus`: Name of the bus that will hold this UART connection
+/// * `port`: A number representing a serial port
+///
+/// # Safety
+///
+/// After a UART connection is created, it must be cleaned up using `uart_close`.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::uart::*;
+/// # use std::ffi::CString;
+/// let conn = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("uart").unwrap();
+/// let name1 = CString::new("uart1").unwrap();
+/// let name2 = CString::new("uart2").unwrap();
+/// let name3 = CString::new("uart3").unwrap();
+///
+/// let mut uart1 = uart_open(name1.as_ptr(), conn.as_ptr(), bus.as_ptr(), 1);
+/// assert!(!uart1.is_null());
+/// let mut uart2 = uart_open(name2.as_ptr(), conn.as_ptr(), bus.as_ptr(), 1);
+/// assert!(!uart2.is_null());
+/// let mut uart3 = uart_open(name3.as_ptr(), conn.as_ptr(), bus.as_ptr(), 1);
+/// assert!(uart3.is_null());
+///
+/// # uart_close(&mut uart1 as *mut *mut UARTHandle);
+/// # uart_close(&mut uart2 as *mut *mut UARTHandle);
+/// # uart_close(&mut uart3 as *mut *mut UARTHandle);
+/// ```
+pub fn uart_open(
+    name: *const c_char,
+    connection: *const c_char,
+    bus: *const c_char,
+    port: u8,
+) -> *mut UARTHandle {
+    unsafe { NE_uart_open(name, connection, bus, port) }
+}
+
+/// This function closes a UART connection and cleans up all associated memory. After running this function,
+/// the pointer becomes invalid.
+///
+/// # Arguments
+///
+/// * `uart`: Pointer to a UART handle, which is made null by this function
+///
+/// # Safety
+///
+/// If any functions are called on the UART handle after closing it, they will fail.
+///
+/// # Examples
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::uart::*;
+/// # use std::ffi::CString;
+/// let conn = CString::new("tcp://localhost:12001").unwrap();
+/// let bus = CString::new("uart").unwrap();
+/// let name1 = CString::new("uart4").unwrap();
+/// let name2 = CString::new("uart5").unwrap();
+///
+/// let mut uart1 = uart_open(name1.as_ptr(), conn.as_ptr(), bus.as_ptr(), 2);
+/// let mut uart2 = uart_open(name2.as_ptr(), conn.as_ptr(), bus.as_ptr(), 2);
+///
+/// uart_close(&mut uart1 as *mut *mut UARTHandle);
+/// assert!(uart1.is_null());
+/// uart_close(&mut uart2 as *mut *mut UARTHandle);
+/// assert!(uart2.is_null());
+/// ```
+pub fn uart_close(uart: *mut *mut UARTHandle) -> UARTStatus {
+    unsafe { NE_uart_close(uart) }
+}
+
+/// This function sets a callback which will execute whenever this UART receives data.
+///
+/// # Arguments
+///
+/// * `uart`: Pointer to the UART
+/// * `callback`: Callback which has the following parameters:
+///     * `data`: Bytes that were written
+///     * `len`: Number of bytes that were written
+///     * `user`: User-specified data that is passed every time this callback runs
+/// * `user`: User-specified data that will be passed to the callback every time it runs
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # extern crate libc;
+/// # use nosengine_rust::ffi::uart::*;
+/// # use std::ffi::CString;
+/// # use libc::c_void;
+/// # use std::{slice, ptr};
+/// # let conn = CString::new("tcp://localhost:12001").unwrap();
+/// # let bus = CString::new("uart").unwrap();
+/// # let name1 = CString::new("uart6").unwrap();
+/// # let name2 = CString::new("uart7").unwrap();
+/// let mut uart1 = uart_open(name1.as_ptr(), conn.as_ptr(), bus.as_ptr(), 3);
+/// let mut uart2 = uart_open(name2.as_ptr(), conn.as_ptr(), bus.as_ptr(), 3);
+///
+/// extern "C" fn callback(data: *const u8, len: usize, user: *mut c_void){
+///     let data = unsafe{ slice::from_raw_parts(data, len) };
+///     assert_eq!(data, &[1u8, 2, 3, 4]);
+/// }
+/// uart_set_read_callback(uart2, callback, ptr::null_mut());
+/// uart_write(uart1, [1u8, 2, 3, 4].as_ptr(), 4);
+///
+/// # uart_close(&mut uart1 as *mut *mut UARTHandle);
+/// # uart_close(&mut uart2 as *mut *mut UARTHandle);
+/// ```
+pub fn uart_set_read_callback(
+    uart: *mut UARTHandle,
+    callback: extern "C" fn(data: *const u8, len: usize, _user: *mut c_void),
+    user: *mut c_void,
+) {
+    unsafe {
+        NE_uart_set_read_callback(uart, callback, user);
+    }
+}
+
+/// This function reads data that has been sent to this UART.
+///
+/// # Arguments
+///
+/// * `uart`: Handle to the UART
+/// * `buffer`: A buffer which must contain at lease `len` consecutive bytes of valid memory
+/// * `len`: Maximum number of bytes to read. This function may read fewer than this, but
+///     never more.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::uart::*;
+/// # use std::ffi::CString;
+/// # let conn = CString::new("tcp://localhost:12001").unwrap();
+/// # let bus = CString::new("uart").unwrap();
+/// # let name1 = CString::new("uart8").unwrap();
+/// # let name2 = CString::new("uart9").unwrap();
+/// let mut uart1 = uart_open(name1.as_ptr(), conn.as_ptr(), bus.as_ptr(), 4);
+/// let mut uart2 = uart_open(name2.as_ptr(), conn.as_ptr(), bus.as_ptr(), 4);
+///
+/// uart_write(uart1, [1u8, 2, 3, 4].as_ptr(), 4);
+///
+/// let buffer = &mut [0u8, 0, 0, 0];
+/// uart_read(uart2, buffer.as_mut_ptr(), 4);
+/// assert_eq!(buffer, &[1u8, 2, 3, 4]);
+///
+/// # uart_close(&mut uart1 as *mut *mut UARTHandle);
+/// # uart_close(&mut uart2 as *mut *mut UARTHandle);
+/// ```
+pub fn uart_read(uart: *mut UARTHandle, buffer: *mut u8, len: usize) -> usize {
+    unsafe { NE_uart_read(uart, buffer, len) }
+}
+
+/// This function reads one individual character from this UART connection.
+/// If there are no characters available, then `UARTStatus::Failure` is returned.
+///
+/// # Arguments
+///
+/// * `uart`: UART handle
+/// * `c`: Pointer to a u8, where the result, if any, will be stored.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::uart::*;
+/// # use std::ffi::CString;
+/// # let conn = CString::new("tcp://localhost:12001").unwrap();
+/// # let bus = CString::new("uart").unwrap();
+/// # let name1 = CString::new("uart10").unwrap();
+/// # let name2 = CString::new("uart11").unwrap();
+/// let mut uart1 = uart_open(name1.as_ptr(), conn.as_ptr(), bus.as_ptr(), 5);
+/// let mut uart2 = uart_open(name2.as_ptr(), conn.as_ptr(), bus.as_ptr(), 5);
+///
+/// uart_putc(uart1, 7u8);
+///
+/// let mut c = 0u8;
+/// let result = uart_getc(uart2, &mut c as *mut u8);
+/// assert_eq!(result, UARTStatus::Success);
+/// assert_eq!(c, 7u8);
+/// # uart_close(&mut uart1 as *mut *mut UARTHandle);
+/// # uart_close(&mut uart2 as *mut *mut UARTHandle);
+/// ```
+pub fn uart_getc(uart: *mut UARTHandle, c: *mut u8) -> UARTStatus {
+    unsafe { NE_uart_getc(uart, c) }
+}
+
+/// This function writes data to the UART port.
+///
+/// # Arguments
+///
+/// * `uart`: UART handle
+/// * `buffer`: Buffer to write data from. Must contain at least `length` consecutive bytes
+///     of valid memory.
+/// * `length`: Max number of bytes to write from `buffer`.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::uart::*;
+/// # use std::ffi::CString;
+/// # let conn = CString::new("tcp://localhost:12001").unwrap();
+/// # let bus = CString::new("uart").unwrap();
+/// # let name1 = CString::new("uart12").unwrap();
+/// # let name2 = CString::new("uart13").unwrap();
+/// let mut uart1 = uart_open(name1.as_ptr(), conn.as_ptr(), bus.as_ptr(), 6);
+/// let mut uart2 = uart_open(name2.as_ptr(), conn.as_ptr(), bus.as_ptr(), 6);
+///
+/// uart_write(uart1, [1u8, 2, 3, 4].as_ptr(), 4);
+///
+/// let buffer = &mut [0u8, 0, 0, 0];
+/// uart_read(uart2, buffer.as_mut_ptr(), 4);
+/// assert_eq!(buffer, &[1u8, 2, 3, 4]);
+///
+/// # uart_close(&mut uart1 as *mut *mut UARTHandle);
+/// # uart_close(&mut uart2 as *mut *mut UARTHandle);
+/// ```
+pub fn uart_write(uart: *mut UARTHandle, buffer: *const u8, length: usize) -> usize {
+    unsafe { NE_uart_write(uart, buffer, length) }
+}
+
+/// This function writes a single byte to the UART port.
+///
+/// # Arguments
+///
+/// * `uart`: UART handle
+/// * `c`: Byte to write
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::uart::*;
+/// # use std::ffi::CString;
+/// # let conn = CString::new("tcp://localhost:12001").unwrap();
+/// # let bus = CString::new("uart").unwrap();
+/// # let name1 = CString::new("uart14").unwrap();
+/// # let name2 = CString::new("uart15").unwrap();
+/// let mut uart1 = uart_open(name1.as_ptr(), conn.as_ptr(), bus.as_ptr(), 7);
+/// let mut uart2 = uart_open(name2.as_ptr(), conn.as_ptr(), bus.as_ptr(), 7);
+///
+/// uart_putc(uart1, 7u8);
+///
+/// let mut c = 0u8;
+/// let result = uart_getc(uart2, &mut c as *mut u8);
+/// assert_eq!(result, UARTStatus::Success);
+/// assert_eq!(c, 7u8);
+/// # uart_close(&mut uart1 as *mut *mut UARTHandle);
+/// # uart_close(&mut uart2 as *mut *mut UARTHandle);
+/// ```
+pub fn uart_putc(uart: *mut UARTHandle, c: u8) {
+    unsafe { NE_uart_putc(uart, c) }
+}
+
+/// This function returns the number of bytes available to be read.
+///
+/// # Arguments
+///
+/// * `uart`: UART handle
+///
+/// # Examples
+///
+/// ```
+/// # extern crate nosengine_rust;
+/// # use nosengine_rust::ffi::uart::*;
+/// # use std::ffi::CString;
+/// # let conn = CString::new("tcp://localhost:12001").unwrap();
+/// # let bus = CString::new("uart").unwrap();
+/// # let name1 = CString::new("uart16").unwrap();
+/// # let name2 = CString::new("uart17").unwrap();
+/// let mut uart1 = uart_open(name1.as_ptr(), conn.as_ptr(), bus.as_ptr(), 8);
+/// let mut uart2 = uart_open(name2.as_ptr(), conn.as_ptr(), bus.as_ptr(), 8);
+///
+/// uart_write(uart1, [1u8, 2, 3, 4].as_ptr(), 4);
+///
+/// assert_eq!(uart_available(uart2), 4);
+///
+/// # uart_close(&mut uart1 as *mut *mut UARTHandle);
+/// # uart_close(&mut uart2 as *mut *mut UARTHandle);
+/// ```
+pub fn uart_available(uart: *mut UARTHandle) -> usize {
+    unsafe { NE_uart_available(uart) }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[repr(C)]
+#[allow(missing_docs)]
+pub enum UARTStatus {
+    Success,
+    Failure,
+}
+
+extern "C" {
+    fn NE_uart_open(
+        name: *const c_char,
+        connection: *const c_char,
+        bus: *const c_char,
+        port: u8,
+    ) -> *mut UARTHandle;
+    fn NE_uart_close(uart: *mut *mut UARTHandle) -> UARTStatus;
+    fn NE_uart_set_read_callback(
+        uart: *mut UARTHandle,
+        callback: extern "C" fn(*const u8, usize, *mut c_void),
+        user: *mut c_void,
+    );
+    fn NE_uart_read(uart: *mut UARTHandle, buffer: *mut u8, len: usize) -> usize;
+    fn NE_uart_getc(uart: *mut UARTHandle, c: *mut u8) -> UARTStatus;
+    fn NE_uart_write(uart: *mut UARTHandle, buffer: *const u8, length: usize) -> usize;
+    fn NE_uart_putc(uart: *mut UARTHandle, c: u8);
+    fn NE_uart_available(uart: *mut UARTHandle) -> usize;
+}

--- a/apis/nosengine-rust/src/lib.rs
+++ b/apis/nosengine-rust/src/lib.rs
@@ -1,0 +1,174 @@
+//! This crate contains wrappers around the NOSEngine API. This crate can only be built in a
+//! system that has NOS3 installed.
+//!
+//! The tests in this crate will not run properly unless the NOSEngine server is running on
+//! `tcp://localhost:12001`. This is the way it is configured to run in the NOS3 VM.
+//!
+//! # Example Usage
+//!
+//! ### Simple send and receive
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::client;
+//! # use nosengine_rust::ffi;
+//! let bus = client::Bus::new("testbus", "tcp://localhost:12001").unwrap();
+//! let node1 = client::DataNode::new(&bus, "node1").unwrap();
+//! let node2 = client::DataNode::new(&bus, "node2").unwrap();
+//!
+//! node1
+//!     .send_message("node2", &[1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+//!     .unwrap();
+//! let result = node2.receive_message().unwrap();
+//! assert_eq!(result.get_contents(), &[1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+//! ```
+//!
+//! ### Using callbacks
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::client;
+//! # use nosengine_rust::ffi;
+//! let bus = client::Bus::new("testbus", "tcp://localhost:12001").unwrap();
+//! let node3 = client::DataNode::new(&bus, "node3").unwrap();
+//! let node4 = client::DataNode::new(&bus, "node4").unwrap();
+//!
+//! extern "C" fn callback(
+//!     _data_node: *mut ffi::DataNodeHandle,
+//!     msg_ptr: *mut ffi::MessageHandle,
+//! ) {
+//!     println!("Received message in callback: {:?}", unsafe {
+//!         client::Message::get_contents_from_ptr(msg_ptr)
+//!     });
+//! }
+//!
+//! node4.set_message_callback(callback);
+//!
+//! node3.send_message("node4", &[1u8, 2, 3, 4, 5]).unwrap();
+//! ```
+//!
+//! ### UART
+//!
+//! ```
+//! # extern crate nosengine_rust;
+//! # use nosengine_rust::client::uart::*;
+//! let uart1 = UART::new("uart10", "tcp://localhost:12001", "testuart", 15).unwrap();
+//! let mut uart2 = UART::new("uart11", "tcp://localhost:12001", "testuart", 15).unwrap();
+//!
+//! uart2.set_callback(move |data: &[u8]|{
+//!     assert_eq!(data, &[1u8, 2, 3, 4]);
+//! });
+//!
+//! uart1.write(&[1u8, 2, 3, 4]);
+//! ```
+
+#![deny(missing_docs)]
+
+extern crate libc;
+
+pub mod client;
+pub mod ffi;
+
+#[cfg(test)]
+#[allow(missing_docs)]
+mod tests {
+    use super::client;
+
+    #[test]
+    fn callback_test() {
+        let bus = client::Bus::new("testbus", "tcp://localhost:12001").unwrap();
+        let node3 = client::DataNode::new(&bus, "node3").unwrap();
+        let node4 = client::DataNode::new(&bus, "node4").unwrap();
+
+        extern "C" fn callback(
+            _data_node: *mut super::ffi::DataNodeHandle,
+            msg_ptr: *mut super::ffi::MessageHandle,
+        ) {
+            println!("Received message in callback: {:?}", unsafe {
+                client::Message::get_contents_from_ptr(msg_ptr)
+            });
+        }
+
+        node4.set_message_callback(callback);
+
+        node3.send_message("node4", &[1u8, 2, 3, 4, 5]).unwrap();
+    }
+
+    #[test]
+    fn request_message_test() {
+        let bus = client::Bus::new("testbus", "tcp://localhost:12001").unwrap();
+        let node5 = client::DataNode::new(&bus, "node5").unwrap();
+        let node6 = client::DataNode::new(&bus, "node6").unwrap();
+
+        extern "C" fn callback(
+            node_ptr: *mut super::ffi::DataNodeHandle,
+            msg_ptr: *mut super::ffi::MessageHandle,
+        ) {
+            client::DataNode::send_reply_message_ptr(node_ptr, msg_ptr, &[5u8, 6, 7, 8]);
+        }
+
+        node6.set_message_callback(callback);
+
+        let response = node5
+            .send_request_message("node6", &[1u8, 2, 3, 4])
+            .unwrap();
+        assert_eq!(response.get_contents(), &[5u8, 6, 7, 8]);
+    }
+
+    #[test]
+    fn expect_error() {
+        let bus = client::Bus::new("testbus", "tcp://localhost:12001").unwrap();
+        let node7 = client::DataNode::new(&bus, "node7").unwrap();
+        let node8 = client::DataNode::new(&bus, "node8").unwrap();
+
+        extern "C" fn callback(
+            node_ptr: *mut super::ffi::DataNodeHandle,
+            msg_ptr: *mut super::ffi::MessageHandle,
+        ) {
+            client::DataNode::send_reply_message_ptr(node_ptr, msg_ptr, &[5u8, 6, 7, 8]);
+        }
+
+        node8.set_message_callback(callback);
+
+        let response = node7.send_request_message("nowhere", &[1u8, 2, 3, 4]);
+        match response {
+            Err(client::NosError::NosEngineError {
+                error_code: _,
+                description: _,
+            }) => {}
+            _ => panic!("Expected invalid destination error."),
+        }
+    }
+
+    #[test]
+    fn spi_test() {
+        use client::spi::*;
+        use ffi::spi;
+        use std::slice;
+
+        extern "C" fn callback(dir: spi::SPIDirection, buffer: *mut u8, len: usize) -> usize {
+            let data = unsafe { slice::from_raw_parts_mut(buffer, len) };
+            match dir {
+                spi::SPIDirection::Write => {
+                    println!("Wrote {} bytes: {:?}", len, data);
+                    len
+                }
+                spi::SPIDirection::Read => {
+                    println!("Reading {} bytes.", len);
+                    for i in 0..len {
+                        data[i] = i as u8;
+                    }
+                    len
+                }
+            }
+        }
+
+        let master = SPIMaster::new("tcp://localhost:12001", "spia").unwrap();
+        let _slave = SPISlave::new(1u8, "tcp://localhost:12001", "spia", callback).unwrap();
+
+        master.chip_select(1u8);
+        master.write(&[1u8, 2u8, 3u8, 4u8]).unwrap();
+        let data = master.read(4).unwrap();
+        assert_eq!(data, &[0u8, 1, 2, 3]);
+    }
+}

--- a/apis/nosengine-rust/src/lib.rs
+++ b/apis/nosengine-rust/src/lib.rs
@@ -67,6 +67,7 @@
 extern crate libc;
 
 pub mod client;
+#[allow(clippy::all)]
 pub mod ffi;
 
 #[cfg(test)]

--- a/apis/novatel-oem6-api/Cargo.toml
+++ b/apis/novatel-oem6-api/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Catherine Garabedian <catherine@kubos.co>"]
 edition = "2018"
 
+[features]
+nos3 = ["rust-uart/nos3"]
+
 [dependencies]
 bitflags = "1.0"
 byteorder = "1.2"

--- a/apis/novatel-oem6-api/examples/gps-test.rs
+++ b/apis/novatel-oem6-api/examples/gps-test.rs
@@ -131,12 +131,13 @@ fn main() -> OEMResult<()> {
 
     let (log_send, log_recv) = sync_channel(5);
     let (response_send, response_recv) = sync_channel(5);
+    let (response_abbrv_send, response_abbrv_recv) = sync_channel(5);
 
-    let oem = OEM6::new(bus, BaudRate::Baud9600, log_recv, response_recv)?;
+    let oem = OEM6::new(bus, BaudRate::Baud9600, log_recv, response_recv, response_abbrv_recv)?;
 
     let rx_conn = oem.conn.clone();
 
-    thread::spawn(move || read_thread(&rx_conn, &log_send, &response_send));
+    thread::spawn(move || read_thread(&rx_conn, &log_send, &response_send, &response_abbrv_send));
 
     get_version(&oem)?;
 

--- a/apis/novatel-oem6-api/src/messages/commands/log.rs
+++ b/apis/novatel-oem6-api/src/messages/commands/log.rs
@@ -16,10 +16,11 @@
 
 use super::*;
 
+#[allow(dead_code)]
 pub struct LogCmd {
     hdr: Header,
-    port: u32,
-    msg_id: u16,
+    port: Port,
+    msg_id: MessageID,
     msg_type: u8,
     trigger: LogTrigger,
     period: f64,
@@ -27,10 +28,11 @@ pub struct LogCmd {
     hold: bool,
 }
 
+#[allow(dead_code)]
 impl LogCmd {
     pub fn new(
-        port: u32,
-        msg_id: u16,
+        port: Port,
+        msg_id: MessageID,
         trigger: LogTrigger,
         period: f64,
         offset: f64,
@@ -49,6 +51,7 @@ impl LogCmd {
     }
 }
 
+#[cfg(not(feature = "nos3"))]
 impl Message for LogCmd {
     fn serialize(&self) -> Vec<u8> {
         let mut vec = vec![];
@@ -57,14 +60,78 @@ impl Message for LogCmd {
         vec.append(&mut self.hdr.serialize());
 
         // Add LOG message
-        vec.write_u32::<LittleEndian>(self.port).unwrap();
-        vec.write_u16::<LittleEndian>(self.msg_id).unwrap();
+        vec.write_u32::<LittleEndian>(self.port as u32).unwrap();
+        vec.write_u16::<LittleEndian>(self.msg_id as u16).unwrap();
         vec.push(self.msg_type);
         vec.push(0x00); // Reserved byte
         vec.write_u32::<LittleEndian>(self.trigger as u32).unwrap();
         vec.write_f64::<LittleEndian>(self.period).unwrap();
         vec.write_f64::<LittleEndian>(self.offset).unwrap();
         vec.write_u32::<LittleEndian>(self.hold as u32).unwrap();
+
+        vec
+    }
+}
+
+#[cfg(feature = "nos3")]
+impl Message for LogCmd {
+    fn serialize(&self) -> Vec<u8> {
+        let mut vec = vec![];
+
+        // Header is always command name (LOG) for abbrv. ASCII commands
+        let mut header = String::from("LOG ").into_bytes();
+
+        // Lets appropriately set the corresponding command arguments to bytes
+        let mut port = {
+            let from = match self.port {
+                Port::COM1 => "COM1 ",
+                Port::ThisPort => "THISPORT ",
+            };
+            String::from(from).into_bytes()
+        };
+
+        let mut message = {
+            let from = match self.msg_id {
+                MessageID::BestXYZ => "BESTXYZB ",
+                MessageID::Log => "LOG ",
+                MessageID::RxStatusEvent => "RXSTATUSEVENT ",
+                MessageID::Unlog => "UNLOG ",
+                MessageID::UnlogAll => "UNLOGALL ",
+                MessageID::Version => "VERSION ",
+                _ => "UNKNOWN ",
+            };
+            String::from(from).into_bytes()
+        };
+
+        let mut trigger = {
+            let from = match self.trigger {
+                LogTrigger::OnChanged => "ONCHANGED ",
+                LogTrigger::OnTime => "ONTIME ",
+                LogTrigger::Once => "ONCE ",
+            };
+            String::from(from).into_bytes()
+        };
+
+        let mut period = format!("{} ", self.period.to_string()).into_bytes();
+
+        let mut offset = format!("{} ", self.offset.to_string()).into_bytes();
+
+        let mut hold = {
+            let from = match self.hold {
+                true => String::from("HOLD "),
+                false => String::from("NOHOLD "),
+            };
+            String::from(from).into_bytes()
+        };
+
+        // Add LOG message
+        vec.append(&mut header);
+        vec.append(&mut port);
+        vec.append(&mut message);
+        vec.append(&mut trigger);
+        vec.append(&mut period);
+        vec.append(&mut offset);
+        vec.append(&mut hold);
 
         vec
     }

--- a/apis/novatel-oem6-api/src/messages/commands/mod.rs
+++ b/apis/novatel-oem6-api/src/messages/commands/mod.rs
@@ -35,6 +35,7 @@ pub struct Response {
     pub resp_string: String,
 }
 
+#[allow(dead_code)]
 impl Response {
     pub fn new(msg: &[u8]) -> Option<Self> {
         match le_u32(&msg) {

--- a/apis/novatel-oem6-api/src/messages/logs/best_xyz.rs
+++ b/apis/novatel-oem6-api/src/messages/logs/best_xyz.rs
@@ -91,6 +91,7 @@ impl BestXYZLog {
     }
 }
 
+#[cfg(not(feature = "nos3"))]
 named!(parse_bestxyz(&[u8]) -> BestXYZLog,
     do_parse!(
         pos_status: le_u32 >>
@@ -103,6 +104,66 @@ named!(parse_bestxyz(&[u8]) -> BestXYZLog,
         pos_dev_z: le_f32 >>
         vel_status: le_u32 >>
         vel_type: le_u32 >>
+        vel_x: le_f64 >>
+        vel_y: le_f64 >>
+        vel_z: le_f64 >>
+        vel_dev_x: le_f32 >>
+        vel_dev_y: le_f32 >>
+        vel_dev_z: le_f32 >>
+        station_id: take!(4) >>
+        vel_time_latency: le_f32 >>
+        diff_age: le_f32 >>
+        sol_age: le_f32 >>
+        num_sats: le_u8 >>
+        num_sat_vehicles: le_u8 >>
+        num_gg_l1: le_u8 >>
+        num_multi_sats: le_u8 >>
+        le_u8 >>
+        ext_sol_stat: le_u8 >>
+        gal_beidou_sig: le_u8 >>
+        gps_glonass_sig: le_u8 >>
+        (BestXYZLog {
+            recv_status: ReceiverStatusFlags::empty(),
+            time_status: 0,
+            week: 0,
+            ms: 0,
+            pos_status,
+            pos_type,
+            position: [pos_x, pos_y, pos_z],
+            pos_deviation: [pos_dev_x, pos_dev_y, pos_dev_z],
+            vel_status,
+            vel_type,
+            velocity: [vel_x, vel_y, vel_z],
+            vel_deviation: [vel_dev_x, vel_dev_y, vel_dev_z],
+            station_id: String::from_utf8_lossy(station_id).trim_right_matches('\u{0}').to_owned(),
+            vel_time_latency,
+            diff_age,
+            sol_age,
+            num_sats,
+            num_sat_vehicles,
+            num_gg_l1,
+            num_multi_sats,
+            ext_sol_stat,
+            gal_beidou_sig,
+            gps_glonass_sig,
+            }
+        )
+    )
+);
+
+#[cfg(feature = "nos3")]
+named!(parse_bestxyz(&[u8]) -> BestXYZLog,
+    do_parse!(
+        pos_status: be_u32 >>
+        pos_type: be_u32 >>
+        pos_x: le_f64 >>
+        pos_y: le_f64 >>
+        pos_z: le_f64 >>
+        pos_dev_x: le_f32 >>
+        pos_dev_y: le_f32 >>
+        pos_dev_z: le_f32 >>
+        vel_status: be_u32 >>
+        vel_type: be_u32 >>
         vel_x: le_f64 >>
         vel_y: le_f64 >>
         vel_z: le_f64 >>

--- a/apis/novatel-oem6-api/src/messages/mod.rs
+++ b/apis/novatel-oem6-api/src/messages/mod.rs
@@ -135,6 +135,7 @@ impl Message for Header {
 }
 
 /// Device communication ports
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Port {
     COM1 = 32,
     ThisPort = 192,

--- a/hal/rust-hal/SimConfig.toml
+++ b/hal/rust-hal/SimConfig.toml
@@ -1,0 +1,36 @@
+# This file contains configuration options for the simulated NOSEngine HALs.
+# Each HAL needs to know things like how to connect to NOSEngine, which bus to use, etc.
+
+# Connection string to the NOSEngine server. Is generally something like "tcp://<domain>:<port>", but can
+# be other formats. See the connection string section of the NOSEngine user manual for more information.
+connection = "tcp://localhost:12000"
+
+# Name of the nodes created on each NOSEngine bus. Must be different from the nodes created by the simulators.
+nodename = "fsw"
+
+# Minimum timeout in milliseconds. If the user of the HAL sets a timeout less than this, then the
+# timeout will actually be this. This is because communication over the network with the NOSEngine server has
+# different timing from actual UART communication, so there will sometimes be larger delays.
+min_timeout = 500
+
+# This table maps "real" bus names to simulated NOSEngine buses. The keys are the real bus names on the spacecraft,
+# and the values are the simulated bus names within NOSEngine.
+# If this changes, then the configuration of the simulators will have to change.
+[busnames.uart]
+"/dev/ttyUSB0" = "usart_usb0"
+"/dev/ttyS0" = "usart_0"
+"/dev/ttyS1" = "usart_1"
+"/dev/ttyS2" = "usart_2"
+"/dev/ttyS4" = "usart_4"
+"/dev/ttyS5" = "usart_5"
+
+[i2c]
+# In real life, and I2C master doesn't have an address, but NOSEngine requires it. Just choose an address that
+# doesn't conflict with anything else.
+master_address = 119
+
+# Maps real I2C paths to NOSEngine buses. 
+[i2c.busnames]
+"/dev/i2c0" = "i2c_2"
+"/dev/i2c1" = "i2c_1"
+"/dev/i2c-1" = "i2c_0"

--- a/hal/rust-hal/rust-i2c/Cargo.toml
+++ b/hal/rust-hal/rust-i2c/Cargo.toml
@@ -4,5 +4,10 @@ version = "0.1.0"
 authors = ["Ryan Plauche <ryan@kubos.co>"]
 edition = "2018"
 
+[features]
+nos3 = ["nosengine-rust", "toml"]
+
 [dependencies]
 i2c-linux = "0.1"
+nosengine-rust = { path = "../../../apis/nosengine-rust", optional = true }
+toml = { version = "0.4.0", optional = true }

--- a/hal/rust-hal/rust-uart/Cargo.toml
+++ b/hal/rust-hal/rust-uart/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.2.0"
 authors = ["William Greer <wgreer184@gmail.com>", "Catherine Garabedian <catherine@kubos.co>"]
 edition = "2018"
 
+[features]
+nos3 = ["nosengine-rust"]
+
 [dependencies]
 serial = "0.4.0"
 failure = "0.1.2"
+nosengine-rust = { path = "../../../apis/nosengine-rust", optional = true }
+toml = "0.4.0"
+display_derive = "0.0.0"

--- a/hal/rust-hal/rust-uart/src/error.rs
+++ b/hal/rust-hal/rust-uart/src/error.rs
@@ -15,7 +15,13 @@
 //
 
 use failure::Fail;
+#[cfg(feature = "nos3")]
+use nosengine_rust::client::uart;
 use std::error::Error;
+#[cfg(feature = "nos3")]
+use std::sync;
+#[cfg(feature = "nos3")]
+use toml;
 
 /// Custom errors for UART actions
 #[derive(Fail, Debug, Clone, PartialEq)]
@@ -59,6 +65,34 @@ impl From<serial::Error> for UartError {
             cause: error.kind(),
             description: error.description().to_owned(),
         }
+    }
+}
+
+#[cfg(feature = "nos3")]
+impl From<uart::UARTError> for UartError {
+    fn from(_error: uart::UARTError) -> Self {
+        UartError::GenericError
+    }
+}
+
+#[cfg(feature = "nos3")]
+impl From<toml::ser::Error> for UartError {
+    fn from(_error: toml::ser::Error) -> Self {
+        UartError::GenericError
+    }
+}
+
+#[cfg(feature = "nos3")]
+impl From<toml::de::Error> for UartError {
+    fn from(_error: toml::de::Error) -> Self {
+        UartError::GenericError
+    }
+}
+
+#[cfg(feature = "nos3")]
+impl From<sync::mpsc::RecvError> for UartError {
+    fn from(_error: sync::mpsc::RecvError) -> Self {
+        UartError::GenericError
     }
 }
 

--- a/services/clyde-3g-eps-service/Cargo.toml
+++ b/services/clyde-3g-eps-service/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Ryan Plauche <ryan@kubos.co>", "Catherine Garabedian <catherine@kubos.co>"]
 edition = "2018"
 
+[features]
+nos3 = ["clyde-3g-eps-api/nos3"]
+
 [dependencies]
 clyde-3g-eps-api = { path = "../../apis/clyde-3g-eps-api" }
 eps-api = { path = "../../apis/eps-api" }

--- a/services/novatel-oem6-service/Cargo.toml
+++ b/services/novatel-oem6-service/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Catherine Garabedian <catherine@kubos.co>"]
 edition = "2018"
 
+[features]
+nos3 = ["novatel-oem6-api/nos3"]
+
 [dependencies]
 failure = "0.1.2"
 juniper =  "0.11"

--- a/services/novatel-oem6-service/src/model.rs
+++ b/services/novatel-oem6-service/src/model.rs
@@ -140,11 +140,12 @@ impl Subsystem {
     pub fn new(bus: &str, data: Arc<LockData>) -> OEMResult<Subsystem> {
         let (log_send, log_recv) = sync_channel(5);
         let (response_send, response_recv) = sync_channel(5);
+        let (response_abbrv_send, response_abbrv_recv) = sync_channel(5);
 
-        let oem = OEM6::new(bus, BaudRate::Baud9600, log_recv, response_recv)?;
+        let oem = OEM6::new(bus, BaudRate::Baud9600, log_recv, response_recv, response_abbrv_recv)?;
 
         let rx_conn = oem.conn.clone();
-        thread::spawn(move || read_thread(&rx_conn, &log_send, &response_send));
+        thread::spawn(move || read_thread(&rx_conn, &log_send, &response_send, &response_abbrv_send));
 
         let (error_send, error_recv) = sync_channel(10);
         let (version_send, version_recv) = sync_channel(1);


### PR DESCRIPTION
Adds "nos3" feature to `clyde-3g-eps-service` and `clyde-3g-eps-api`, both work as is; `--feature nos3` enables the api's dependency `rust-i2c` to compile for nos engine.