### PR TITLE
Locking version of breathe until we fully migrate to Python3

### DIFF
--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -1,4 +1,4 @@
-# kubos/kubos-dev:1.15.0
+# kubos/kubos-dev:1.15.1
 
 FROM phusion/baseimage:0.9.22
 
@@ -21,6 +21,8 @@ RUN easy_install pip
 
 # Set up pip for Python3.5
 RUN apt-get install -y python3-pip
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
 
 #Kubos Linux setup
 RUN echo "Installing Kubos Linux Toolchain"
@@ -52,7 +54,7 @@ COPY cargo_config /root/.cargo/config
 #Tools to generate docs
 RUN apt-get install -y doxygen graphviz plantuml
 RUN pip install Sphinx==1.5.6
-RUN pip install breathe
+RUN pip install breathe==4.12.0
 RUN pip install sphinx-rtd-theme==0.2.4
 RUN pip install sphinxcontrib-plantuml sphinxcontrib-versioning
 RUN pip install sphinx-jsondomain


### PR DESCRIPTION
When I tried to regenerate our Docker image, it failed because the latest version of `breathe` only supports Python3. I have locked it at the last Python2.7-friendly version and created a couple cards to migrate everything to Python3 in the future.

There are two other lines which I added while messing with things that I would like to leave in:
- Upgrading pip to the latest version - This is just because the default version is super old
- Upgrade setuptools to the latest version - I ran into issues when installing `sphinxcontrib-plantuml` for Python3. It threw a really weird (non-obvious) error. A google search led me to conclude that `setuptools` needed to be updated.