### PR TITLE
Adding 'ping' query to all services

### DIFF
--- a/services/app-service/src/schema.rs
+++ b/services/app-service/src/schema.rs
@@ -27,6 +27,18 @@ pub struct QueryRoot;
 
 /// Base GraphQL query model
 graphql_object!(QueryRoot : Context as "Query" |&self| {
+    // Test query to verify service is running without
+    // attempting to execute an actual logic
+    //
+    // {
+    //    ping: "pong"
+    // }
+    field ping() -> FieldResult<String>
+        as "Test service query"
+    {
+        Ok(String::from("pong"))
+    }
+
     field apps(&executor,
                name: Option<String>,
                version: Option<String>,

--- a/services/app-service/src/tests/mod.rs
+++ b/services/app-service/src/tests/mod.rs
@@ -70,3 +70,25 @@ mod registry_start_app;
 mod registry_test;
 mod set_version;
 mod upgrade_app;
+
+use crate::registry::*;
+use crate::schema;
+use kubos_service::{Config, Service};
+use serde_json::json;
+use tempfile::TempDir;
+
+#[test]
+fn ping() {
+    let registry_dir = TempDir::new().unwrap();
+    let service = mock_service!(registry_dir);
+
+    let query = r#"{
+            ping
+        }"#;
+
+    let expected = json!({
+            "ping": "pong"
+    });
+
+    test!(service, query, expected);
+}

--- a/services/iobc-supervisor-service/src/main.rs
+++ b/services/iobc-supervisor-service/src/main.rs
@@ -47,6 +47,7 @@
 //!
 //! ```json
 //! query {
+//!     ping: "pong",
 //! 	supervisor: {
 //! 		version: {
 //! 			dummy,

--- a/services/iobc-supervisor-service/src/schema.rs
+++ b/services/iobc-supervisor-service/src/schema.rs
@@ -220,6 +220,12 @@ pub struct QueryRoot;
 
 /// Base GraphQL query model
 graphql_object!(QueryRoot : Context as "Query" |&self| {
+    field ping() -> FieldResult<String>
+        as "Test service query"
+    {
+        Ok(String::from("pong"))
+    }
+
     field supervisor(&executor) -> FieldResult<&Supervisor>
         as "Supervisor Query"
     {

--- a/services/pumpkin-mcu-service/service/schema.py
+++ b/services/pumpkin-mcu-service/service/schema.py
@@ -37,7 +37,7 @@ class Query(graphene.ObjectType):
         fields=graphene.List(graphene.String, default_value=["all"]))
 
     def resolve_ping(self, info):
-        return "PONG"
+        return "pong"
 
     def resolve_moduleList(self, info):
         """
@@ -151,7 +151,7 @@ class Test(graphene.Mutation):
         errors = []
         test_output = {}
         if test == 0:  # PING
-            test_output = "PONG"
+            test_output = "pong"
         elif test == 1:  # NOOP
             for module in MODULES:
                 try:

--- a/services/telemetry-service/src/main.rs
+++ b/services/telemetry-service/src/main.rs
@@ -61,6 +61,7 @@
 //!   value: Float!
 //! }
 //!
+//! query ping: "pong"
 //! query telemetry(timestampGe: Integer, timestampLe: Integer, subsystem: String, parameter: String): Entry
 //! query routedTelemetry(timestampGe: Integer, timestampLe: Integer, subsystem: String, parameter: String, output: String!, compress: Boolean = true): String!
 //!

--- a/services/telemetry-service/src/schema.rs
+++ b/services/telemetry-service/src/schema.rs
@@ -137,6 +137,18 @@ fn query_db(
 pub struct QueryRoot;
 
 graphql_object!(QueryRoot: Context |&self| {
+    // Test query to verify service is running without
+    // attempting to execute any actual logic
+    //
+    // {
+    //    ping: "pong"
+    // }
+    field ping() -> FieldResult<String>
+        as "Test service query"
+    {
+        Ok(String::from("pong"))
+    }
+
     field telemetry(
         &executor,
         timestamp_ge: Option<f64>,

--- a/services/telemetry-service/tests/test_ping.rs
+++ b/services/telemetry-service/tests/test_ping.rs
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use serde_json::json;
+mod utils;
+use crate::utils::*;
+
+#[test]
+fn test() {
+    let (handle, sender) = setup(None, None, None, None);
+    let res = do_query(None, "{ping}");
+    teardown(handle, sender);
+    assert_eq!(
+        res,
+        json!({
+            "data": {
+                "ping": "pong"
+            }
+        })
+    );
+}


### PR DESCRIPTION
A few of our services don't include the "ping" query. It's super nice to have, so I'm adding it.