### PR TITLE
Scheduler mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1846,7 +1846,7 @@ dependencies = [
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2329,7 +2329,11 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utils 0.1.0",
 ]
 
 [[package]]
@@ -2614,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3163,7 +3167,7 @@ name = "unicode-normalization"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3228,6 +3232,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "utils"
 version = "0.1.0"
 dependencies = [
+ "reqwest 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3590,7 +3596,7 @@ dependencies = [
 "checksum slog-extra 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "511581f4dd1dc90e4eca99b60be8a692d9c975e8757558aa774f16007d27492a"
 "checksum slog-stream 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3fac4af71007ddb7338f771e059a46051f18d1454d8ac556f234a0573e719daa"
 "checksum slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
-"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/services/scheduler-service/Cargo.toml
+++ b/services/scheduler-service/Cargo.toml
@@ -12,3 +12,9 @@ log = "^0.4.0"
 log4rs = "0.8"
 log4rs-syslog = "3.0"
 syslog = "4.0"
+
+[dev-dependencies]
+utils = { path = "../../utils" }
+tempfile = "3.0"
+reqwest = "0.9.9"
+serde_json = "1.0"

--- a/services/scheduler-service/src/main.rs
+++ b/services/scheduler-service/src/main.rs
@@ -22,6 +22,7 @@
 #[macro_use]
 extern crate juniper;
 
+mod objects;
 mod scheduler;
 mod schema;
 
@@ -80,11 +81,13 @@ fn main() {
         })
         .unwrap();
 
-    let scheduler_dir = config
-        .get("scheduler_dir")
-        .and_then(|s| s.try_into().ok())
-        .unwrap_or(DEFAULT_SCHEDULES_DIR);
-    let scheduler = Scheduler::new(scheduler_dir);
+    let scheduler_dir = if let Some(s_dir) = config.get("schedules_dir") {
+        String::from(s_dir.as_str().unwrap())
+    } else {
+        String::from(DEFAULT_SCHEDULES_DIR)
+    };
+
+    let scheduler = Scheduler::new(&scheduler_dir);
 
     info!("Starting scheduler-service - {:?}", scheduler_dir);
 

--- a/services/scheduler-service/src/objects.rs
+++ b/services/scheduler-service/src/objects.rs
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[derive(GraphQLObject)]
+pub struct GenericResponse {
+    pub success: bool,
+    pub errors: String,
+}
+
+#[derive(GraphQLObject)]
+pub struct Schedule {
+    pub contents: String,
+    pub path: String,
+    pub name: String,
+    pub time_registered: String,
+    pub active: bool,
+}

--- a/services/scheduler-service/src/scheduler.rs
+++ b/services/scheduler-service/src/scheduler.rs
@@ -41,7 +41,7 @@ impl Scheduler {
     }
 
     pub fn register_schedule(&self, path: &str, name: &str) -> Result<(), String> {
-        info!("Registering new schedule {}:{}", path, name);
+        info!("Registering new schedule '{}': {}", name, path);
         let schedule_dest = format!("{}/{}.json", self.scheduler_dir, name);
         fs::copy(path, schedule_dest).map_err(|e| format!("Schedule copy failed: {}", e))?;
         Ok(())
@@ -63,6 +63,18 @@ impl Scheduler {
 
         symlink(sched_path, active_path)
             .map_err(|e| format!("Failed to create active symlink: {}", e))?;
+        info!("Activated schedule {}", name);
+        Ok(())
+    }
+
+    pub fn remove_schedule(&self, name: &str) -> Result<(), String> {
+        info!("Removing schedule {}", name);
+        let sched_path = format!("{}/{}.json", self.scheduler_dir, name);
+
+        fs::remove_file(&sched_path)
+            .map_err(|e| format!("Failed to remove schedule {}.json: {}", name, e))?;
+
+        info!("Removed schedule {}", name);
         Ok(())
     }
 }

--- a/services/scheduler-service/src/schema.rs
+++ b/services/scheduler-service/src/schema.rs
@@ -18,7 +18,6 @@ use crate::objects::{GenericResponse, Schedule};
 use crate::scheduler::Scheduler;
 use juniper::FieldResult;
 use kubos_service;
-use log::info;
 
 type Context = kubos_service::Context<Scheduler>;
 
