### PR TITLE
Service logging fix + app service OnBoot fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,6 @@ name = "kubos-system"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/apis/system-api/Cargo.toml
+++ b/apis/system-api/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1.2"
-getopts = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.4"

--- a/apis/system-api/src/config.rs
+++ b/apis/system-api/src/config.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 use failure::{bail, Error};
-use getopts::Options;
 use serde_derive::Deserialize;
 use std::env;
 use std::fs::File;
@@ -83,7 +82,7 @@ impl Config {
     /// # Arguments
     /// `name` - Category name used as a key in the config file
     pub fn new(name: &str) -> Result<Self, Error> {
-        Self::new_from_path(name, get_config_path())
+        Self::new_from_path(name, get_config_path()?)
     }
 
     /// Creates and parses configuration data from the passed in configuration
@@ -144,26 +143,28 @@ impl Config {
     }
 }
 
-fn get_config_path() -> String {
-    let args: Vec<String> = env::args().collect();
+fn get_config_path() -> Result<String, Error> {
+    // Manually check for a "-c {config-path}" command line argument specifying a custom config
+    // file path to use.
+    // Doing it this way so that entities which use this module (apps, services) can have any
+    // number of additional command arguments
+    let mut args = env::args();
 
-    let mut opts = Options::new();
-    opts.optopt("c", "config", "Path to config file", "CONFIG");
-    // This library can be used by applications, which have this additional run level arg which
-    // can be specified
-    opts.optopt(
-        "r",
-        "run",
-        "Run level which should be executed",
-        "RUN_LEVEL",
-    );
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => panic!(f.to_string()),
-    };
-    match matches.opt_str("c") {
-        Some(s) => s,
-        None => DEFAULT_PATH.to_string(),
+    let config_arg_pos = args
+        .position(|arg| arg == "-c")
+        .and_then(|pos| Some(pos + 1));
+
+    if let Some(pos) = config_arg_pos {
+        let mut args_vec: Vec<String> = args.collect();
+        if pos < args_vec.len() {
+            let config_arg = args_vec.remove(pos);
+            return Ok(config_arg);
+        } else {
+            bail!("The '-c' arg was specified, but no path value was provided");
+        }
+    } else {
+        // The "-c" arg wasn't specified, so we can go ahead with the default
+        return Ok(DEFAULT_PATH.to_string());
     }
 }
 

--- a/apis/system-api/src/config.rs
+++ b/apis/system-api/src/config.rs
@@ -150,17 +150,14 @@ fn get_config_path() -> Result<String, Error> {
     // number of additional command arguments
     let mut args = env::args();
 
-    let config_arg_pos = args
-        .position(|arg| arg == "-c")
-        .and_then(|pos| Some(pos + 1));
+    // Navigate to the "-c" option
+    let config_arg_pos = args.position(|arg| arg == "-c");
 
-    if let Some(pos) = config_arg_pos {
-        let mut args_vec: Vec<String> = args.collect();
-        if pos < args_vec.len() {
-            let config_arg = args_vec.remove(pos);
-            return Ok(config_arg);
-        } else {
-            bail!("The '-c' arg was specified, but no path value was provided");
+    if let Some(_pos) = config_arg_pos {
+        // The config path will be the arg immediately after "-c"
+        match args.next() {
+            Some(path) => Ok(path),
+            None => bail!("The '-c' arg was specified, but no path value was provided"),
         }
     } else {
         // The "-c" arg wasn't specified, so we can go ahead with the default

--- a/services/app-service/src/main.rs
+++ b/services/app-service/src/main.rs
@@ -46,6 +46,7 @@ fn main() -> Result<(), Error> {
     let mut opts = Options::new();
 
     opts.optflag("b", "onboot", "Execute OnBoot logic");
+    // This will be parsed by the system API crate during Config::new()
     opts.optopt("c", "config", "Path to config file", "CONFIG");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -54,16 +55,10 @@ fn main() -> Result<(), Error> {
         }
     };
 
-    let config = match matches.opt_str("c") {
-        Some(file) => Config::new_from_path("app-service", file.clone()).map_err(|err| {
-            error!("Failed to load service config from {}: {:?}", file, err);
-            err
-        })?,
-        None => Config::new("app-service").map_err(|err| {
-            error!("Failed to load default service config: {:?}", err);
-            err
-        })?,
-    };
+    let config = Config::new("app-service").map_err(|err| {
+        error!("Failed to load service config: {:?}", err);
+        err
+    })?;
 
     let registry = {
         match config.get("registry-dir") {

--- a/services/clyde-3g-eps-service/src/main.rs
+++ b/services/clyde-3g-eps-service/src/main.rs
@@ -433,14 +433,14 @@ fn main() {
         .unwrap();
     let bus = config
         .get("bus")
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to load 'bus' config value");
             "Failed to load 'bus' config value"
         })
         .unwrap();
     let bus = bus
         .as_str()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to parse 'bus' config value");
             "Failed to parse 'bus' config value"
         })

--- a/services/isis-ants-service/src/main.rs
+++ b/services/isis-ants-service/src/main.rs
@@ -383,7 +383,7 @@ fn main() -> AntSResult<()> {
 
     let bus = config
         .get("bus")
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to load 'bus' config value");
             format_err!("Failed to load 'bus' config value")
         })
@@ -392,7 +392,7 @@ fn main() -> AntSResult<()> {
 
     let primary = config
         .get("primary")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'primary' value found in 'isis-ants-service' section of config");
             format_err!("No 'primary' value found in 'isis-ants-service' section of config")
         })
@@ -406,7 +406,7 @@ fn main() -> AntSResult<()> {
 
     let secondary = config
         .get("secondary")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'secondary' value found in 'isis-ants-service' section of config");
             format_err!("No 'secondary' value found in 'isis-ants-service' section of config")
         })
@@ -420,7 +420,7 @@ fn main() -> AntSResult<()> {
 
     let antennas = config
         .get("antennas")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'antennas' value found in 'isis-ants-service' section of config");
             format_err!("No 'antennas' value found in 'isis-ants-service' section of config")
         })
