### PR TITLE
Scheduler tokio + general refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,6 +2326,7 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/services/scheduler-service/Cargo.toml
+++ b/services/scheduler-service/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"]}
 syslog = "4.0"
 tokio = "0.1"
+futures = "*"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/services/scheduler-service/src/config.rs
+++ b/services/scheduler-service/src/config.rs
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//!
+//! Definitions and parsing instructions for Schedule Configurations
+//!
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::Duration;
+
+// Configuration used for execution of an app
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ScheduleApp {
+    pub name: String,
+    pub args: Option<Vec<String>>,
+    pub config: Option<String>,
+    pub run_level: Option<String>,
+}
+
+// Configuration used to schedule app execution
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ScheduleTask {
+    // Start delay specified in HH:mm:ss format
+    // Used by init and recurring tasks
+    pub delay: Option<String>,
+    // Details of the app to be executed
+    pub app: ScheduleApp,
+}
+
+impl ScheduleTask {
+    // Parse delay duration from delay field
+    pub fn get_duration(&self) -> Result<Duration, String> {
+        if let Some(delay) = &self.delay {
+            let mut task_delay: Vec<&str> = delay.split(':').collect();
+            let delay_s: u64 = task_delay.pop().unwrap_or("").parse().unwrap_or(0);
+            let delay_m: u64 = task_delay.pop().unwrap_or("").parse().unwrap_or(0) * 60;
+            let delay_h: u64 = task_delay.pop().unwrap_or("").parse().unwrap_or(0) * 3600;
+            Ok(Duration::from_secs(delay_s + delay_m + delay_h))
+        } else {
+            Err("No delay defined for task".to_owned())
+        }
+    }
+}
+
+// Schedule configuration information - the guts of the actual schedule
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ScheduleConfig {
+    pub init: Option<HashMap<String, ScheduleTask>>,
+    pub one_time: Option<HashMap<String, ScheduleTask>>,
+}

--- a/services/scheduler-service/src/file.rs
+++ b/services/scheduler-service/src/file.rs
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2019 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//!
+//! Definitions and functions concerning the manipulation of schedule files
+//!
+
+use chrono::{DateTime, Utc};
+use log::{info, warn};
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+// Descriptive information about a Schedule File
+#[derive(Debug, GraphQLObject)]
+pub struct ScheduleFile {
+    pub contents: String,
+    pub path: String,
+    pub name: String,
+    pub time_registered: String,
+    pub active: bool,
+}
+
+impl ScheduleFile {
+    pub fn from_path(path_obj: &Path) -> Result<ScheduleFile, String> {
+        let path = path_obj
+            .to_str()
+            .map(|path| path.to_owned())
+            .ok_or_else(|| "Failed to convert path".to_owned())?;
+
+        let data = path_obj
+            .metadata()
+            .map_err(|e| format!("Failed to read file metadata: {}", e))?;
+
+        let time_registered: DateTime<Utc> = data
+            .modified()
+            .map_err(|e| format!("Failed to get modified time: {}", e))?
+            .into();
+        let time_registered = time_registered.format("%Y-%m-%d %H:%M:%S").to_string();
+
+        let name = path_obj
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| "Failed to read schedule name".to_owned())?
+            .to_owned();
+
+        let contents = fs::read_to_string(&path_obj)
+            .map_err(|e| format!("Failed to read schedule contents: {}", e))?;
+
+        Ok(ScheduleFile {
+            path,
+            name,
+            contents,
+            time_registered,
+            active: false,
+        })
+    }
+}
+
+// Copy a new schedule file into the schedules directory
+pub fn import_schedule(scheduler_dir: &str, path: &str, name: &str) -> Result<(), String> {
+    info!("Importing new schedule '{}': {}", name, path);
+    let schedule_dest = format!("{}/{}.json", scheduler_dir, name);
+    fs::copy(path, schedule_dest).map_err(|e| format!("Schedule copy failed: {}", e))?;
+    Ok(())
+}
+
+// Make an existing schedule file the active schedule file
+// TODO: Should this kill the schedule and rerun scheduler.start()?
+// TODO: What if this is the active schedule?? What would happen?
+pub fn activate_schedule(scheduler_dir: &str, name: &str) -> Result<(), String> {
+    info!("Activating schedule {}", name);
+    let sched_path = format!("{}/{}.json", scheduler_dir, name);
+    let active_path = format!("{}/active.json", scheduler_dir);
+    let new_active_path = format!("{}/new_active.json", scheduler_dir);
+
+    if !Path::new(&sched_path).is_file() {
+        return Err(format!("Schedule {}.json not found", name));
+    }
+    symlink(sched_path, &new_active_path)
+        .map_err(|e| format!("Failed to create active symlink: {}", e))?;
+
+    fs::rename(&new_active_path, &active_path)
+        .map_err(|e| format!("Failed to copy over new active symlink: {}", e))?;
+
+    info!("Activated schedule {}", name);
+    Ok(())
+}
+
+// Remove an existing schedule file from the schedules directory
+// TODO: What happens if this is the active schedule?
+pub fn remove_schedule(scheduler_dir: &str, name: &str) -> Result<(), String> {
+    info!("Removing schedule {}", name);
+    let sched_path = format!("{}/{}.json", scheduler_dir, name);
+
+    fs::remove_file(&sched_path)
+        .map_err(|e| format!("Failed to remove schedule {}.json: {}", name, e))?;
+
+    info!("Removed schedule {}", name);
+    Ok(())
+}
+
+// Retrieve information on the active schedule file
+pub fn get_active_schedule(scheduler_dir: &str) -> Option<ScheduleFile> {
+    let active_path = fs::read_link(format!("{}/active.json", scheduler_dir)).ok()?;
+
+    match ScheduleFile::from_path(&active_path) {
+        Ok(mut s) => {
+            s.active = true;
+            Some(s)
+        }
+        Err(e) => {
+            warn!("Failed to parse active schedule: {}", e);
+            None
+        }
+    }
+}
+
+// Retrieve information on all schedule files in the schedules directory
+pub fn get_available_schedules(
+    scheduler_dir: &str,
+    name: Option<String>,
+) -> Result<Vec<ScheduleFile>, String> {
+    let mut schedules: Vec<ScheduleFile> = vec![];
+
+    let active_path: Option<PathBuf> = fs::read_link(format!("{}/active.json", scheduler_dir)).ok();
+
+    for path in fs::read_dir(scheduler_dir)
+        .map_err(|e| format!("Failed to read schedules dir: {}", e))?
+        // Filter out invalid entries
+        .filter_map(|x| x.ok())
+        // Convert DirEntry -> PathBuf
+        .map(|entry| entry.path())
+        // Filter out non-files
+        .filter(|entry| entry.is_file())
+        // Filter out active.json
+        .filter(|path| !path.ends_with("active.json"))
+        // Filter on name if specified
+        .filter(|path| {
+            if let Some(name_str) = &name {
+                path.ends_with(format!("{}.json", name_str))
+            } else {
+                true
+            }
+        })
+    {
+        let active = if let Some(active_sched) = active_path.clone() {
+            active_sched == path
+        } else {
+            false
+        };
+
+        match ScheduleFile::from_path(&path) {
+            Ok(mut sched) => {
+                sched.active = active;
+                schedules.push(sched);
+            }
+            Err(e) => warn!("Error loading schedule: {}", e),
+        }
+    }
+
+    Ok(schedules)
+}

