### PR TITLE
Adding ability to register app with custom config

### DIFF
--- a/docs/ecosystem/apps/app-guide.rst
+++ b/docs/ecosystem/apps/app-guide.rst
@@ -110,12 +110,17 @@ This file must have the following key values:
 - ``version`` - The version number of the application
 - ``author`` - The author of the application
 
-Optionally, the file may also specify the ``executable`` key value.
-This parameter allows you to specify which file should be called in order to begin execution of the
-application.
+Optionally, the file may also specify the following values:
+
+The ``executable`` key value allows you to specify which file should be called in order to begin
+execution of the application.
 If it's omitted, the value of ``name`` will be used.
 This is particularly useful for Python applications, where the name of the application might not
 match the name of the file to be called.
+
+The ``config`` key value allows you to specify a custom file which the application should use in
+order to read :doc:`service configuration <../services/service-config>` information.
+If it is omitted, the default location ``/home/system/etc/config.toml`` will be used.
 
 For example::
 
@@ -123,6 +128,7 @@ For example::
     executable = "app.py"
     version = "1.1"
     author = "Me"
+    config = "/custom/config.toml"
     
 Local Execution
 ---------------

--- a/docs/ecosystem/services/app-service.rst
+++ b/docs/ecosystem/services/app-service.rst
@@ -62,7 +62,8 @@ It has the following schema::
                     name: String!,
                     executable: String!,
                     version: String!,
-                    author: String!
+                    author: String!,
+                    config: String!
                 }
             ]
         }
@@ -86,6 +87,8 @@ Queries return the following fields:
       run for this application
     - ``version``: The particular version number of this application entry
     - ``author``: The creator/owner of this application entry
+    - ``config``: The :doc:`configuration file <service-config>` which will be passed to the
+      application when it is run
 
 
 An example query requesting the name, version number, and active status of all registered

--- a/services/app-service/src/app_entry.rs
+++ b/services/app-service/src/app_entry.rs
@@ -34,6 +34,8 @@ pub struct AppMetadata {
     pub version: String,
     /// The author of the application
     pub author: String,
+    /// The custom configuration file which should be passed to the application when it is started
+    pub config: Option<String>,
 }
 /// Kubos App struct
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -46,6 +48,8 @@ pub struct App {
     pub version: String,
     /// The author of the application
     pub author: String,
+    /// Configuration file to be passed to the application
+    pub config: String,
 }
 /// AppRegistryEntry
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/services/app-service/src/monitor.rs
+++ b/services/app-service/src/monitor.rs
@@ -30,7 +30,7 @@ pub struct MonitorEntry {
     pub pid: i32,
     pub run_level: String,
     pub args: Option<Vec<String>>,
-    pub config: Option<String>,
+    pub config: String,
 }
 
 pub fn monitor_app(

--- a/services/app-service/src/objects.rs
+++ b/services/app-service/src/objects.rs
@@ -76,6 +76,12 @@ graphql_object!(KApp: () as "App" where Scalar = <S> |&self| {
     {
         &self.0.executable
     }
+
+    field config() -> &String
+        as "Configuration File Path"
+    {
+        &self.0.config
+    }
 });
 
 pub struct KAppRegistryEntry(pub app_entry::AppRegistryEntry);

--- a/services/app-service/src/tests/register_app.rs
+++ b/services/app-service/src/tests/register_app.rs
@@ -51,6 +51,7 @@ fn register_good() {
                 active, 
                 app {{
                     author,
+                    config,
                     name,
                     version,
                 }}
@@ -68,6 +69,7 @@ fn register_good() {
               "active": true,
                "app": {
                    "author": "user",
+                   "config": "/home/system/etc/config.toml",
                    "name": "dummy",
                    "version": "0.0.1",
                }
@@ -149,6 +151,81 @@ fn register_good_exec() {
     let path = app["executable"].as_str().unwrap();
 
     assert!(path.ends_with("dummy/0.0.1/dummy2"));
+}
+
+#[test]
+fn register_good_config() {
+    let registry_dir = TempDir::new().unwrap();
+    let service = mock_service!(registry_dir);
+
+    let app_dir = TempDir::new().unwrap();
+    let app_bin = app_dir.path().join("dummy-app");
+
+    fs::create_dir(app_bin.clone()).unwrap();
+
+    // Create dummy app file
+    fs::File::create(app_bin.join("dummy2")).unwrap();
+
+    // Create manifest file
+    let manifest = r#"
+            name = "dummy"
+            executable = "dummy2"
+            version = "0.0.1"
+            author = "user"
+            config = "/custom/config.toml"
+            "#;
+    fs::write(app_bin.join("manifest.toml"), manifest).unwrap();
+
+    let register_query = format!(
+        r#"mutation {{
+        register(path: \"{}\") {{
+            entry {{
+                active, 
+                app {{
+                    author,
+                    name,
+                    version,
+                    executable,
+                    config
+                }}
+            }},
+            errors,
+            success,
+        }}
+    }}"#,
+        app_bin.to_str().unwrap()
+    );
+
+    // We have to manually check the results, rather than using the test! macro, because the
+    // path contains a dynamically created directory
+    let result: Vec<u8> = request!(service, register_query)
+        .body()
+        .iter()
+        .map(|entry| *entry)
+        .collect();
+    let result: serde_json::Value =
+        serde_json::from_str(::std::str::from_utf8(&result).unwrap()).unwrap();
+
+    let data = &result["data"]["register"];
+
+    assert_eq!(data["errors"], "");
+    assert_eq!(data["success"], true);
+
+    let entry = &data["entry"];
+
+    assert_eq!(entry["active"], true);
+
+    let app = &entry["app"];
+
+    assert_eq!(app["author"], "user");
+    assert_eq!(app["name"], "dummy");
+    assert_eq!(app["version"], "0.0.1");
+
+    let path = app["executable"].as_str().unwrap();
+
+    assert!(path.ends_with("dummy/0.0.1/dummy2"));
+
+    assert_eq!(app["config"], "/custom/config.toml");
 }
 
 #[test]