@@ -429,7 +429,7 @@ fn main() -> AntSResult<()> {
 
     let wd_timeout = config
         .get("wd_timeout")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'wd_timeout' value found in 'isis-ants-service' section of config");
             format_err!("No 'wd_timeout' value found in 'isis-ants-service' section of config")
         })

--- a/services/kubos-service/src/service.rs
+++ b/services/kubos-service/src/service.rs
@@ -163,7 +163,7 @@ impl Service {
         let hosturl = self
             .config
             .hosturl()
-            .ok_or({
+            .ok_or_else(|| {
                 log::error!("Failed to load service URL");
                 "Failed to load service URL"
             })

--- a/services/local-comms-service/src/main.rs
+++ b/services/local-comms-service/src/main.rs
@@ -94,13 +94,13 @@ fn main() -> LocalCommsServiceResult<()> {
 
     let gateway_ip = service_config
         .get("gateway_ip")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'gateway_ip' parameter in config");
             "No 'gateway_ip' parameter in config"
         })
         .unwrap()
         .as_str()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to parse 'gateway_ip' config value");
             "Failed to parse 'gateway_ip' config value"
         })
@@ -109,13 +109,13 @@ fn main() -> LocalCommsServiceResult<()> {
 
     let gateway_port = service_config
         .get("gateway_port")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'gateway_port' parameter in config");
             "No 'gateway_port' parameter in config"
         })
         .unwrap()
         .as_integer()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to parse 'gateway_port' config value");
             "Failed to parse 'gateway_port' config value"
         })
@@ -123,13 +123,13 @@ fn main() -> LocalCommsServiceResult<()> {
 
     let listening_ip = service_config
         .get("listening_ip")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'listening_ip' parameter in config");
             "No 'listening_ip' parameter in config"
         })
         .unwrap()
         .as_str()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to parse 'listening_ip' config value");
             "Failed to parse 'listening_ip' config value"
         })
