### PR TITLE
Correcting telem db table creation

### DIFF
--- a/apis/telemetry-db-api/src/lib.rs
+++ b/apis/telemetry-db-api/src/lib.rs
@@ -80,7 +80,7 @@ impl Database {
                 info!("Telemetry table not found. Creating table.");
                 match sql_query(
                     "CREATE TABLE telemetry (
-                    timestamp INTEGER NOT NULL,
+                    timestamp DOUBLE NOT NULL,
                     subsystem VARCHAR(255) NOT NULL,
                     parameter VARCHAR(255) NOT NULL,
                     value VARCHAR(255) NOT NULL,


### PR DESCRIPTION
The telemetry database uses fractional seconds since UNIX epoch for its timestamps. Basically everywhere, this value is stored as a double.

This PR fixes the one remaining place that it's still an integer value.