--- a/services/app-service/src/tests/registry_onboot.rs
+++ b/services/app-service/src/tests/registry_onboot.rs
@@ -168,6 +168,7 @@ fn registry_onboot_preexisting() {
                 name = "tiny-app"
                 version = "1.0"
                 author = "user"
+                config = "/custom/config.toml"
                 "#,
             registry_dir.path().to_string_lossy(),
         );

--- a/services/app-service/src/tests/registry_start_app.rs
+++ b/services/app-service/src/tests/registry_start_app.rs
@@ -59,6 +59,7 @@ fn start_app_good() {
                 name = "tiny-app"
                 version = "1.0"
                 author = "user"
+                config = "/custom/config.toml"
                 "#,
             registry_dir.path().to_string_lossy(),
         );
@@ -104,6 +105,7 @@ fn start_app_fail() {
                 name = "tiny-app"
                 version = "1.0"
                 author = "user"
+                config = "/custom/config.toml"
                 "#,
             registry_dir.path().to_string_lossy(),
         );
@@ -144,6 +146,7 @@ fn start_app_bad() {
             name = "tiny-app"
             version = "1.0"
             author = "user"
+            config = "/custom/config.toml"
             "#,
         registry_dir.path().to_string_lossy(),
     );
@@ -199,6 +202,7 @@ fn start_app_nonzero_rc() {
                 name = "tiny-app"
                 version = "1.0"
                 author = "user"
+                config = "/custom/config.toml"
                 "#,
             registry_dir.path().to_string_lossy(),
         );

--- a/services/app-service/src/tests/registry_test.rs
+++ b/services/app-service/src/tests/registry_test.rs
@@ -58,6 +58,7 @@ fn serialize_entry() {
             version: String::from("0.0.1"),
             author: String::from("noone"),
             executable: String::from("/fake/path"),
+            config: String::from("/home/system/etc/config.toml"),
         },
         active_version: true,
     };