@@ -138,13 +138,13 @@ fn main() -> LocalCommsServiceResult<()> {
 
     let listening_port = service_config
         .get("listening_port")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'listening_port' parameter in config");
             "No 'listening_port' parameter in config"
         })
         .unwrap()
         .as_integer()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to parse 'listening_port' config value");
             "Failed to parse 'listening_port' config value"
         })

--- a/services/novatel-oem6-service/src/main.rs
+++ b/services/novatel-oem6-service/src/main.rs
@@ -349,14 +349,14 @@ fn main() -> OEMResult<()> {
         .unwrap();
     let bus = config
         .get("bus")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No 'bus' value found in 'novatel-oem6-service' section of config");
             "No 'bus' value found in 'novatel-oem6-service' section of config"
         })
         .unwrap();
     let bus = bus
         .as_str()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to parse 'bus' config value");
             "Failed to parse 'bus' config value"
         })

--- a/services/nsl-duplex-d2-comms-service/src/main.rs
+++ b/services/nsl-duplex-d2-comms-service/src/main.rs
@@ -252,13 +252,13 @@ fn main() -> NslDuplexCommsResult<()> {
 
     let bus = service_config
         .get("bus")
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to load 'bus' config value");
             "Failed to load 'bus' config value"
         })
         .unwrap()
         .as_str()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to parse 'bus' config value");
             "Failed to parse 'bus' config value"
         })

--- a/services/shell-service/src/main.rs
+++ b/services/shell-service/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
 
     let hosturl = config
         .hosturl()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to load service URL");
             failure::format_err!("Failed to load service URL")
         })

--- a/services/telemetry-service/src/main.rs
+++ b/services/telemetry-service/src/main.rs
@@ -231,14 +231,14 @@ fn main() {
 
     let db_path = config
         .get("database")
-        .ok_or({
+        .ok_or_else(|| {
             error!("No database path found in config file");
             "No database path found in config file"
         })
         .unwrap();
     let db_path = db_path
         .as_str()
-        .ok_or({
+        .ok_or_else(|| {
             error!("Failed to parse 'database' config value");
             "Failed to parse 'database' config value"
         })
@@ -250,7 +250,7 @@ fn main() {
     let direct_udp = config.get("direct_port").map(|port| {
         let host = config
             .hosturl()
-            .ok_or({
+            .ok_or_else(|| {
                 error!("Failed to load service URL");
                 "Failed to load service URL"
             })
@@ -258,7 +258,7 @@ fn main() {
         let mut host_parts = host.split(':').map(|val| val.to_owned());
         let host_ip = host_parts
             .next()
-            .ok_or({
+            .ok_or_else(|| {
                 error!("Failed to parse service IP address");
                 "Failed to parse service IP address"
             })


### PR DESCRIPTION
This PR fixes two bugs which slipped through the cracks of our CI tests:

- When the services start up, they attempt to read various config options. There is currently `ok_or()` logic to log an error message and then exit the service. `ok_or()` is "eagerly evaluated" by the Rust compiler, so the error message ends up _always_ getting logged, even if the config fetch succeeded.
  - Migrating to `ok_or_else` instead to avoid this problem
  - Problem wasn't caught by CI because we don't verify logging
- Our config parsing logic currently uses `getopts` to parse the command line options and look for the `-c {config.toml}` argument. Now that config parsing no longer silently fails and takes defaults, the init system is failing to start the app service. It tries to call `kubos-app-service -b` to trigger the OnBoot logic. The `-b` option isn't recognized by the config parser, so everything crashes
  - Updating `get_config_path` to manually look for the `-c` option, rather than by using `getopts`, so that way we can ignore any unknown arguments (under the assumption that they will be parsed by whatever entity is trying to parse a config file)
  - Updating the way the app service fetches its config file so that it a) matches all the other services and b) causes the unit test to correctly fail with the old `get_config_path` logic