@@ -120,7 +119,23 @@ graphql_object!(MutationRoot: Context as "Mutation" |&self| {
     field activate(&executor, name: String) -> FieldResult<GenericResponse> {
         Ok(match executor.context().subsystem().activate_schedule(&name) {
             Ok(_) => {
-                info!("Activated schedule {}", name);
+                GenericResponse { success: true, errors: "".to_owned() }
+            },
+            Err(error) => GenericResponse { success: false, errors: error.to_string() }
+        })
+    }
+
+    // Removes a schedule
+    //
+    // mutation {
+    //     remove(name: String!): {
+    //         errors: String,
+    //         success: Boolean
+    //    }
+    // }
+    field remove(&executor, name: String) -> FieldResult<GenericResponse> {
+        Ok(match executor.context().subsystem().remove_schedule(&name) {
+            Ok(_) => {
                 GenericResponse { success: true, errors: "".to_owned() }
             },
             Err(error) => GenericResponse { success: false, errors: error.to_string() }

--- a/services/scheduler-service/tests/mutations.rs
+++ b/services/scheduler-service/tests/mutations.rs
@@ -1,0 +1,228 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+mod util;
+
+use serde_json::json;
+use tempfile::{NamedTempFile, TempDir};
+use util::{activate_schedule, register_schedule, spawn_scheduler};
+
+#[test]
+fn register_new_schedule() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8020;
+
+    let _scheduler_service = spawn_scheduler(
+        &graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let schedule = NamedTempFile::new().unwrap();
+    let schedule_path = schedule.path().to_str().unwrap();
+
+    let expected = json!({
+        "data" : {
+            "register": {
+                "errors": "",
+                "success": true
+            }
+        }
+    }
+    );
+
+    let response = register_schedule("operational", schedule_path, graphql_ip, graphql_port);
+
+    assert_eq!(expected, response);
+}
+
+#[test]
+fn register_new_schedule_nonexistant_file() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8021;
+
+    let _scheduler_service = spawn_scheduler(
+        &graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let expected = json!({
+            "data" : {
+                "register": {
+                    "errors": "Schedule copy failed: No such file or directory (os error 2)",
+                    "success": false
+                }
+            }
+        }
+    );
+    let response = register_schedule("operational", "", graphql_ip, graphql_port);
+
+    assert_eq!(expected, response);
+}
+
+#[test]
+fn register_duplicate_schedule() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8022;
+
+    let _scheduler_service = spawn_scheduler(
+        &graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let schedule_one = NamedTempFile::new().unwrap();
+    let schedule_one_path = schedule_one.path().to_str().unwrap();
+
+    let schedule_two = NamedTempFile::new().unwrap();
+    let schedule_two_path = schedule_two.path().to_str().unwrap();
+
+    let expected = json!({
+        "data" : {
+            "register": {
+                "errors": "",
+                "success": true
+            }
+        }
+    }
+    );
+
+    let response = register_schedule("operational", schedule_one_path, graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+
+    let response = register_schedule("operational", schedule_two_path, graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+}
+
+#[test]
+fn activate_existing_schedule() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8023;
+
+    let _scheduler_service = spawn_scheduler(
+        graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let schedule = NamedTempFile::new().unwrap();
+    let schedule_path = schedule.path().to_str().unwrap();
+
+    let expected = json!({
+            "data" : {
+                "register": {
+                    "errors": "",
+                    "success": true
+                }
+            }
+        }
+    );
+    let response = register_schedule("imaging", schedule_path, graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+
+    let expected = json!({
+        "data" : {
+            "activate": {
+                "errors": "",
+                "success": true
+            }
+        }
+    }
+    );
+    let response = activate_schedule("imaging", graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+}
+
+#[test]
+fn activate_non_existent_schedule() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8024;
+
+    let _scheduler_service = spawn_scheduler(
+        graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let expected = json!({
+            "data" : {
+                "activate": {
+                    "errors": "Schedule operational.json not found",
+                    "success": false
+                }
+            }
+        }
+    );
+    let response = activate_schedule("operational", graphql_ip, graphql_port);
+
+    assert_eq!(expected, response);
+}
+
+#[test]
+fn active_two_schedules() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8025;
+
+    let _scheduler_service = spawn_scheduler(
+        graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let schedule_one = NamedTempFile::new().unwrap();
+    let schedule_one_path = schedule_one.path().to_str().unwrap();
+
+    let schedule_two = NamedTempFile::new().unwrap();
+    let schedule_two_path = schedule_two.path().to_str().unwrap();
+
+    let expected = json!({
+            "data" : {
+                "register": {
+                    "errors": "",
+                    "success": true
+                }
+            }
+        }
+    );
+
+    let response = register_schedule("imaging", schedule_one_path, graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+
+    let response = register_schedule("operational", schedule_two_path, graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+
+    let expected = json!({
+        "data" : {
+            "activate": {
+                "errors": "",
+                "success": true
+            }
+        }
+    }
+    );
+    let response = activate_schedule("imaging", graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+
+    let response = activate_schedule("operational", graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+}

--- a/services/scheduler-service/tests/remove.rs
+++ b/services/scheduler-service/tests/remove.rs
@@ -1,0 +1,104 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+mod util;
+
+use serde_json::json;
+use tempfile::{NamedTempFile, TempDir};
+use util::{activate_schedule, register_schedule, remove_schedule, spawn_scheduler};
+
+#[test]
+fn remove_existing_schedule() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8020;
+
+    let _scheduler_service = spawn_scheduler(
+        &graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let schedule = NamedTempFile::new().unwrap();
+    let schedule_path = schedule.path().to_str().unwrap();
+
+    register_schedule("operational", schedule_path, graphql_ip, graphql_port);
+
+    let expected = json!({
+        "data": {
+            "remove": {
+                "errors": "",
+                "success": true
+            }
+        }
+    });
+    let response = remove_schedule("operational", graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+}
+
+#[test]
+fn remove_active_schedule() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8022;
+
+    let _scheduler_service = spawn_scheduler(
+        &graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let schedule = NamedTempFile::new().unwrap();
+    let schedule_path = schedule.path().to_str().unwrap();
+
+    register_schedule("operational", schedule_path, graphql_ip, graphql_port);
+    activate_schedule("operational", graphql_ip, graphql_port);
+
+    let expected = json!({
+        "data": {
+            "remove": {
+                "errors": "",
+                "success": true
+            }
+        }
+    });
+    let response = remove_schedule("operational", graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+}
+
+#[test]
+fn remove_nonexistant_schedule() {
+    let schedules_dir = TempDir::new().unwrap();
+    let graphql_ip = "127.0.0.1";
+    let graphql_port = 8021;
+
+    let _scheduler_service = spawn_scheduler(
+        &graphql_ip,
+        graphql_port,
+        schedules_dir.path().to_str().unwrap(),
+    );
+
+    let expected = json!({
+        "data": {
+            "remove": {
+                "errors": "Failed to remove schedule operational.json: No such file or directory (os error 2)",
+                "success": false
+            }
+        }
+    });
+    let response = remove_schedule("operational", graphql_ip, graphql_port);
+    assert_eq!(expected, response);
+}

--- a/services/scheduler-service/tests/util/mod.rs
+++ b/services/scheduler-service/tests/util/mod.rs
@@ -1,0 +1,56 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::thread;
+use std::time::Duration;
+use utils::testing::{service_query, TestService};
+
+pub fn spawn_scheduler(ip: &str, port: u16, schedules_dir: &str) -> TestService {
+    let config = format!(
+        r#"
+        [scheduler-service]
+        schedules_dir = "{}"
+        "#,
+        schedules_dir
+    );
+
+    let mut scheduler_service = TestService::new("scheduler-service", ip, port);
+    scheduler_service.config(&config);
+    scheduler_service.build();
+    scheduler_service.spawn();
+
+    thread::sleep(Duration::from_millis(1000));
+
+    scheduler_service
+}
+
+pub fn register_schedule(name: &str, path: &str, ip: &str, port: u16) -> serde_json::Value {
+    let mutation = format!(
+        r#"mutation {{ register(name: "{}", path: "{}") {{ errors, success }} }}"#,
+        name, path
+    );
+
+    service_query(&mutation, ip, port)
+}
+
+pub fn activate_schedule(name: &str, ip: &str, port: u16) -> serde_json::Value {
+    let mutation = format!(
+        r#"mutation {{ activate(name: "{}") {{ errors, success }} }}"#,
+        name
+    );
+
+    service_query(&mutation, ip, port)
+}

--- a/services/scheduler-service/tests/util/mod.rs
+++ b/services/scheduler-service/tests/util/mod.rs
@@ -54,3 +54,12 @@ pub fn activate_schedule(name: &str, ip: &str, port: u16) -> serde_json::Value {
 
     service_query(&mutation, ip, port)
 }
+
+pub fn remove_schedule(name: &str, ip: &str, port: u16) -> serde_json::Value {
+    let mutation = format!(
+        r#"mutation {{ remove(name: "{}") {{ errors, success }} }}"#,
+        name
+    );
+
+    service_query(&mutation, ip, port)
+}

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2018"
 
 [dependencies]
 tempfile = "3"
+reqwest = "0.9.9"
+serde_json = "1.0"


### PR DESCRIPTION
Adds implementations for the following mutations:
- `register` - Registering a new schedule
- `activate` - Activating an existing schedule