### PR TITLE
Allow bulk telemetry over UDP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde-value"

--- a/docs/ecosystem/linux-docs/logging.rst
+++ b/docs/ecosystem/linux-docs/logging.rst
@@ -48,6 +48,8 @@ For each of these naming schemes, the following files may be created:
 - ``*-info.log`` - Records log messages with a priority of ``info`` or higher
 - ``*-warn.log`` - Records log messages with a priority of ``warn`` or higher
 
+On the SDK, logs can be found in ``/var/log/syslog``.
+
 .. _log-rotation:
 
 Log Rotation

--- a/docs/ecosystem/services/telemetry-db.rst
+++ b/docs/ecosystem/services/telemetry-db.rst
@@ -213,7 +213,7 @@ This UDP port is configured with the ``direct_port`` value in the system's ``con
 
 Insert requests should be sent as individual UDP messages in JSON format.
 
-The requests have the following schema::
+Individual requests have the following schema::
 
     {
         "timestamp": Float,
@@ -231,6 +231,18 @@ For example::
         "parameter": "voltage",
         "value": "3.5"
     }
+
+Bulk inserts are also supported, with or without timestamps, as long as they fit in a UDP packet::
+
+  [
+      {
+          "timestamp": Float,
+          "subsystem": String!,
+          "parameter": String!,
+          "value": String!,
+      },
+      ...
+  ]
 
 Limitations
 ~~~~~~~~~~~

--- a/docs/ecosystem/services/telemetry-db.rst
+++ b/docs/ecosystem/services/telemetry-db.rst
@@ -211,7 +211,7 @@ If you would like to add many entries to the database quickly, and don't care ab
 was successful, the service's direct UDP port may be used.
 This UDP port is configured with the ``direct_port`` value in the system's ``config.toml`` file.
 
-Insert requests should be sent as individual UDP messages in JSON format.
+Individual or bulk insert requests should be sent as single UDP messages in JSON format.
 
 Individual requests have the following schema::
 
@@ -232,7 +232,8 @@ For example::
         "value": "3.5"
     }
 
-Bulk inserts are also supported, with or without timestamps, as long as they fit in a UDP packet::
+If the top-level is a JSON array, the request is a bulk insert. Timestamps are again optional. Be sure to verify that the JSON
+message will fit in a single UDP packet. (The default UDP payload size limit is 4096 bytes.) Here is a bulk insert example::
 
   [
       {

--- a/services/telemetry-service/Cargo.toml
+++ b/services/telemetry-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "telemetry-service"
 version = "0.1.0"
-authors = ["Ryan Plauche <ryan@kubos.co>"]
+authors = ["Ryan Plauche <ryan@kubos.co>", "Andrew Cantino <andrew@kubos.co>"]
 edition = "2018"
 
 [dependencies]
@@ -11,7 +11,7 @@ juniper =  "0.11"
 kubos-service = { path = "../kubos-service" }
 kubos-telemetry-db = { path = "../../apis/telemetry-db-api" }
 log = "^0.4.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 syslog = "4.0"

--- a/services/telemetry-service/tests/test_udp.rs
+++ b/services/telemetry-service/tests/test_udp.rs
@@ -157,3 +157,119 @@ fn test_udp_no_timestamp() {
         })
     );
 }
+
+#[test]
+fn test_udp_bulk_timestamp() {
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("test.db");
+
+    let db = db_path.to_str().unwrap();
+    let port = 8113;
+    let udp = 8123;
+
+    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    let service = format!("0.0.0.0:{}", udp);
+
+    let entries = json!([{
+            "timestamp": 1000,
+            "subsystem": "eps",
+            "parameter": "voltage",
+            "value": "3.3"
+    }, {
+            "timestamp": 1001,
+            "subsystem": "eps",
+            "parameter": "voltage",
+            "value": "3.4"
+    }, {
+            "timestamp": 1002,
+            "subsystem": "eps",
+            "parameter": "voltage",
+            "value": "3.2"
+    }]);
+
+    socket
+        .send_to(&ser::to_vec(&entries).unwrap(), &service)
+        .unwrap();
+
+    // Give the service time to process the messages, since we're not actually waiting
+    // for a response
+    ::std::thread::sleep(Duration::from_secs(1));
+
+    let res = do_query(
+        Some(port),
+        "{telemetry{timestamp,subsystem,parameter,value}}",
+    );
+    teardown(handle, sender);
+    assert_eq!(
+        res,
+        json!({
+            "data": {
+                "telemetry":[
+                    {"timestamp":1002.0,"subsystem":"eps","parameter":"voltage","value":"3.2"},
+                    {"timestamp":1001.0,"subsystem":"eps","parameter":"voltage","value":"3.4"},
+                    {"timestamp":1000.0,"subsystem":"eps","parameter":"voltage","value":"3.3"},
+                ]
+            }
+        })
+    );
+}
+
+#[test]
+fn test_udp_bulk_no_timestamp() {
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("test.db");
+
+    let db = db_path.to_str().unwrap();
+
+    let port = 8114;
+    let udp = 8124;
+
+    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    let service = format!("0.0.0.0:{}", udp);
+
+    let entries = json!([{
+            "subsystem": "test1",
+            "parameter": "current",
+            "value": "2.0"
+    }, {
+            "subsystem": "test2",
+            "parameter": "current",
+            "value": "2.3"
+    }, {
+            "subsystem": "test3",
+            "parameter": "current",
+            "value": "2.1"
+    }, {
+            "subsystem": "test4",
+            "parameter": "current",
+            "value": "2.2"
+    }]);
+
+    socket
+        .send_to(&ser::to_vec(&entries).unwrap(), &service)
+        .unwrap();
+
+    // Give the service time to process the messages, since we're not actually waiting
+    // for a response
+    ::std::thread::sleep(Duration::from_secs(1));
+
+    let res = do_query(Some(port), "{telemetry{subsystem,parameter,value}}");
+    teardown(handle, sender);
+    assert_eq!(
+        res,
+        json!({
+            "data": {
+                "telemetry":[
+                    {"subsystem":"test4","parameter":"current","value":"2.2"},
+                    {"subsystem":"test3","parameter":"current","value":"2.1"},
+                    {"subsystem":"test2","parameter":"current","value":"2.3"},
+                    {"subsystem":"test1","parameter":"current","value":"2.0"},
+                ]
+            }
+        })
+    );
+}


### PR DESCRIPTION
If telemetry entries come wrapped in an array over UDP, they are all imported.

What's the best way to write a test that asserts error logs?