### PR TITLE
Updating Rust app API and example apps to allow custom config file

### DIFF
--- a/apis/app-api/rust/src/framework.rs
+++ b/apis/app-api/rust/src/framework.rs
@@ -149,6 +149,13 @@ pub fn app_start(
         "Run level which should be executed",
         "RUN_LEVEL",
     );
+    // This option will be processed by the system-api crate when a service query is run
+    opts.optflagopt(
+        "c",
+        "config",
+        "System config file which should be used",
+        "CONFIG",
+    );
     opts.optflag("h", "help", "Print this help menu");
 
     let matches = match opts.parse(&args[1..]) {

--- a/apis/system-api/src/config.rs
+++ b/apis/system-api/src/config.rs
@@ -162,6 +162,9 @@ fn get_config_path() -> String {
 
     let mut opts = Options::new();
     opts.optopt("c", "config", "Path to config file", "CONFIG");
+    // This library can be used by applications, which have this additional run level arg which
+    // can be specified
+    opts.optopt("r", "run", "Run level which should be executed", "RUN_LEVEL");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(_) => {

--- a/apis/system-api/src/config.rs
+++ b/apis/system-api/src/config.rs
@@ -164,10 +164,16 @@ fn get_config_path() -> String {
     opts.optopt("c", "config", "Path to config file", "CONFIG");
     // This library can be used by applications, which have this additional run level arg which
     // can be specified
-    opts.optopt("r", "run", "Run level which should be executed", "RUN_LEVEL");
+    opts.optopt(
+        "r",
+        "run",
+        "Run level which should be executed",
+        "RUN_LEVEL",
+    );
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(_) => {
+            eprintln!("Using default config values");
             // suppress errors so applications using Config can have their own Options
             return DEFAULT_PATH.to_string();
         }

--- a/examples/python-mission-application/mission-app.py
+++ b/examples/python-mission-application/mission-app.py
@@ -105,7 +105,7 @@ def on_command(logger, cmd_args):
             sys.exit(1)
                     
     else:
-        query = '{ apps { active, app { uuid, name, version, author } } }'
+        query = '{ apps { active, app { name, version, author } } }'
         try:
             logger.info("Querying for active applications")
             logger.info("Query: {}".format(query))
@@ -130,10 +130,21 @@ def main():
         nargs=1,
         help='Determines run behavior. Either "OnBoot" or "OnCommand"',
         required=True)
+    # The -c argument should be present if you would like to be able to specify a non-default
+    # configuration file
+    parser.add_argument(
+        '-c',
+        '--config',
+        nargs=1,
+        help='Specifies the location of a non-default configuration file')
     # Other optional arguments which will be passed through to the underlying logic
     parser.add_argument('cmd_args', nargs='*')
 
     args = parser.parse_args()
+    
+    if args.config is not None:
+        global SERVICES
+        SERVICES = app_api.Services(args.config[0])
 
     if args.run[0] == 'OnBoot':
         on_boot(logger)

--- a/examples/python-mission-framework/python-mission-app.py
+++ b/examples/python-mission-framework/python-mission-app.py
@@ -4,6 +4,8 @@ import app_api
 import argparse
 import sys
 
+SERVICES = app_api.Services()
+
 def on_boot(logger):
     
     logger.info("OnBoot logic")
@@ -18,14 +20,19 @@ def main():
     
     parser = argparse.ArgumentParser()
     
-    parser.add_argument('--run', '-r')
+    parser.add_argument('--run', '-r', nargs=1)
+    parser.add_argument('--config', '-c', nargs=1)
     parser.add_argument('cmd_args', nargs='*')
     
     args = parser.parse_args()
     
-    if args.run == 'OnBoot':
+    if args.config is not None:
+        global SERVICES
+        SERVICES = app_api.Services(args.config[0])
+    
+    if args.run[0] == 'OnBoot':
         on_boot(logger)
-    elif args.run == 'OnCommand':
+    elif args.run[0] == 'OnCommand':
         on_command(logger)
     else:
         logger.error("Unknown run level specified")

--- a/examples/rust-mission-app/src/main.rs
+++ b/examples/rust-mission-app/src/main.rs
@@ -71,22 +71,21 @@ impl AppHandler for MyApp {
     fn on_command(&self, args: Vec<String>) -> Result<(), Error> {
         let mut opts = Options::new();
 
-        opts.optflagopt(
-            "r",
-            "run",
-            "Run level which should be executed",
-            "RUN_LEVEL",
-        );
         opts.optflagopt("s", "cmd_string", "Subcommand", "CMD_STR");
         opts.optflagopt("t", "cmd_sleep", "Safe-mode sleep time", "CMD_INT");
+        
+        info!("OnCommand logic called");
+        
+        if args.len() == 0 {
+            // No subcommand options were given, so we're done here
+            return Ok(())
+        }
 
         // Parse the command args (skip the first arg with the application name)
-        let matches = match opts.parse(&args[1..]) {
+        let matches = match opts.parse(args) {
             Ok(r) => r,
             Err(f) => panic!(f.to_string()),
         };
-
-        info!("OnCommand logic called");
 
         let subcommand = matches.opt_str("s").unwrap_or_else(|| "".to_owned());
 

--- a/examples/rust-mission-app/src/main.rs
+++ b/examples/rust-mission-app/src/main.rs
@@ -73,12 +73,12 @@ impl AppHandler for MyApp {
 
         opts.optflagopt("s", "cmd_string", "Subcommand", "CMD_STR");
         opts.optflagopt("t", "cmd_sleep", "Safe-mode sleep time", "CMD_INT");
-        
+
         info!("OnCommand logic called");
-        
+
         if args.len() == 0 {
             // No subcommand options were given, so we're done here
-            return Ok(())
+            return Ok(());
         }
 
         // Parse the command args (skip the first arg with the application name)

--- a/examples/rust-mission-app/src/main.rs
+++ b/examples/rust-mission-app/src/main.rs
@@ -111,7 +111,6 @@ impl AppHandler for MyApp {
                     apps {
                         active,
                         app {
-                            uuid,
                             name,
                             version,
                             author

--- a/services/app-service/tests/utils/python-proj/main.py
+++ b/services/app-service/tests/utils/python-proj/main.py
@@ -10,6 +10,8 @@ import logging
 from sub import sub
 import sys
 
+SERVICES = app_api.Services()
+
 def on_boot():
     
     sub.test_func()
@@ -52,9 +54,18 @@ def main():
         nargs=1,
         help='Determines run behavior. Either "OnBoot" or "OnCommand"',
         required=True)
+    parser.add_argument(
+        '-c',
+        '--config',
+        nargs=1,
+        help='Specifies the location of a non-default configuration file')
     parser.add_argument('cmd_args', nargs='*')
     
     args = parser.parse_args()
+    
+    if args.config is not None:
+        global SERVICES
+        SERVICES = app_api.Services(args.config[0])
     
     if args.run[0] == 'OnBoot':
         on_boot()


### PR DESCRIPTION
- Updated the rust app api to allow the `-c config` option
- Updated the rust system-api to allow the `-r level` option (not that it will be used by that crate, but it was the easiest/fastest way to fix this issue. The `getopt` crate does not have a way to allow unknown args. We might want to migrate to something like `clap` in the future)
- Updated the python examples to get and set the non-default config value

Doc updates will be done in a separate PR (against the doc-reorg branch)