### PR TITLE
File service + client fixes

### DIFF
--- a/clients/kubos-file-client/README.rst
+++ b/clients/kubos-file-client/README.rst
@@ -21,7 +21,6 @@ Required arguments:
         - ``download`` - Transfer ``source-file`` on the remote target to ``target-file`` location
                        on the local host
     - ``source-file`` - The file to be transferred. May be a relative or absolute path.
-    - ``-P {host_port}`` - The UDP port that the file transfer service will send responses to.
 
 Optional arguments:
 
@@ -31,3 +30,4 @@ Optional arguments:
     - ``-h {host IP}`` - Default: `0.0.0.0`. IP address of the local host to use.
     - ``-r {remote IP}`` - Default: `0.0.0.0`. IP address of the file transfer service to connect to.
     - ``-p {remote port}`` - Default: `8040`. UDP port of the file transfer service to connect to.
+    - ``-P {host_port}`` - Default: `8080`. The UDP port that the file transfer service will send responses to.

--- a/clients/kubos-file-client/src/main.rs
+++ b/clients/kubos-file-client/src/main.rs
@@ -197,7 +197,8 @@ fn main() {
             Arg::with_name("host_port")
                 .short("-P")
                 .help("UDP port that the file transfer service will send responses to")
-                .takes_value(true),
+                .takes_value(true)
+                .default_value("8080"),
         )
         .arg(
             Arg::with_name("remote_ip")

--- a/docs/tutorials/file-transfer.rst
+++ b/docs/tutorials/file-transfer.rst
@@ -43,7 +43,6 @@ Required arguments:
         - ``cleanup`` - Cleanup the endpoint service's temporary storage directory
 
     - ``source-file`` - The file to be transferred. May be a relative or absolute path.
-    - ``-P {host_port}`` - The UDP port that the file transfer service will send responses to.
 
 Optional arguments:
 
@@ -53,6 +52,7 @@ Optional arguments:
     - ``-h {host IP}`` - Default: `0.0.0.0`. IP address of the local host to use.
     - ``-r {remote IP}`` - Default: `0.0.0.0`. IP address of the file transfer service to connect to.
     - ``-p {remote port}`` - Default: `8040`. UDP port of the file transfer service to connect to.
+    - ``-P {host_port}`` - Default: `8080`. The UDP port that the file transfer service will send responses to.
     - ``-s {storage_prefix}`` - Default: `file-storage`. Name of the directory which should be used
       for temporary file transfer storage.
     - ``-c {chunk_size}`` - Default: `4096`. Size, in bytes, of the individual chunks the file

--- a/services/file-service/src/lib.rs
+++ b/services/file-service/src/lib.rs
@@ -47,8 +47,8 @@ pub fn recv_loop(config: &ServiceConfig) -> Result<(), failure::Error> {
 
     // Get the chunk size to be used for transfers
     let chunk_size = match config.get("chunk_size") {
-        Some(val) => val.as_integer().unwrap_or(4096),
-        None => 4096,
+        Some(val) => val.as_integer().unwrap_or(1024),
+        None => 1024,
     } as usize;
 
     let hold_count = match config.get("hold_count") {
@@ -60,15 +60,16 @@ pub fn recv_loop(config: &ServiceConfig) -> Result<(), failure::Error> {
     let downlink_port = config
         .get("downlink_port")
         .and_then(|i| i.as_integer())
-        .expect("Downlink port not found") as u16;
+        .unwrap_or(8080) as u16;
 
     // Get the downlink ip we'll be using when sending responses
-    let downlink_ip = config
-        .get("downlink_ip")
-        .expect("Downlink IP not found")
-        .as_str()
-        .and_then(|str| Some(str.to_owned()))
-        .expect("Downlink IP not found");
+    let downlink_ip = match config.get("downlink_ip") {
+        Some(ip) => match ip.as_str().and_then(|ip| Some(ip.to_owned())) {
+            Some(ip) => ip,
+            None => "127.0.0.1".to_owned(),
+        },
+        None => "127.0.0.1".to_owned(),
+    };
 
     info!("Starting file transfer service");
     info!("Listening on {}", host);


### PR DESCRIPTION
- File service now logs a message if config file is missing
- File service and file client will now run on compatible, default ip/port values if not specified
- Adjusted default chunk size in file service to match client