### PR TITLE
Tweaking first mission app to be compatible with OSX

### DIFF
--- a/docs/tutorials/app-register.rst
+++ b/docs/tutorials/app-register.rst
@@ -238,13 +238,13 @@ Updating
 --------
 
 After looking at our output, it would be nice if our memory message included the timestamp of
-when the system memory was checked.
+when the system was checked.
 
 Let's add the ``datetime`` module to our file with ``import datetime`` and then update the log line like so:
 
 .. code-block:: python
 
-    print("%s: Current available memory: %s kB" % (str(datetime.datetime.now()), available))
+    print("%s: Successfully pinged monitor service" % (str(datetime.datetime.now())))
 
 Since this is a new version of our application, we'll then need to update our ``manifest.toml``
 file to change the ``version`` key from ``"1.0"`` to ``"2.0"``.
@@ -287,7 +287,7 @@ After running our app again with the ``startApp`` mutation, our output should no
 
 .. code-block:: none
 
-    2019-07-03 16:15:29.452626: Current available memory: 4390664 kB
+    2019-07-03 16:15:29.452626: Successfully pinged monitor service
     Telemetry insert completed successfully
 
 Verifying

--- a/docs/tutorials/first-obc-project.rst
+++ b/docs/tutorials/first-obc-project.rst
@@ -20,7 +20,9 @@ Setup
 
     - :ref:`Configuring Ethernet <ethernet>`
 
-- We'll start with the base project from the :doc:`first mission app <first-mission-app>` tutorial
+- We'll start with the base project from the :doc:`first mission app <first-mission-app>` tutorial,
+  except we'll tweak our monitor service query to instead fetch the current amount of available
+  memory
 
 Setting Up Logging
 ------------------

--- a/examples/python-mission-application/mission-app.py
+++ b/examples/python-mission-application/mission-app.py
@@ -22,8 +22,6 @@ import sys
 import time
 import toml
 
-SERVICES = app_api.Services()
-
 # On-boot logic which will be called at boottime if this app is registered with
 # the applications service
 def on_boot(logger):
@@ -145,6 +143,8 @@ def main():
     if args.config is not None:
         global SERVICES
         SERVICES = app_api.Services(args.config[0])
+    else:
+        SERVICES = app_api.Services()
 
     if args.run[0] == 'OnBoot':
         on_boot(logger)

--- a/examples/python-mission-framework/python-mission-app.py
+++ b/examples/python-mission-framework/python-mission-app.py
@@ -4,8 +4,6 @@ import app_api
 import argparse
 import sys
 
-SERVICES = app_api.Services()
-
 def on_boot(logger):
     
     logger.info("OnBoot logic")
@@ -29,6 +27,8 @@ def main():
     if args.config is not None:
         global SERVICES
         SERVICES = app_api.Services(args.config[0])
+    else:
+        SERVICES = app_api.Services()
     
     if args.run[0] == 'OnBoot':
         on_boot(logger)


### PR DESCRIPTION
The monitor service relies on `/proc/meminfo` in order to query the system's available memory. OSX doesn't have this file, which means that the first mission app tutorial doesn't work for Mac users.

Tweaking the app to just do a `{ping}` query instead