### PR TITLE
Adding ability to start app with custom config file

### DIFF
--- a/services/app-service/src/registry.rs
+++ b/services/app-service/src/registry.rs
@@ -238,7 +238,7 @@ impl AppRegistry {
         // Make sure the file which should be called for execution is present in the directory
         if !app_path.join(app_exec.clone()).exists() {
             return Err(AppError::RegisterError {
-                err: format!("Application file {} not found in given path", app_name),
+                err: format!("Application file {} not found in given path", app_exec),
             });
         }
 
@@ -538,6 +538,7 @@ impl AppRegistry {
         &self,
         app_name: &str,
         run_level: &RunLevel,
+        config: Option<String>,
         args: Option<Vec<String>>,
     ) -> Result<u32, AppError> {
         // Look up the active version of the requested application
@@ -588,6 +589,10 @@ impl AppRegistry {
         let mut cmd = Command::new(app_path);
 
         cmd.arg("-r").arg(format!("{}", run_level));
+
+        if let Some(path) = config {
+            cmd.arg("-c").arg(path);
+        }
 
         if let Some(add_args) = args {
             cmd.args(&add_args);
@@ -644,7 +649,7 @@ impl AppRegistry {
             match entry {
                 Ok(file) => {
                     let name = file.file_name();
-                    match self.start_app(&name.to_string_lossy(), &RunLevel::OnBoot, None) {
+                    match self.start_app(&name.to_string_lossy(), &RunLevel::OnBoot, None, None) {
                         Ok(_) => apps_started += 1,
                         Err(error) => {
                             error!("Failed to start {}: {}", name.to_string_lossy(), error);

--- a/services/app-service/src/schema.rs
+++ b/services/app-service/src/schema.rs
@@ -113,7 +113,7 @@ graphql_object!(MutationRoot : Context as "Mutation" |&self| {
         })
     }
 
-    field start_app(&executor, name: String, run_level: String, args: Option<Vec<String>>) -> FieldResult<StartResponse>
+    field start_app(&executor, name: String, run_level: String, config: Option<String>, args: Option<Vec<String>>) -> FieldResult<StartResponse>
         as "Start App"
     {
         let run_level_o = {
@@ -133,7 +133,7 @@ graphql_object!(MutationRoot : Context as "Mutation" |&self| {
             None
         };
 
-        Ok(match executor.context().subsystem().start_app(&name, &run_level_o, args) {
+        Ok(match executor.context().subsystem().start_app(&name, &run_level_o, config, args) {
             Ok(num) => StartResponse { success: true, errors: "".to_owned(), pid: Some(num as i32)},
             Err(error) => StartResponse { success: false, errors: error.to_string(), pid: None },
         })

--- a/services/app-service/src/tests/registry_start_app.rs
+++ b/services/app-service/src/tests/registry_start_app.rs
@@ -69,7 +69,7 @@ fn start_app_good() {
     // Create the registry
     let registry = AppRegistry::new_from_dir(&registry_dir.path().to_string_lossy()).unwrap();
 
-    let result = registry.start_app("tiny-app", &RunLevel::OnCommand, None);
+    let result = registry.start_app("tiny-app", &RunLevel::OnCommand, None, None);
 
     // Small sleep to prevent tiny-app from being destroyed before
     // the system finishes calling it
@@ -114,7 +114,7 @@ fn start_app_fail() {
     // Create the registry
     let registry = AppRegistry::new_from_dir(&registry_dir.path().to_string_lossy()).unwrap();
 
-    let result = registry.start_app("tiny-app", &RunLevel::OnCommand, None);
+    let result = registry.start_app("tiny-app", &RunLevel::OnCommand, None, None);
 
     assert_eq!(
         result.unwrap_err(),
@@ -153,7 +153,7 @@ fn start_app_bad() {
     // Create the registry
     let registry = AppRegistry::new_from_dir(&registry_dir.path().to_string_lossy()).unwrap();
 
-    let result = registry.start_app("tiny-app", &RunLevel::OnCommand, None);
+    let result = registry.start_app("tiny-app", &RunLevel::OnCommand, None, None);
 
     match result.unwrap_err() {
         AppError::StartError { err } => {
@@ -209,7 +209,7 @@ fn start_app_nonzero_rc() {
     // Create the registry
     let registry = AppRegistry::new_from_dir(&registry_dir.path().to_string_lossy()).unwrap();
 
-    let result = registry.start_app("tiny-app", &RunLevel::OnCommand, None);
+    let result = registry.start_app("tiny-app", &RunLevel::OnCommand, None, None);
 
     // Small sleep to prevent tiny-app from being destroyed before
     // the system finishes calling it

--- a/services/app-service/tests/test_rust_app.rs
+++ b/services/app-service/tests/test_rust_app.rs
@@ -47,6 +47,13 @@ fn setup_app(registry_dir: &Path) {
     // Copy our test file to make sure we can access it later
     fs::copy("tests/utils/rust-proj/testfile", app_dir.join("testfile")).unwrap();
 
+    // Copy our config file to make sure we can access it later
+    fs::copy(
+        "tests/utils/rust-proj/config.toml",
+        app_dir.join("config.toml"),
+    )
+    .unwrap();
+
     // Create our manifest file
     let toml = format!(
         r#"
@@ -190,6 +197,40 @@ fn app_flag_arg() {
         config,
         r#"mutation {
             startApp(name: "rust-proj", runLevel: "OnCommand", args: ["-t", "test"]) {
+                errors,
+                success
+            }
+        }"#,
+    );
+
+    fixture.teardown();
+
+    assert!(result["startApp"]["success"].as_bool().unwrap());
+}
+
+#[test]
+fn app_custom_config() {
+    let mut fixture = AppServiceFixture::setup();
+    let config = ServiceConfig::new_from_path(
+        "app-service",
+        format!(
+            "{}",
+            fixture
+                .registry_dir
+                .path()
+                .join("config.toml")
+                .to_string_lossy()
+        ),
+    );
+
+    setup_app(&fixture.registry_dir.path());
+
+    fixture.start_service(true);
+
+    let result = send_query(
+        config,
+        r#"mutation {
+            startApp(name: "rust-proj", runLevel: "OnCommand", config: "config.toml") {
                 errors,
                 success
             }

--- a/services/app-service/tests/utils/rust-proj/config.toml
+++ b/services/app-service/tests/utils/rust-proj/config.toml
@@ -1,0 +1,3 @@
+[test-service.addr]
+ip = "123.4.5.6"
+port = 7890

--- a/services/app-service/tests/utils/rust-proj/src/main.rs
+++ b/services/app-service/tests/utils/rust-proj/src/main.rs
@@ -33,8 +33,16 @@ impl AppHandler for MyApp {
     }
 
     fn on_command(&self, args: Vec<String>) -> Result<(), Error> {
+        let mut success = false;
+        
         if args.is_empty() {
-            bail!("No args given");
+            // Test using a custom config file
+            let service = ServiceConfig::new("test-service");
+            if service.hosturl() == "123.4.5.6:7890" {
+                success = true;
+            } else {
+                bail!("Service URL mismatch: {}", service.hosturl());
+            }
         }
 
         // Test passing through args to this underlying app logic
@@ -48,7 +56,9 @@ impl AppHandler for MyApp {
             Err(f) => panic!(f.to_string()),
         };
 
-        let mut success = matches.opt_present("f");
+        if matches.opt_present("f") {
+            success = true;
+        }
 
         if matches.opt_str("t") == Some("test".to_owned()) {
             success = true;


### PR DESCRIPTION
If you want to play with KubOS locally, you need to be able to start an app with the app service using a custom config file.

This PR adds a new schema arg, ``config``, to do so.

Docs will be updated in a separate PR