### PR TITLE
Fixing ISIS antenna structure ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,10 +1009,9 @@ name = "isis-ants"
 version = "0.1.0"
 dependencies = [
  "isis-ants-api 0.1.0",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-stream 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/apis/isis-ants-api/src/ants.rs
+++ b/apis/isis-ants-api/src/ants.rs
@@ -35,7 +35,7 @@ pub enum AntsError {
 pub type AntSResult<T> = Result<T, AntsError>;
 
 /// Trait used to represent the AntS object. Allows for mock objects to be created for unit tests
-pub trait IAntS: IAntSClone + Sync + Send {
+pub trait IAntS: Send {
     /// Construct a new AntS instance
     fn new(bus: &str, primary: u8, secondary: u8, ant_count: u8, timeout: u32) -> AntSResult<Self>
     where
@@ -74,29 +74,7 @@ pub trait IAntS: IAntSClone + Sync + Send {
     fn passthrough(&self, tx: &[u8], rx_in: &mut [u8]) -> AntSResult<()>;
 }
 
-/// Helper trait to allow us to clone our subsystem object
-pub trait IAntSClone {
-    /// Helper function to allow us to clone our subsystem object
-    fn box_clone(&self) -> Box<IAntS>;
-}
-
-impl<T> IAntSClone for T
-where
-    T: 'static + IAntS + Clone,
-{
-    fn box_clone(&self) -> Box<IAntS> {
-        Box::new(self.clone())
-    }
-}
-
-impl Clone for Box<IAntS> {
-    fn clone(&self) -> Box<IAntS> {
-        self.box_clone()
-    }
-}
-
 /// Structure for interacting with an ISIS Antenna System
-#[derive(Clone)]
 pub struct AntS;
 
 impl IAntS for AntS {

--- a/services/isis-ants-service/src/main.rs
+++ b/services/isis-ants-service/src/main.rs
@@ -346,6 +346,7 @@
 //!
 
 #![deny(missing_docs)]
+#![deny(warnings)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/services/isis-ants-service/src/schema.rs
+++ b/services/isis-ants-service/src/schema.rs
@@ -23,7 +23,7 @@ type Context = kubos_service::Context<Subsystem>;
 
 pub struct QueryRoot;
 
-/// Base GraphQL query model
+// Base GraphQL query model
 graphql_object!(QueryRoot: Context as "Query" |&self| {
 
     // Test query to verify service is running without attempting
@@ -193,7 +193,7 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
 
 pub struct MutationRoot;
 
-/// Base GraphQL mutation model
+// Base GraphQL mutation model
 graphql_object!(MutationRoot: Context as "Mutation" |&self| {
 
     // Get all errors encountered while processing this GraphQL request

--- a/services/isis-ants-service/src/tests/mutations/errors.rs
+++ b/services/isis-ants-service/src/tests/mutations/errors.rs
@@ -54,7 +54,7 @@ fn mutation_errors_single() {
         }"#;
 
     let expected = json!({
-            "errors": ["watchdog_kick (services/isis-ants-service/src/model.rs:364): Configuration error"]
+            "errors": ["lock (services/isis-ants-service/src/model.rs:350): Configuration error"]
     });
 
     test!(service, query, expected);
@@ -81,7 +81,7 @@ fn mutation_errors_multiple() {
         }"#;
 
     let expected = json!({
-            "errors": ["watchdog_kick (services/isis-ants-service/src/model.rs:364): Configuration error", "watchdog_kick (services/isis-ants-service/src/model.rs:364): Configuration error"]
+            "errors": ["lock (services/isis-ants-service/src/model.rs:350): Configuration error", "lock (services/isis-ants-service/src/model.rs:350): Configuration error"]
     });
 
     test!(service, query, expected);

--- a/services/isis-ants-service/src/tests/mutations/test_hardware.rs
+++ b/services/isis-ants-service/src/tests/mutations/test_hardware.rs
@@ -147,14 +147,14 @@ fn integration_test_bad() {
 
     let expected = json!({
         "testHardware": {
-            "errors": "Nominal: Generic error; Debug: get_activation_count (services/isis-ants-service/src/model.rs:306): Generic error, \
-                get_activation_time (services/isis-ants-service/src/model.rs:308): Generic error, \
-                get_activation_count (services/isis-ants-service/src/model.rs:312): Generic error, \
-                get_activation_time (services/isis-ants-service/src/model.rs:314): Generic error, \
-                get_activation_count (services/isis-ants-service/src/model.rs:318): Generic error, \
-                get_activation_time (services/isis-ants-service/src/model.rs:320): Generic error, \
-                get_activation_count (services/isis-ants-service/src/model.rs:324): Generic error, \
-                get_activation_time (services/isis-ants-service/src/model.rs:326): Generic error",
+            "errors": "Nominal: Generic error; Debug: get_activation_count (services/isis-ants-service/src/objects.rs:429): Generic error, \
+                get_activation_time (services/isis-ants-service/src/objects.rs:430): Generic error, \
+                get_activation_count (services/isis-ants-service/src/objects.rs:429): Generic error, \
+                get_activation_time (services/isis-ants-service/src/objects.rs:430): Generic error, \
+                get_activation_count (services/isis-ants-service/src/objects.rs:429): Generic error, \
+                get_activation_time (services/isis-ants-service/src/objects.rs:430): Generic error, \
+                get_activation_count (services/isis-ants-service/src/objects.rs:429): Generic error, \
+                get_activation_time (services/isis-ants-service/src/objects.rs:430): Generic error",
             "success": false,
             "telemetryDebug": {
                  "ant1ActivationCount": 0,

--- a/services/isis-ants-service/src/tests/queries/deployment_status.rs
+++ b/services/isis-ants-service/src/tests/queries/deployment_status.rs
@@ -158,7 +158,7 @@ fn deploy_status_deployed_2_antennas() {
     let service = Service::new(
         Config::new_from_str("isis-ants-service", &config).unwrap(),
         Subsystem {
-            ants: Box::new(mock),
+            ants: Arc::new(Mutex::new(Box::new(mock))),
             controller: Arc::new(RwLock::new(ConfigureController::Primary)),
             errors: Arc::new(RwLock::new(vec![])),
             last_cmd: Arc::new(RwLock::new(AckCommand::None)),
@@ -233,7 +233,7 @@ fn deploy_status_stowed_2_antennas() {
     let service = Service::new(
         Config::new_from_str("isis-ants-service", &config).unwrap(),
         Subsystem {
-            ants: Box::new(mock),
+            ants: Arc::new(Mutex::new(Box::new(mock))),
             controller: Arc::new(RwLock::new(ConfigureController::Primary)),
             errors: Arc::new(RwLock::new(vec![])),
             last_cmd: Arc::new(RwLock::new(AckCommand::None)),

--- a/services/isis-ants-service/src/tests/queries/errors.rs
+++ b/services/isis-ants-service/src/tests/queries/errors.rs
@@ -54,7 +54,7 @@ fn query_errors_single() {
         }"#;
 
     let expected = json!({
-            "errors": ["watchdog_kick (services/isis-ants-service/src/model.rs:364): Configuration error"]
+            "errors": ["lock (services/isis-ants-service/src/model.rs:350): Configuration error"]
     });
 
     test!(service, query, expected);
@@ -81,7 +81,7 @@ fn query_errors_multiple() {
         }"#;
 
     let expected = json!({
-            "errors": ["watchdog_kick (services/isis-ants-service/src/model.rs:364): Configuration error", "watchdog_kick (services/isis-ants-service/src/model.rs:364): Configuration error"]
+            "errors": ["lock (services/isis-ants-service/src/model.rs:350): Configuration error", "lock (services/isis-ants-service/src/model.rs:350): Configuration error"]
     });
 
     test!(service, query, expected);

--- a/test/integration/linux/isis-ants/Cargo.toml
+++ b/test/integration/linux/isis-ants/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 isis-ants-api = { path = "../../../../apis/isis-ants-api" }
-slog = "2.1.1"
-slog-stream = "1.2.1"
-slog-term = "2.3.0"
-slog-async = "2.0.0-2.0"
+log = "^0.4.0"
+log4rs = "0.8"
+log4rs-syslog = "3.0"

--- a/test/integration/linux/isis-ants/src/main.rs
+++ b/test/integration/linux/isis-ants/src/main.rs
@@ -15,492 +15,480 @@
 //
 
 use isis_ants_api::*;
-use slog::{error, info, o, warn, Drain, Logger};
+use log::*;
 use std::fs::File;
 use std::sync::Mutex;
 
-fn arm(ants: &AntS, logger: &Logger) -> u8 {
+fn arm(ants: &AntS) -> u8 {
     match ants.arm() {
         Ok(()) => {
-            info!(logger, "[Arm Test] Test completed successfully");
+            info!("[Arm Test] Test completed successfully");
             0
         }
         Err(err) => {
-            error!(logger, "[Arm Test] Failed to arm AntS: {}", err);
+            error!("[Arm Test] Failed to arm AntS: {}", err);
             1
         }
     }
 }
 
-fn disarm(ants: &AntS, logger: &Logger) -> u8 {
+fn disarm(ants: &AntS) -> u8 {
     match ants.disarm() {
         Ok(()) => {
-            info!(logger, "[Disarm Test] Test completed successfully");
+            info!("[Disarm Test] Test completed successfully");
             0
         }
         Err(err) => {
-            error!(logger, "[Disarm Test] Failed to disarm AntS: {}", err);
+            error!("[Disarm Test] Failed to disarm AntS: {}", err);
             1
         }
     }
 }
 
-fn configure(ants: &AntS, logger: &Logger) -> u8 {
+fn configure(ants: &AntS) -> u8 {
     match ants.configure(KANTSController::Secondary) {
         Ok(()) => {
-            info!(logger, "[Configure Test] Test completed successfully");
+            info!("[Configure Test] Test completed successfully");
             0
         }
         Err(err) => {
-            error!(logger, "[Configure Test] Failed to configure AntS: {}", err);
+            error!("[Configure Test] Failed to configure AntS: {}", err);
             1
         }
     }
 }
 
-fn deploy(ants: &AntS, logger: &Logger) -> u8 {
-    match ants.deploy(KANTSAnt::Ant3, false, 1) {
+fn deploy(ants: &AntS) -> u8 {
+    match ants.deploy(KANTSAnt::Ant3, false, 10) {
         Ok(()) => {
-            info!(logger, "[Deploy Test] Test completed successfully");
+            info!("[Deploy Test] Test completed successfully");
             0
         }
         Err(err) => {
-            error!(logger, "[Deploy Test] Failed to deploy antenna 3: {}", err);
+            error!("[Deploy Test] Failed to deploy antenna 3: {}", err);
             1
         }
     }
 }
 
-fn deploy_override(ants: &AntS, logger: &Logger) -> u8 {
-    match ants.deploy(KANTSAnt::Ant1, true, 1) {
+fn deploy_override(ants: &AntS) -> u8 {
+    match ants.deploy(KANTSAnt::Ant1, true, 10) {
         Ok(()) => {
-            info!(logger, "[Deploy Override Test] Test completed successfully");
+            info!("[Deploy Override Test] Test completed successfully");
             0
         }
         Err(err) => {
-            error!(
-                logger,
-                "[Deploy Override Test] Failed to deploy antenna 1: {}", err
-            );
+            error!("[Deploy Override Test] Failed to deploy antenna 1: {}", err);
             1
         }
     }
 }
 
-fn auto_deploy(ants: &AntS, logger: &Logger) -> u8 {
+fn auto_deploy(ants: &AntS) -> u8 {
     match ants.auto_deploy(2) {
         Ok(()) => {
-            info!(logger, "[Auto-Deploy Test] Test completed successfully");
+            info!("[Auto-Deploy Test] Test completed successfully");
             0
         }
         Err(err) => {
-            error!(
-                logger,
-                "[Auto-Deploy Test] Failed to auto-deploy antennas: {}", err
-            );
+            error!("[Auto-Deploy Test] Failed to auto-deploy antennas: {}", err);
             1
         }
     }
 }
 
-fn cancel_deploy(ants: &AntS, logger: &Logger) -> u8 {
+fn cancel_deploy(ants: &AntS) -> u8 {
     match ants.cancel_deploy() {
         Ok(()) => {
-            info!(logger, "[Disarm Test] Test completed successfully");
+            info!("[Disarm Test] Test completed successfully");
             0
         }
         Err(err) => {
-            error!(
-                logger,
-                "[Disarm Test] Failed to cancel AntS deployment: {}", err
-            );
+            error!("[Disarm Test] Failed to cancel AntS deployment: {}", err);
             1
         }
     }
 }
 
-fn passthrough(ants: &AntS, logger: &Logger) -> u8 {
+fn passthrough(ants: &AntS) -> u8 {
     let tx: [u8; 1] = [0xC3];
     let mut rx: [u8; 2] = [0; 2];
 
     match ants.passthrough(&tx, &mut rx) {
         Ok(()) => {
-            info!(logger, "[Passthrough Test] Result: {:?}", rx);
+            info!("[Passthrough Test] Result: {:?}", rx);
             0
         }
         Err(err) => {
             error!(
-                logger,
-                "[Passthrough Test] Failed to read AntS deployment status: {}", err
+                "[Passthrough Test] Failed to read AntS deployment status: {}",
+                err
             );
             1
         }
     }
 }
 
-fn reset(ants: &AntS, logger: &Logger) -> u8 {
+fn reset(ants: &AntS) -> u8 {
     match ants.reset() {
         Ok(()) => {
-            info!(logger, "[Reset Test] Test completed successfully");
+            info!("[Reset Test] Test completed successfully");
             0
         }
         Err(err) => {
-            error!(logger, "[Reset Test] Failed to reset AntS: {}", err);
+            error!("[Reset Test] Failed to reset AntS: {}", err);
             1
         }
     }
 }
 
-fn get_deploy(ants: &AntS, logger: &Logger) -> u8 {
+fn get_deploy(ants: &AntS) -> u8 {
     let deploy = match ants.get_deploy() {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Passthrough Test] Failed to read AntS deployment status: {}", err
+                "[Passthrough Test] Failed to read AntS deployment status: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna deployment status:");
-    info!(logger, "    sys_burn_active: {}", deploy.sys_burn_active);
-    info!(
-        logger,
-        "    sys_ignore_deploy: {}", deploy.sys_ignore_deploy
-    );
-    info!(logger, "    sys_armed: {}", deploy.sys_armed);
-    info!(
-        logger,
-        "    ant_1_not_deployed: {}", deploy.ant_1_not_deployed
-    );
-    info!(
-        logger,
-        "    ant_1_stopped_time: {}", deploy.ant_1_stopped_time
-    );
-    info!(logger, "    ant_1_active: {}", deploy.ant_1_active);
-    info!(
-        logger,
-        "    ant_2_not_deployed: {}", deploy.ant_2_not_deployed
-    );
-    info!(
-        logger,
-        "    ant_2_stopped_time: {}", deploy.ant_2_stopped_time
-    );
-    info!(logger, "    ant_2_active: {}", deploy.ant_2_active);
-    info!(
-        logger,
-        "    ant_3_not_deployed: {}", deploy.ant_3_not_deployed
-    );
-    info!(
-        logger,
-        "    ant_3_stopped_time: {}", deploy.ant_3_stopped_time
-    );
-    info!(logger, "    ant_3_active: {}", deploy.ant_3_active);
-    info!(
-        logger,
-        "    ant_4_not_deployed: {}", deploy.ant_4_not_deployed
-    );
-    info!(
-        logger,
-        "    ant_4_stopped_time: {}", deploy.ant_4_stopped_time
-    );
-    info!(logger, "    ant_4_active: {}", deploy.ant_4_active);
+    info!("Antenna deployment status:");
+    info!("    sys_burn_active: {}", deploy.sys_burn_active);
+    info!("    sys_ignore_deploy: {}", deploy.sys_ignore_deploy);
+    info!("    sys_armed: {}", deploy.sys_armed);
+    info!("    ant_1_not_deployed: {}", deploy.ant_1_not_deployed);
+    info!("    ant_1_stopped_time: {}", deploy.ant_1_stopped_time);
+    info!("    ant_1_active: {}", deploy.ant_1_active);
+    info!("    ant_2_not_deployed: {}", deploy.ant_2_not_deployed);
+    info!("    ant_2_stopped_time: {}", deploy.ant_2_stopped_time);
+    info!("    ant_2_active: {}", deploy.ant_2_active);
+    info!("    ant_3_not_deployed: {}", deploy.ant_3_not_deployed);
+    info!("    ant_3_stopped_time: {}", deploy.ant_3_stopped_time);
+    info!("    ant_3_active: {}", deploy.ant_3_active);
+    info!("    ant_4_not_deployed: {}", deploy.ant_4_not_deployed);
+    info!("    ant_4_stopped_time: {}", deploy.ant_4_stopped_time);
+    info!("    ant_4_active: {}", deploy.ant_4_active);
 
     if !deploy.sys_armed {
-        error!(logger, "[Deploy Status Test] AntS not reporting as armed");
+        error!("[Deploy Status Test] AntS not reporting as armed");
         return 1;
     }
 
-    info!(logger, "[Deploy Status Test] Test completed successfully");
+    info!("[Deploy Status Test] Test completed successfully");
     0
 }
 
-fn get_sys_telem(ants: &AntS, logger: &Logger) -> u8 {
+fn get_sys_telem(ants: &AntS) -> u8 {
     let sys_telem = match ants.get_system_telemetry() {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Passthrough Test] Failed to read AntS deployment status: {}", err
+                "[Passthrough Test] Failed to read AntS deployment status: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna system telemetry:");
-    info!(logger, "    raw_temp: {}", sys_telem.raw_temp);
-    info!(logger, "    deploy_status:");
+    info!("Antenna system telemetry:");
+    info!("    raw_temp: {}", sys_telem.raw_temp);
+    info!("    deploy_status:");
     info!(
-        logger,
-        "        sys_burn_active: {}", sys_telem.deploy_status.sys_burn_active
+        "        sys_burn_active: {}",
+        sys_telem.deploy_status.sys_burn_active
     );
     info!(
-        logger,
-        "        sys_ignore_deploy: {}", sys_telem.deploy_status.sys_ignore_deploy
+        "        sys_ignore_deploy: {}",
+        sys_telem.deploy_status.sys_ignore_deploy
+    );
+    info!("        sys_armed: {}", sys_telem.deploy_status.sys_armed);
+    info!(
+        "        ant_1_not_deployed: {}",
+        sys_telem.deploy_status.ant_1_not_deployed
     );
     info!(
-        logger,
-        "        sys_armed: {}", sys_telem.deploy_status.sys_armed
+        "        ant_1_stopped_time: {}",
+        sys_telem.deploy_status.ant_1_stopped_time
     );
     info!(
-        logger,
-        "        ant_1_not_deployed: {}", sys_telem.deploy_status.ant_1_not_deployed
+        "        ant_1_active: {}",
+        sys_telem.deploy_status.ant_1_active
     );
     info!(
-        logger,
-        "        ant_1_stopped_time: {}", sys_telem.deploy_status.ant_1_stopped_time
+        "        ant_2_not_deployed: {}",
+        sys_telem.deploy_status.ant_2_not_deployed
     );
     info!(
-        logger,
-        "        ant_1_active: {}", sys_telem.deploy_status.ant_1_active
+        "        ant_2_stopped_time: {}",
+        sys_telem.deploy_status.ant_2_stopped_time
     );
     info!(
-        logger,
-        "        ant_2_not_deployed: {}", sys_telem.deploy_status.ant_2_not_deployed
+        "        ant_2_active: {}",
+        sys_telem.deploy_status.ant_2_active
     );
     info!(
-        logger,
-        "        ant_2_stopped_time: {}", sys_telem.deploy_status.ant_2_stopped_time
+        "        ant_3_not_deployed: {}",
+        sys_telem.deploy_status.ant_3_not_deployed
     );
     info!(
-        logger,
-        "        ant_2_active: {}", sys_telem.deploy_status.ant_2_active
+        "        ant_3_stopped_time: {}",
+        sys_telem.deploy_status.ant_3_stopped_time
     );
     info!(
-        logger,
-        "        ant_3_not_deployed: {}", sys_telem.deploy_status.ant_3_not_deployed
+        "        ant_3_active: {}",
+        sys_telem.deploy_status.ant_3_active
     );
     info!(
-        logger,
-        "        ant_3_stopped_time: {}", sys_telem.deploy_status.ant_3_stopped_time
+        "        ant_4_not_deployed: {}",
+        sys_telem.deploy_status.ant_4_not_deployed
     );
     info!(
-        logger,
-        "        ant_3_active: {}", sys_telem.deploy_status.ant_3_active
+        "        ant_4_stopped_time: {}",
+        sys_telem.deploy_status.ant_4_stopped_time
     );
     info!(
-        logger,
-        "        ant_4_not_deployed: {}", sys_telem.deploy_status.ant_4_not_deployed
+        "        ant_4_active: {}",
+        sys_telem.deploy_status.ant_4_active
     );
-    info!(
-        logger,
-        "        ant_4_stopped_time: {}", sys_telem.deploy_status.ant_4_stopped_time
-    );
-    info!(
-        logger,
-        "        ant_4_active: {}", sys_telem.deploy_status.ant_4_active
-    );
-    info!(logger, "    uptime: {}", sys_telem.uptime);
+    info!("    uptime: {}", sys_telem.uptime);
 
-    info!(
-        logger,
-        "[System Telemetry Test] Test completed successfully"
-    );
+    info!("[System Telemetry Test] Test completed successfully");
 
     0
 }
 
-fn get_act_counts(ants: &AntS, logger: &Logger) -> u8 {
+fn get_act_counts(ants: &AntS) -> u8 {
     let act_count = match ants.get_activation_count(KANTSAnt::Ant1) {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Activation Count Test] Failed to get antenna 1's activation count: {}", err
+                "[Activation Count Test] Failed to get antenna 1's activation count: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna 1 activation count: {}", act_count);
+    info!("Antenna 1 activation count: {}", act_count);
 
     let act_count = match ants.get_activation_count(KANTSAnt::Ant2) {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Activation Count Test] Failed to get antenna 2's activation count: {}", err
+                "[Activation Count Test] Failed to get antenna 2's activation count: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna 2 activation count: {}", act_count);
+    info!("Antenna 2 activation count: {}", act_count);
 
     let act_count = match ants.get_activation_count(KANTSAnt::Ant3) {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Activation Count Test] Failed to get antenna 3's activation count: {}", err
+                "[Activation Count Test] Failed to get antenna 3's activation count: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna 3 activation count: {}", act_count);
+    info!("Antenna 3 activation count: {}", act_count);
 
     let act_count = match ants.get_activation_count(KANTSAnt::Ant4) {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Activation Count Test] Failed to get antenna 4's activation count: {}", err
+                "[Activation Count Test] Failed to get antenna 4's activation count: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna 4 activation count: {}", act_count);
+    info!("Antenna 4 activation count: {}", act_count);
 
-    info!(
-        logger,
-        "[Activation Counts Test] Test completed successfully"
-    );
+    info!("[Activation Counts Test] Test completed successfully");
 
     0
 }
 
-fn get_act_times(ants: &AntS, logger: &Logger) -> u8 {
+fn get_act_times(ants: &AntS) -> u8 {
     let act_time = match ants.get_activation_time(KANTSAnt::Ant1) {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Activation Time Test] Failed to get antenna 1's activation time: {}", err
+                "[Activation Time Test] Failed to get antenna 1's activation time: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna 1 activation time: {}", act_time);
+    info!("Antenna 1 activation time: {}", act_time);
 
     let act_time = match ants.get_activation_time(KANTSAnt::Ant2) {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Activation Time Test] Failed to get antenna 2's activation time: {}", err
+                "[Activation Time Test] Failed to get antenna 2's activation time: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna 2 activation time: {}", act_time);
+    info!("Antenna 2 activation time: {}", act_time);
 
     let act_time = match ants.get_activation_time(KANTSAnt::Ant3) {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Activation Time Test] Failed to get antenna 3's activation time: {}", err
+                "[Activation Time Test] Failed to get antenna 3's activation time: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna 3 activation time: {}", act_time);
+    info!("Antenna 3 activation time: {}", act_time);
 
     let act_time = match ants.get_activation_time(KANTSAnt::Ant4) {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Activation Time Test] Failed to get antenna 4's activation time: {}", err
+                "[Activation Time Test] Failed to get antenna 4's activation time: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "Antenna 4 activation time: {}", act_time);
+    info!("Antenna 4 activation time: {}", act_time);
 
-    info!(
-        logger,
-        "[Activation Times Test] Test completed successfully"
-    );
+    info!("[Activation Times Test] Test completed successfully");
 
     0
 }
 
-fn get_uptime(ants: &AntS, logger: &Logger) -> u8 {
+fn get_uptime(ants: &AntS) -> u8 {
     let uptime = match ants.get_uptime() {
         Ok(result) => result,
         Err(err) => {
             error!(
-                logger,
-                "[Passthrough Test] Failed to read AntS deployment status: {}", err
+                "[Passthrough Test] Failed to read AntS deployment status: {}",
+                err
             );
             return 1;
         }
     };
 
-    info!(logger, "System uptime: {}", uptime);
-    info!(logger, "[Uptime Test] Test completed successfully");
+    info!("System uptime: {}", uptime);
+    info!("[Uptime Test] Test completed successfully");
 
     0
+}
+
+fn watchdog_kick(ants: &AntS) -> u8 {
+    match ants.watchdog_kick() {
+        Ok(()) => {
+            info!("[WD Test] Test completed successfully");
+            0
+        }
+        Err(err) => {
+            error!("[WD Test] Failed to kick WD: {}", err);
+            1
+        }
+    }
 }
 
 pub fn main() {
     let mut error_count: u8 = 0;
 
-    // Output warning and error messages to stderr
-    let decorator = slog_term::PlainSyncDecorator::new(std::io::stderr());
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
-    let console_drain = slog::LevelFilter(drain, slog::Level::Warning);
+    use log4rs::append::console::ConsoleAppender;
+    use log4rs::encode::pattern::PatternEncoder;
+    use log4rs_syslog::SyslogAppender;
+    // Use custom PatternEncoder to avoid duplicate timestamps in logs.
+    let syslog_encoder = Box::new(PatternEncoder::new("{m}"));
+    // Set up logging which will be routed to syslog for processing
+    let syslog = Box::new(
+        SyslogAppender::builder()
+            .encoder(syslog_encoder)
+            .openlog(
+                "isis-ants",
+                log4rs_syslog::LogOption::LOG_PID | log4rs_syslog::LogOption::LOG_CONS,
+                log4rs_syslog::Facility::User,
+            )
+            .build(),
+    );
 
-    // Output all messages to the log file
-    let file = File::create("ants-rust-results.txt").expect("Couldn't open log file");
-    let decorator = slog_term::PlainSyncDecorator::new(file);
-    let file_drain = Mutex::new(slog_term::FullFormat::new(decorator).build()).fuse();
+    // Set up logging which will be routed to stdout
+    let stdout = Box::new(ConsoleAppender::builder().build());
 
-    // Combine the loggers so we only have to make one logging call per message
-    let logger = Logger::root(slog::Duplicate(console_drain, file_drain).fuse(), o!());
+    // Combine the loggers into one master config
+    let config = log4rs::config::Config::builder()
+        .appender(log4rs::config::Appender::builder().build("syslog", syslog))
+        .appender(log4rs::config::Appender::builder().build("stdout", stdout))
+        .build(
+            log4rs::config::Root::builder()
+                .appender("syslog")
+                .appender("stdout")
+                // Set the minimum logging level to record
+                .build(log::LevelFilter::Debug),
+        )
+        .unwrap();
+
+    // Start the logger
+    log4rs::init_config(config).unwrap();
 
     // Initialize connection with the antenna system
     let ants = match AntS::new("/dev/i2c-0", 0x31, 0x32, 4, 10) {
         Ok(result) => result,
         Err(err) => {
-            error!(logger, "Failed to init connection: {}", err);
+            error!("Failed to init connection: {}", err);
             panic!("Unable to connect to AntS. Cancelling test");
         }
     };
 
-    info!(logger, "ISIS AntS Integration Tests");
+    info!("ISIS AntS Integration Tests");
 
-    error_count += arm(&ants, &logger);
-    error_count += disarm(&ants, &logger);
-    error_count += configure(&ants, &logger);
+    error_count += arm(&ants);
+    error_count += disarm(&ants);
+    error_count += configure(&ants);
 
     // Prep for deployment tests
     if ants.arm().is_err() {
         error_count += 1;
-        error!(logger, "Failed to arm AntS");
+        error!("Failed to arm AntS");
     }
 
-    error_count += deploy(&ants, &logger);
-    error_count += deploy_override(&ants, &logger);
-    error_count += auto_deploy(&ants, &logger);
-    error_count += cancel_deploy(&ants, &logger);
-    error_count += passthrough(&ants, &logger);
-    error_count += get_deploy(&ants, &logger);
-    error_count += get_sys_telem(&ants, &logger);
-    error_count += get_act_counts(&ants, &logger);
-    error_count += get_act_times(&ants, &logger);
-    error_count += get_uptime(&ants, &logger);
+    error_count += deploy(&ants);
+    error_count += deploy_override(&ants);
+    error_count += auto_deploy(&ants);
+    error_count += cancel_deploy(&ants);
+    error_count += passthrough(&ants);
+    error_count += get_deploy(&ants);
+    error_count += get_sys_telem(&ants);
+    error_count += get_act_counts(&ants);
+    error_count += get_act_times(&ants);
+    error_count += get_uptime(&ants);
 
-    error_count += reset(&ants, &logger);
+    error_count += reset(&ants);
+    error_count += watchdog_kick(&ants);
 
-    info!(logger, "ISIS AntS Integration Tests Complete");
+    info!("ISIS AntS Integration Tests Complete");
 
     if error_count == 0 {
         // Since we don't have the logger set up to print to stdout,
         // we need a manual println call here
         println!("AntS tests completed successfully");
-        info!(logger, "AntS tests completed successfully");
+        info!("AntS tests completed successfully");
     } else {
         eprintln!("One or more AntS tests have failed. See ant-results.txt for info");
-        warn!(logger, "One or more AntS tests have failed");
+        warn!("One or more AntS tests have failed");
     }
 }

--- a/tools/default_config.toml
+++ b/tools/default_config.toml
@@ -26,3 +26,14 @@ port = 8004
 [shell-service.addr]
 ip = "127.0.0.1"
 port = 8005
+
+[isis-ants-service.addr]
+ip = "0.0.0.0"
+port = 8007
+
+[isis-ants-service]
+bus = "/dev/i2c-0"
+primary = "0x31"
+secondary = "0x32"
+antennas = 4
+wd_timeout = 10


### PR DESCRIPTION
Primary change: The ISIS antenna service now initiates the `AntS` structure inside a mutex. Previously we were allowing it to be cloned, which lead to the HTTP server cloning the structure, doing its GraphQL query work, then dropping the clone. This clone triggered the `AntS::Drop()` logic, which closes the I2C connection, preventing any further communication with the underlying device.

Auxiliary changes: Bringing code up to rust 1.37 standards, disallowing warnings