--- a/services/app-service/tests/test_apps.rs
+++ b/services/app-service/tests/test_apps.rs
@@ -33,6 +33,7 @@ fn setup_apps(registry_dir: &Path) {
     MockAppBuilder::new("app1")
         .version("0.0.2")
         .active(false)
+        .config("/custom/config.toml")
         .install(&registry_dir);
     MockAppBuilder::new("app2")
         .version("1.0.0")
@@ -244,6 +245,22 @@ test_query!(
         assert_eq!(
             apps[2],
             json!({"app": {"name": "app2", "version": "1.0.0"}})
+        );
+    }
+);
+
+test_query!(
+    config,
+    "{ registeredApps(name: \"app1\") { app { name, version, config } } }",
+    |apps| {
+        assert_eq!(apps.len(), 2);
+        assert_eq!(
+            apps[0],
+            json!({"app": {"name": "app1", "version": "0.0.1", "config": "/home/system/etc/config.toml"}})
+        );
+        assert_eq!(
+            apps[1],
+            json!({"app": {"name": "app1", "version": "0.0.2", "config": "/custom/config.toml"}})
         );
     }
 );

--- a/services/app-service/tests/test_monitor.rs
+++ b/services/app-service/tests/test_monitor.rs
@@ -67,6 +67,7 @@ fn setup_app(registry_dir: &Path) {
             name = "rust-proj"
             version = "1.0"
             author = "user"
+            config = "/home/system/etc/config.toml"
             "#,
         registry_dir.to_string_lossy(),
     );
@@ -137,8 +138,10 @@ fn monitor_good() {
     );
     assert_eq!(result["runningApps"][0]["version"].as_str().unwrap(), "1.0");
     assert_eq!(result["runningApps"][0]["pid"].as_i64().unwrap(), pid);
-    // No custom config was given, so this should be empty
-    assert_eq!(result["runningApps"][0]["config"].as_str(), None);
+    assert_eq!(
+        result["runningApps"][0]["config"].as_str().unwrap(),
+        "/home/system/etc/config.toml"
+    );
     assert_eq!(args, ["--", "-l"]);
     assert_eq!(
         result["runningApps"][0]["runLevel"].as_str().unwrap(),

--- a/services/app-service/tests/test_python_app.rs
+++ b/services/app-service/tests/test_python_app.rs
@@ -61,6 +61,7 @@ fn setup_app(registry_dir: &Path) {
             name = "python-proj"
             version = "1.0"
             author = "user"
+            config = "/home/system/etc/config.toml"
             "#,
         registry_dir.to_string_lossy(),
     );

--- a/services/app-service/tests/test_rust_app.rs
+++ b/services/app-service/tests/test_rust_app.rs
@@ -65,6 +65,7 @@ fn setup_app(registry_dir: &Path) {
             name = "rust-proj"
             version = "1.0"
             author = "user"
+            config = "/home/system/etc/config.toml"
             "#,
         registry_dir.to_string_lossy(),
     );

--- a/services/app-service/tests/utils/mod.rs
+++ b/services/app-service/tests/utils/mod.rs
@@ -34,6 +34,7 @@ pub struct MockAppBuilder {
     _author: Option<String>,
     _active: Option<bool>,
     _run_level: Option<String>,
+    _config: Option<String>,
 }
 
 impl MockAppBuilder {
@@ -45,6 +46,7 @@ impl MockAppBuilder {
             _author: None,
             _active: None,
             _run_level: None,
+            _config: None,
         }
     }
 
@@ -73,6 +75,11 @@ impl MockAppBuilder {
         self
     }
 
+    pub fn config<'a>(&'a mut self, config: &str) -> &'a mut Self {
+        self._config = Some(String::from(config));
+        self
+    }
+
     pub fn toml(&self, registry_dir: &str) -> String {
         format!(
             r#"
@@ -84,6 +91,7 @@ impl MockAppBuilder {
             name = "{name}"
             version = "{version}"
             author = "{author}"
+            config = "{config}"
             "#,
             name = self._name,
             dir = registry_dir,
@@ -92,6 +100,10 @@ impl MockAppBuilder {
             version = self._version.as_ref().unwrap_or(&String::from("0.0.1")),
             author = self._author.as_ref().unwrap_or(&String::from("unknown")),
             bin = self._bin.as_ref().unwrap_or(&self._name),
+            config = self
+                ._config
+                .as_ref()
+                .unwrap_or(&String::from("/home/system/etc/config.toml")),
         )
     }
 


### PR DESCRIPTION
We previously added the ability for apps to be started via the `startApp` mutation with a custom config. This PR expands that so that a custom config can be defined as the default for a particular app, that way that config file will be used when that app's OnBoot logic is called during the app service's initialization.