### PR TITLE
Adding instructions for local cross-compile

### DIFF
--- a/docs/obc-docs/cross-compile.rst
+++ b/docs/obc-docs/cross-compile.rst
@@ -2,7 +2,7 @@ Compiling Code for a Target OBC
 ===============================
 
 In order for programs written using a compiled language (Rust, C, etc) to work on a target OBC,
-it will need to be compiled using the appropriate cross-compile toolchain.
+they will need to be compiled using the appropriate cross-compile toolchain.
 
 This document covers the process of installing the cross-compile toolchain and compiling a program
 for a target OBC using a local development environment.
@@ -12,10 +12,20 @@ helper tooling.
 If you are using the SDK as your development environment, please refer to :doc:`those docs <../sdk-docs/index>`
 for more specific information.
 
+.. note::
+
+    The toolchains have been generated and tested with a Linux-based host operating system.
+    There may be issues when using them with a Mac-based operating system. If so, please use the
+    :doc:`SDK <../sdk-docs/index>` in order to cross-compile your projectes instead.
+
 Download
 --------
 
 Below are the direct download links for the latest cross-compiling toolchains.
+These toolchains contain the majority of utilities required to build a KubOS project.
+They include things like the C and C++ compilers and linkers which are needed to generate
+executables for the target architecture, as well as tools which the host will use to assemble and
+package other OS components.
 If you need a prior version of a toolchain, please contact a Kubos team member for support.
 
 - `Beaglebone Black / Pumpkin MBM2 <https://s3.amazonaws.com/kubos-world-readable-assets/bbb_toolchain.tar.gz>`__
@@ -25,9 +35,8 @@ Installation
 ------------
 
 Uncompress the toolchain into your location of choice.
-
-The remainder of this document will refer to the location as `/usr/bin/{obc}_toolchain/`, since this
-is the location we use internally.
+We recommend that you choose a location which is outside of your system path, since the toolchains
+may contain binaries which have duplicate names to those which already exist in the system.
 
 Rust
 ~~~~
@@ -42,7 +51,7 @@ Add a new ``[target.*]`` section with a ``linker`` variable which points to the 
 file::
 
     [target.$triple]
-    linker = "/usr/bin/{obc}_toolchain/usr/bin/{arch}-gcc"
+    linker = "/path/to/{obc}_toolchain/usr/bin/{arch}-gcc"
     
 Please refer to the Kubos SDK's `Cargo config file <https://github.com/kubos/kubos-vagrant/blob/master/kubos-dev/bin/cargo_config>`__
 for reference.
@@ -54,15 +63,15 @@ Using the Toolchains
 Rust
 ~~~~
 
-The new toolchains can be used by specifying the target triple you defined in the ``--target``
-argument when running ``cargo build``.
+The new toolchains can be used by specifying the previously-defined target triple in the
+``--target`` argument when running ``cargo build``.
 
 For example::
 
     $ cargo build --target arm-unknown-linux-gnueabihf
     
 More specific information about how to set up and use a Rust project can be found in the
-:doc:`../sdk-docs/sdk-rust` doc.
+:doc:`../getting-started/using-rust` doc.
 
 C
 ^
@@ -72,8 +81,8 @@ binary prior to compiling your code.
 
 For example::
 
-    $ export CC=/usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc
-    $ export CXX=/usr/bin/bbb_toolchain/usr/bin/arm-linux-g++
+    $ export CC=/home/user/bbb_toolchain/usr/bin/arm-linux-gcc
+    $ export CXX=/home/user/bbb_toolchain/usr/bin/arm-linux-g++
     $ cmake .. && make
 
 More specific information about how to set up and use a C project can be found in the

--- a/docs/obc-docs/cross-compile.rst
+++ b/docs/obc-docs/cross-compile.rst
@@ -1,8 +1,80 @@
 Compiling Code for a Target OBC
 ===============================
 
-TODO: Rust and C need to use our toolchains
+In order for programs written using a compiled language (Rust, C, etc) to work on a target OBC,
+it will need to be compiled using the appropriate cross-compile toolchain.
 
-Point to the toolchain URLs
+This document covers the process of installing the cross-compile toolchain and compiling a program
+for a target OBC using a local development environment.
 
-Talk about the Vagrant
+The Kubos SDK comes with the cross-compile toolchains pre-installed, as well as some additional
+helper tooling.
+If you are using the SDK as your development environment, please refer to :doc:`those docs <../sdk-docs/index>`
+for more specific information.
+
+Download
+--------
+
+Below are the direct download links for the latest cross-compiling toolchains.
+If you need a prior version of a toolchain, please contact a Kubos team member for support.
+
+- `Beaglebone Black / Pumpkin MBM2 <https://s3.amazonaws.com/kubos-world-readable-assets/bbb_toolchain.tar.gz>`__
+- `ISIS OBC <https://s3.amazonaws.com/kubos-world-readable-assets/iobc_toolchain.tar.gz>`__
+
+Installation
+------------
+
+Uncompress the toolchain into your location of choice.
+
+The remainder of this document will refer to the location as `/usr/bin/{obc}_toolchain/`, since this
+is the location we use internally.
+
+Rust
+~~~~
+
+If you are programming in Rust, you will now want to `configure Cargo <https://doc.rust-lang.org/cargo/reference/config.html>`__
+to use the new toolchain.
+
+Navigate to your ``.cargo`` directory and edit the ``config`` file (or create one if it doesn't
+already exist)
+
+Add a new ``[target.*]`` section with a ``linker`` variable which points to the toolchain's ``gcc``
+file::
+
+    [target.$triple]
+    linker = "/usr/bin/{obc}_toolchain/usr/bin/{arch}-gcc"
+    
+Please refer to the Kubos SDK's `Cargo config file <https://github.com/kubos/kubos-vagrant/blob/master/kubos-dev/bin/cargo_config>`__
+for reference.
+You should be able to directly copy the lines pertaining to your target OBC.
+
+Using the Toolchains
+--------------------
+
+Rust
+~~~~
+
+The new toolchains can be used by specifying the target triple you defined in the ``--target``
+argument when running ``cargo build``.
+
+For example::
+
+    $ cargo build --target arm-unknown-linux-gnueabihf
+    
+More specific information about how to set up and use a Rust project can be found in the
+:doc:`../sdk-docs/sdk-rust` doc.
+
+C
+^
+
+To use the toolchains with C, define the ``CC`` and ``CXX`` envars with the path to the appropriate
+binary prior to compiling your code.
+
+For example::
+
+    $ export CC=/usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc
+    $ export CXX=/usr/bin/bbb_toolchain/usr/bin/arm-linux-g++
+    $ cmake .. && make
+
+More specific information about how to set up and use a C project can be found in the
+:doc:`../sdk-docs/sdk-c` doc.


### PR DESCRIPTION
Adding instructions for setting up cross-compiling in a local dev environment, rather than the SDK.

The SDK docs already have some information about cross-compiling, but I'm leaving that where it is for now. Once the dust settles (or if someone has a better idea), the information might get moved around.