### PR TITLE
Improving app service edge cases

### DIFF
--- a/services/app-service/src/registry.rs
+++ b/services/app-service/src/registry.rs
@@ -158,6 +158,16 @@ impl AppRegistry {
         }
 
         if let Err(err) = unix::fs::symlink(app_dir, active_symlink.clone()) {
+            // Make sure the 'active' directory exists
+            // If it doesn't, we'll go ahead and recreate it and try again
+            let active_dir = PathBuf::from(format!("{}/active", self.apps_dir));
+            if !active_dir.exists() {
+                fs::create_dir_all(&active_dir)?;
+
+                if unix::fs::symlink(app_dir, active_symlink.clone()).is_ok() {
+                    return Ok(());
+                }
+            }
             return Err(AppError::RegisterError {
                 err: format!(
                     "Couldn't symlink {} to {}: {:?}",

--- a/services/app-service/src/registry.rs
+++ b/services/app-service/src/registry.rs
@@ -347,7 +347,15 @@ impl AppRegistry {
         // If that was the last version, also remove the parent directory.
         // (If this call fails, it's probably because the directory wasn't empty because some
         // version of the app still exists, so ignore the error)
-        let _ = fs::remove_dir(format!("{}/{}", self.apps_dir, app_name));
+        if fs::remove_dir(format!("{}/{}", self.apps_dir, app_name)).is_ok() {
+            // That worked, so we also want to remove the active version symlink
+            if let Err(error) = fs::remove_file(format!("{}/active/{}", self.apps_dir, app_name)) {
+                errors = Some(format!(
+                    "{}. Failed to remove active symlink for {}: {}",
+                    error, app_name, error
+                ));
+            }
+        }
 
         // Remove the app entry from the registry list
         let mut entries = self

--- a/services/app-service/tests/test_uninstall.rs
+++ b/services/app-service/tests/test_uninstall.rs
@@ -46,8 +46,11 @@ fn uninstall_last_app() {
 
     // Make sure our app directory and active symlink exist
     assert_eq!(fixture.registry_dir.path().join("dummy").exists(), true);
-    assert!(fs::symlink_metadata(fixture.registry_dir.path().join("active/dummy")).is_ok(), true);
-    
+    assert!(
+        fs::symlink_metadata(fixture.registry_dir.path().join("active/dummy")).is_ok(),
+        true
+    );
+
     let result = panic::catch_unwind(|| {
         let result = send_query(
             ServiceConfig::new_from_path("app-service", config.to_owned()),
@@ -71,9 +74,17 @@ fn uninstall_last_app() {
 
     // Our app directory should now no longer exist
     assert_eq!(fixture.registry_dir.path().join("dummy").exists(), false);
-    
+
     // The app's active version symlink should also no longer exist
-    assert_eq!(format!("{}", fs::symlink_metadata(fixture.registry_dir.path().join("active/dummy")).err().unwrap()), "No such file or directory (os error 2)");
+    assert_eq!(
+        format!(
+            "{}",
+            fs::symlink_metadata(fixture.registry_dir.path().join("active/dummy"))
+                .err()
+                .unwrap()
+        ),
+        "No such file or directory (os error 2)"
+    );
 
     fixture.teardown();
     assert!(result.is_ok());

--- a/services/app-service/tests/test_uninstall.rs
+++ b/services/app-service/tests/test_uninstall.rs
@@ -44,9 +44,10 @@ fn uninstall_last_app() {
     app.install(&fixture.registry_dir.path());
     fixture.start_service(false);
 
-    // Make sure our app directory exists
+    // Make sure our app directory and active symlink exist
     assert_eq!(fixture.registry_dir.path().join("dummy").exists(), true);
-
+    assert!(fs::symlink_metadata(fixture.registry_dir.path().join("active/dummy")).is_ok(), true);
+    
     let result = panic::catch_unwind(|| {
         let result = send_query(
             ServiceConfig::new_from_path("app-service", config.to_owned()),
@@ -70,6 +71,9 @@ fn uninstall_last_app() {
 
     // Our app directory should now no longer exist
     assert_eq!(fixture.registry_dir.path().join("dummy").exists(), false);
+    
+    // The app's active version symlink should also no longer exist
+    assert_eq!(format!("{}", fs::symlink_metadata(fixture.registry_dir.path().join("active/dummy")).err().unwrap()), "No such file or directory (os error 2)");
 
     fixture.teardown();
     assert!(result.is_ok());


### PR DESCRIPTION
1. If the last version of an app is uninstalled, its active symlink will now be removed
2. If, for some reason, the active symlink directory stops existing, it will be recreated during the next app registration