### PR TITLE
Fixing intermittently failing CI tests

### DIFF
--- a/apis/isis-imtq-api/test/imtq/imtq.c
+++ b/apis/isis-imtq-api/test/imtq/imtq.c
@@ -627,7 +627,7 @@ static void test_watchdog(void ** arg)
 
     start_ret = k_imtq_watchdog_start();
 
-    const struct timespec delay = {.tv_sec = 0, .tv_nsec = 2000001 };
+    const struct timespec delay = {.tv_sec = 0, .tv_nsec = 20000001 };
 
     nanosleep(&delay, NULL);
 
@@ -649,7 +649,7 @@ static void test_watchdog_twice(void ** arg)
 
     start_ret = k_imtq_watchdog_start();
 
-    const struct timespec delay = {.tv_sec = 0, .tv_nsec = 2000001 };
+    const struct timespec delay = {.tv_sec = 0, .tv_nsec = 20000001 };
 
     nanosleep(&delay, NULL);
 

--- a/apis/system-api/tests/test_boot_vars.rs
+++ b/apis/system-api/tests/test_boot_vars.rs
@@ -20,6 +20,7 @@ use std::env;
 use std::fs;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use tempfile::TempDir;
 
 const DUMMY_PRINTENV: &'static str = r#"#!/bin/bash
@@ -28,8 +29,8 @@ VAR="$2"
 echo ${!VAR}
 "#;
 
-fn setup_dummy_vars(bin_dest: Path) -> UBootVars {
-    bin_dest.join("dummy-printenv");
+fn setup_dummy_vars(env_dir: &Path) -> UBootVars {
+    let bin_dest = env_dir.join("dummy-printenv");
 
     let mut file = fs::File::create(bin_dest.clone()).unwrap();
     file.write_all(DUMMY_PRINTENV.as_bytes())

--- a/apis/system-api/tests/test_boot_vars.rs
+++ b/apis/system-api/tests/test_boot_vars.rs
@@ -21,6 +21,8 @@ use std::fs;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use std::thread;
+use std::time::Duration;
 use tempfile::TempDir;
 
 const DUMMY_PRINTENV: &'static str = r#"#!/bin/bash
@@ -34,7 +36,7 @@ fn setup_dummy_vars(env_dir: &Path) -> UBootVars {
 
     let mut file = fs::File::create(bin_dest.clone()).unwrap();
     file.write_all(DUMMY_PRINTENV.as_bytes())
-        .expect("Failed to write dummy printenv");;
+        .expect("Failed to write dummy printenv");
 
     let mut perms = file.metadata().unwrap().permissions();
     perms.set_mode(0o755);
@@ -51,15 +53,18 @@ fn u32_vars() {
     let vars = setup_dummy_vars(env_dir.path());
 
     env::set_var("count", "123");
+    thread::sleep(Duration::from_millis(1));
     assert_eq!(vars.get_u32("count"), Some(123));
 
     env::set_var("count", "");
+    thread::sleep(Duration::from_millis(1));
     assert_eq!(vars.get_u32("count"), None);
 
     // should be undefined so far..
     assert_eq!(vars.get_u32("limit"), None);
 
     env::set_var("limit", "abc");
+    thread::sleep(Duration::from_millis(1));
     assert_eq!(vars.get_u32("limit"), None);
 }
 
@@ -70,9 +75,11 @@ fn bool_vars() {
     assert_eq!(vars.get_bool("abcdefg"), None);
 
     env::set_var("abcdefg", "0");
+    thread::sleep(Duration::from_millis(1));
     assert_eq!(vars.get_bool("abcdefg"), Some(false));
 
     env::set_var("abcdefg", "1");
+    thread::sleep(Duration::from_millis(1));
     assert_eq!(vars.get_bool("abcdefg"), Some(true));
 }
 
@@ -83,8 +90,10 @@ fn str_vars() {
     assert_eq!(vars.get_str("currv"), None);
 
     env::set_var("currv", "1.23");
+    thread::sleep(Duration::from_millis(1));
     assert_eq!(vars.get_str("currv"), Some(String::from("1.23")));
 
     env::set_var("currv", "");
+    thread::sleep(Duration::from_millis(1));
     assert_eq!(vars.get_str("currv"), Some(String::from("")));
 }

--- a/libs/cbor-protocol/src/lib.rs
+++ b/libs/cbor-protocol/src/lib.rs
@@ -104,7 +104,7 @@ impl Protocol {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use cbor_protocol::*;
     ///
     /// let cbor_connection = Protocol::new(&"0.0.0.0:8000".to_owned(), 4096);
@@ -316,7 +316,7 @@ impl Protocol {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use cbor_protocol::*;
     /// use std::time::Duration;
     ///

--- a/services/app-service/src/registry.rs
+++ b/services/app-service/src/registry.rs
@@ -16,6 +16,7 @@
 
 use crate::app_entry::*;
 use crate::error::*;
+use failure::format_err;
 use fs_extra;
 use kubos_app::RunLevel;
 use log::*;
@@ -572,9 +573,13 @@ impl AppRegistry {
 
         // Change our current directory to the app's directory so that it can access any
         // auxiliary files with relative file paths
-        let cwd = ::std::env::current_dir()?;
-        let parent_dir = app_path.parent().unwrap_or(&cwd);
-        if let Err(err) = ::std::env::set_current_dir(parent_dir) {
+        if let Err(err) = app_path
+            .parent()
+            .ok_or_else(|| format_err!("Failed to get parent dir"))
+            .and_then(|parent_dir| {
+                ::std::env::set_current_dir(parent_dir).map_err(|err| err.into())
+            })
+        {
             // If we can't change the current directory, we'll log an error and then just
             // continue trying to execute the application
             warn!("Failed to set cwd before executing {}: {:?}", app_name, err);

--- a/tools/ci_c.py
+++ b/tools/ci_c.py
@@ -43,6 +43,7 @@ def build(dir):
 
 def run_test(dir):
     build_dir = "build"
+    os.environ["CTEST_OUTPUT_ON_FAILURE"] = "1"
     subprocess.run(["make", "test"], cwd=build_dir, check=True)
 
 def test(dir):


### PR DESCRIPTION
We have a few unit tests that fail periodically. This PR attempts to fix them

- Updating boot vars tests to use a randomly generated temporary directory rather than just `/tmp`
- Updating boot var tests to add a little time between setting a variable and then fetching it
- Expanding the delay for the iMTQ watchdog tests
- Making all CBOR doc examples `no_run`
- Tweaking the way we change the current directory for running apps
- Adding retry logic to the app service test setup