### PR TITLE
Updating the app service to change to app's dir before kicking it off

### DIFF
--- a/services/app-service/src/registry.rs
+++ b/services/app-service/src/registry.rs
@@ -552,6 +552,12 @@ impl AppRegistry {
             return Err(AppError::StartError { err: msg });
         }
 
+        // Change our current directory to the app's directory so that it can access any
+        // auxiliary files with relative file paths
+        let cwd = ::std::env::current_dir()?;
+        let parent_dir = app_path.parent().unwrap_or(&cwd);
+        let _ = ::std::env::set_current_dir(parent_dir);
+
         let mut cmd = Command::new(app_path);
 
         cmd.arg("-r").arg(format!("{}", run_level));

--- a/services/app-service/src/registry.rs
+++ b/services/app-service/src/registry.rs
@@ -556,7 +556,11 @@ impl AppRegistry {
         // auxiliary files with relative file paths
         let cwd = ::std::env::current_dir()?;
         let parent_dir = app_path.parent().unwrap_or(&cwd);
-        let _ = ::std::env::set_current_dir(parent_dir);
+        if let Err(err) = ::std::env::set_current_dir(parent_dir) {
+            // If we can't change the current directory, we'll log an error and then just
+            // continue trying to execute the application
+            warn!("Failed to set cwd before executing {}: {:?}", app_name, err);
+        }
 
         let mut cmd = Command::new(app_path);
 

--- a/services/app-service/tests/test_python_app.rs
+++ b/services/app-service/tests/test_python_app.rs
@@ -20,9 +20,12 @@
 // properly run these tests. You'll need to manually run these tests and verify the output by
 // checking for any extraneous error messages.
 
+use fs_extra;
 use kubos_app::ServiceConfig;
 use std::fs;
 use std::path::Path;
+use std::thread;
+use std::time::Duration;
 
 mod utils;
 pub use crate::utils::*;
@@ -33,8 +36,14 @@ fn setup_app(registry_dir: &Path) {
 
     fs::create_dir_all(app_dir.clone()).unwrap();
 
-    // Copy our app executable into our app registry
+    // Copy our app files into our app registry
     fs::copy("tests/utils/python-proj/main.py", app_dir.join("main.py")).unwrap();
+    fs_extra::dir::copy(
+        "tests/utils/python-proj/sub",
+        app_dir.clone(),
+        &fs_extra::dir::CopyOptions::new(),
+    )
+    .unwrap();
 
     // Create our manifest file
     let toml = format!(
@@ -83,6 +92,9 @@ fn app_no_args() {
         }"#,
     );
 
+    // Give the app a moment to run successfully before we tear everything down
+    thread::sleep(Duration::from_millis(100));
+
     fixture.teardown();
 
     assert!(result["startApp"]["success"].as_bool().unwrap());
@@ -116,6 +128,8 @@ fn app_single_pos_arg() {
             }
         }"#,
     );
+
+    thread::sleep(Duration::from_millis(100));
 
     fixture.teardown();
 
@@ -151,6 +165,8 @@ fn app_single_flag() {
         }"#,
     );
 
+    thread::sleep(Duration::from_millis(100));
+
     fixture.teardown();
 
     assert!(result["startApp"]["success"].as_bool().unwrap());
@@ -184,6 +200,8 @@ fn app_flag_arg() {
             }
         }"#,
     );
+
+    thread::sleep(Duration::from_millis(100));
 
     fixture.teardown();
 

--- a/services/app-service/tests/test_rust_app.rs
+++ b/services/app-service/tests/test_rust_app.rs
@@ -44,6 +44,9 @@ fn setup_app(registry_dir: &Path) {
     )
     .unwrap();
 
+    // Copy our test file to make sure we can access it later
+    fs::copy("tests/utils/rust-proj/testfile", app_dir.join("testfile")).unwrap();
+
     // Create our manifest file
     let toml = format!(
         r#"

--- a/services/app-service/tests/utils/python-proj/main.py
+++ b/services/app-service/tests/utils/python-proj/main.py
@@ -7,11 +7,12 @@
 import app_api
 import argparse
 import logging
+from sub import sub
 import sys
 
 def on_boot():
     
-    # Do nothing
+    sub.test_func()
     sys.exit(0)
     
 def on_command(args):

--- a/services/app-service/tests/utils/python-proj/sub/sub.py
+++ b/services/app-service/tests/utils/python-proj/sub/sub.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Kubos Corporation
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# This module exists to test that the app service supports multi-file applications
+
+def test_func():
+    
+    print("I'm a test function")
+    exit(0)

--- a/services/app-service/tests/utils/rust-proj/src/main.rs
+++ b/services/app-service/tests/utils/rust-proj/src/main.rs
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2019 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Test Rust project to help exercise all of the possible app framework behavior
+
 use failure::{bail, Error};
 use getopts::Options;
 use kubos_app::*;
@@ -6,6 +24,11 @@ struct MyApp;
 
 impl AppHandler for MyApp {
     fn on_boot(&self, _args: Vec<String>) -> Result<(), Error> {
+        // Test that we can access a file which was packaged with this binary
+        let contents = ::std::fs::read_to_string("testfile")?;
+
+        assert_eq!(contents, "test string");
+
         Ok(())
     }
 
@@ -14,6 +37,7 @@ impl AppHandler for MyApp {
             bail!("No args given");
         }
 
+        // Test passing through args to this underlying app logic
         let mut opts = Options::new();
         opts.optflag("f", "", "Test flag");
         opts.optopt("t", "test", "Test arg", "TEST");

--- a/services/app-service/tests/utils/rust-proj/testfile
+++ b/services/app-service/tests/utils/rust-proj/testfile
@@ -1,0 +1,1 @@
+test string


### PR DESCRIPTION
When registering an application, we currently copy the entire given directory. This allows users to register an app with multiple files. This is mostly important for Python, but does also give the user the ability to include auxiliary files (ex. a custom config file for something).

This PR updates the app service to change its working directory to the specified application's directory before kicking it off during a ``startApp`` request. This allows users to specify the files they included with their app using relative paths.

Note: Multi-file Python actually works without the app service changes, but I did expand the Python test project in order to verify this