### PR TITLE
Remove undefined and unused module from test

### DIFF
--- a/services/app-service/tests/utils/python-proj/main.py
+++ b/services/app-service/tests/utils/python-proj/main.py
@@ -4,7 +4,6 @@
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
 
-import app_api
 import argparse
 import logging
 from sub import sub


### PR DESCRIPTION
`app-service` tests failed with `ModuleNotFoundError: No module named 'app_api'` until I removed this. If we want to use it, I think we'd need to import it from `apis/app-api/python`. How was this intended to be loaded?