--- a/services/scheduler-service/src/main.rs
+++ b/services/scheduler-service/src/main.rs
@@ -16,16 +16,16 @@
 
 //! Service for scheduling tasks in the KubOS system.
 
-#![deny(warnings)]
-#![deny(missing_docs)]
+// #![deny(warnings)]
+// #![deny(missing_docs)]
 
 #[macro_use]
 extern crate juniper;
 
-mod objects;
+mod config;
+mod file;
 mod scheduler;
 mod schema;
-mod util;
 
 use kubos_service::{Config, Service};
 use log::{error, info};
@@ -85,7 +85,7 @@ fn main() -> Result<(), String> {
         String::from(
             s_dir
                 .as_str()
-                .ok_or_else(|| format!("Error parsing scheduler dir path"))?,
+                .ok_or_else(|| "Error parsing scheduler dir path".to_owned())?,
         )
     } else {
         String::from(DEFAULT_SCHEDULES_DIR)
@@ -96,7 +96,7 @@ fn main() -> Result<(), String> {
     info!("Starting scheduler-service - {:?}", scheduler_dir);
 
     // For now we will only kick off scheduling when the scheduler comes up
-    if let Err(e) = scheduler.schedule() {
+    if let Err(e) = scheduler.start() {
         error!("Failed to schedule tasks: {:?}", e);
     }
 

--- a/services/scheduler-service/tests/activate.rs
+++ b/services/scheduler-service/tests/activate.rs
@@ -23,7 +23,7 @@ use util::SchedulerFixture;
 fn activate_existing_schedule() {
     let fixture = SchedulerFixture::spawn("127.0.0.1", 8020);
 
-    let schedule_path = fixture.create(None);
+    let schedule_path = fixture.create(Some("{}".to_owned()));
     assert_eq!(
         fixture.register("imaging", &schedule_path),
         json!({
@@ -103,8 +103,8 @@ fn activate_non_existent_schedule() {
 fn activate_two_schedules() {
     let fixture = SchedulerFixture::spawn("127.0.0.1", 8022);
 
-    let schedule_one_path = fixture.create(None);
-    let schedule_two_path = fixture.create(None);
+    let schedule_one_path = fixture.create(Some("{}".to_owned()));
+    let schedule_two_path = fixture.create(Some("{}".to_owned()));
 
     fixture.register("imaging", &schedule_one_path);
     fixture.register("operational", &schedule_two_path);


### PR DESCRIPTION
- Refactored `tokio` usage to give us a single runtime in a single thread. This enabled to creation of `stop` to stop an active schedule and all scheduled tasks. Addresses naive implementation found in #465.
- Implementing starting or restarting the active schedule upon activating a schedule.
- Extracted `config.rs` for `ScheduleConfig` related structures and parsing function.
- Extracted `file.rs` for `ScheduleFile` related things, and functions which deal with manipulating on disk schedule files.
- Distilled `scheduler.rs` down to functions and structures solely related to running the actual schedule and executing app tasks. 