### PR TITLE
Improving Rust size optimization for release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,11 @@ jobs:
     rust_test:
       docker:
         - image: kubos/kubos-dev:latest
+      resource_class: xlarge
       steps:
         - checkout
         - run: cd apis/app-api/python && pip3 install .
-        - run: cargo test -j 7 --release
+        - run: cargo test --release
 
     # Rust testing - large upload test
     # Run for all PR commits

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       steps:
         - checkout
         - run: cd apis/app-api/python && pip3 install .
-        - run: cargo test -j 7
+        - run: cargo test -j 7 --release
 
     # Rust testing - large upload test
     # Run for all PR commits
@@ -54,7 +54,7 @@ jobs:
         - image: kubos/kubos-dev:latest
       steps:
         - checkout
-        - run: cargo run --bin large_upload
+        - run: cargo run --bin large_upload --release
 
     # Rust testing - large download
     # Run for all PR commits
@@ -63,7 +63,7 @@ jobs:
         - image: kubos/kubos-dev:latest
       steps:
         - checkout
-        - run: cargo run --bin large_download
+        - run: cargo run --bin large_download --release
 
     # Rust testing - Check formatting
     # Run for all PR commits

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,5 +53,6 @@ members = [
 
 [profile.release]
 lto = true
-opt-level = 3
+opt-level = "z"
 panic = "abort"
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,9 @@ lto = true
 opt-level = "z"
 panic = "abort"
 codegen-units = 1
+
+[profile.bench]
+lto = true
+opt-level = "z"
+panic = "abort"
+codegen-units = 1


### PR DESCRIPTION
Adding two new compiler options for Rust project release builds:
- `opt-size = "z"` - Tells the compiler to optimize for size as much as possible
- `codegen-units = 1` - Tells the compiler not to build in parallel. Building in parallel prevents the compiler from being able to do certain optimizations

I compared the size of the application service's binary when compiled for the iOBC using the release build profile.

Old size: 4,360,632
Adding opt-level z: 3,677,904
(prev) + codegen-units 1: 3,423,072
Diff: -937,560 (-21.5%)

Old size + arm-linux-strip: 2,602,756
New size + arm-linux-strip: 1,496,836
Diff: -1,105,920 (-42.5%)