### PR TITLE
Improving Getting Started workflow

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -61,11 +61,6 @@ Using C
 If you would like to develop in C, we highly recommend you :doc:`install the SDK <../sdk-docs/sdk-installing>`
 and then refer to :doc:`../sdk-docs/sdk-c`.
 
-Running Services
-~~~~~~~~~~~~~~~~
-
-The KubOS core services provide the base functionality that all KubOS systems rely on and interact with. The :doc:`local services guide <local-services>` will help you get the core services up and running in your development environment.
-
 Learn more about KubOS
 ----------------------
 
@@ -95,6 +90,9 @@ Services
 Interested in learning more about the services which make KubOS go? Check out the :doc:`core services guide <../ecosystem/services/core-services>`.
 
 Ready to begin developing your own service? Check out the :doc:`service development guide <../ecosystem/services/service-dev>`.
+
+The KubOS core services provide the base functionality that all KubOS systems rely on and interact with.
+The :doc:`local services guide <local-services>` will help you get the core services up and running in your development environment.
 
 Something Missing?
 ------------------

--- a/docs/getting-started/local-services.rst
+++ b/docs/getting-started/local-services.rst
@@ -6,8 +6,8 @@ services locally. All of the KubOS core services are capable of being run within
 your local development environment. This will allow you to get up and running with
 KubOS before you have an OBC in hand.
 
-A prerequisite for following this document is having your 
-:doc:`local environment setup <local-setup>` and having a copy of the 
+A prerequisite for following this document is having your
+:doc:`local environment setup <local-setup>` and having a copy of the
 `KubOS repo <https://github.com/kubos/kubos>`__ cloned locally.
 
 Configuring Services
@@ -21,7 +21,7 @@ will exist, so we will need to create a custom config file and then
 manually pass it to the service.
 
 This central configuration file is in the ``toml`` format and contains a section
-for each service. Here is a `default config <https://github.com/kubos/kubos/blob/master/tools/default_config.toml>`__  
+for each service. Here is a `default config <https://github.com/kubos/kubos/blob/master/tools/default_config.toml>`__
 you can use when running the core services. It can be found at ``tools/default_config.toml``
 in the Kubos repo folder.
 
@@ -31,7 +31,7 @@ for the service will go in a section named after the service::
     [service-name]
     config_option = "value"
 
-Any service which exposes a GraphQL interface will have a separate section for 
+Any service which exposes a GraphQL interface will have a separate section for
 configuring the GraphQL server::
 
     [service-name.addr]

--- a/docs/getting-started/local-setup.rst
+++ b/docs/getting-started/local-setup.rst
@@ -46,3 +46,14 @@ After installing all of these dependencies, we suggest running the following scr
 from the base of the kubos repo to verify everything is installed correctly and working::
 
     $ ./tools/kubos_verify.sh
+
+Next Steps
+----------
+
+Now that your environment is set up, you can get started developing your first KubOS project.
+
+We recommend that you look at the following documents next:
+
+- :doc:`using-python`
+- :doc:`using-rust`
+- :doc:`../tutorials/index`

--- a/docs/getting-started/windows-setup.rst
+++ b/docs/getting-started/windows-setup.rst
@@ -123,5 +123,4 @@ We recommend that you look at the following documents next:
 
 - :doc:`using-python`
 - :doc:`using-rust`
-- :doc:`local-services`
 - :doc:`../tutorials/index`


### PR DESCRIPTION
- Adding a "Next Steps" section to the local dev setup guide (all other docs already have one)
- Moving the "Running Services Locally" links to be mentioned later on in the Getting Started list. We'd like the users to go look at our tutorials first