### PR TITLE
Adding common service logging function with optional --stdout flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arc-swap"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,11 +384,6 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "crossbeam"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -651,7 +651,6 @@ dependencies = [
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1013,7 +1012,7 @@ version = "0.1.0"
 dependencies = [
  "isis-ants-api 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1149,7 +1148,7 @@ dependencies = [
  "kubos-service 0.1.0",
  "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1228,6 +1227,9 @@ name = "kubos-system"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1319,7 +1321,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1357,12 +1359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log4rs"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1388,7 +1390,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2458,7 +2460,7 @@ dependencies = [
  "kubos-service 0.1.0",
  "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-uart 0.2.0",
  "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3359,6 +3361,7 @@ dependencies = [
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+"checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
@@ -3392,7 +3395,6 @@ dependencies = [
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc16 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "11a65c4797332f3e3a5945e0377875afc79b1bdc87082a4f98ac1ef15b47e2dd"
 "checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
-"checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4c7ea749d9fb09e23c5cb17e3b70650860553a0e2744e38446b1803bf7db94"
 "checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
@@ -3469,7 +3471,7 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
-"checksum log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25e0fc8737a634116a2deb38d821e4400ed16ce9dcb0d628a978d399260f5902"
+"checksum log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "100052474df98158c0738a7d3f4249c99978490178b5f9f68cd835ac57adbd1b"
 "checksum log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ea4f1006c75f7ee0a14564e71b905927f9165da91364cfdb4732f57559c1b59a"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-i2c 0.1.0",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -555,14 +554,6 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "error-chain"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -577,7 +568,6 @@ dependencies = [
  "juniper 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -588,7 +578,6 @@ dependencies = [
  "kubos-service 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -950,7 +939,6 @@ dependencies = [
  "juniper 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-service 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1037,7 +1025,6 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1172,7 +1159,6 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1321,9 +1307,6 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1434,7 +1417,6 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1573,7 +1555,6 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1693,7 +1674,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "novatel-oem6-api 0.1.0",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1719,7 +1699,6 @@ dependencies = [
  "kubos-service 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nsl-duplex-d2 0.1.0",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2460,8 +2439,6 @@ dependencies = [
  "kubos-service 0.1.0",
  "kubos-system 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-uart 0.2.0",
  "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2532,7 +2509,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-protocol 0.1.0",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2730,17 +2706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syslog"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,7 +2735,6 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3411,7 +3375,6 @@ dependencies = [
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
@@ -3598,7 +3561,6 @@ dependencies = [
 "checksum syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646"
 "checksum syntex_pos 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd49988e52451813c61fecbe9abb5cfd4e1b7bb6cdbb980a6fbcbab859171a6"
 "checksum syntex_syntax 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7628a0506e8f9666fdabb5f265d0059b059edac9a3f810bda077abb5d826bd8d"
-"checksum syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0641142b4081d3d44beffa4eefd7346a228cdf91ed70186db2ca2cef762d327"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tar 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "a303ba60a099fcd2aaa646b14d2724591a96a75283e4b7ed3d1a1658909d9ae2"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"

--- a/apis/system-api/Cargo.toml
+++ b/apis/system-api/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1.2"
+log4rs = "0.8.3"
+log4rs-syslog = "3.0"
+log = "^0.4.0"
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.4"

--- a/apis/system-api/src/lib.rs
+++ b/apis/system-api/src/lib.rs
@@ -19,6 +19,7 @@
 //! KubOS System level APIs
 
 mod config;
+pub mod logger;
 mod uboot;
 
 pub use crate::config::DEFAULT_PATH as DEFAULT_CONFIG_PATH;

--- a/apis/system-api/src/logger.rs
+++ b/apis/system-api/src/logger.rs
@@ -1,0 +1,121 @@
+//
+// Copyright (C) 2019 Kubos Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//!
+//! Common structure and functions for setting up service logging
+//!
+
+use failure::{bail, Error};
+use log::LevelFilter;
+use log4rs::append::console::ConsoleAppender;
+use log4rs::config::Config;
+use log4rs::encode::pattern::PatternEncoder;
+use log4rs_syslog::SyslogAppender;
+use std::env;
+
+/// Initialize logging for the service
+/// All messages will be routed to syslog and optionally echoed to the console
+pub fn init(service_name: &str) -> Result<(), Error> {
+    let stdout_flag = get_stdout_flag();
+    let log_level = get_log_level()?;
+
+    // Use custom PatternEncoder to avoid duplicate timestamps in logs.
+    let syslog_encoder = Box::new(PatternEncoder::new("{m}"));
+    // Set up logging which will be routed to syslog for processing
+    let syslog = Box::new(
+        SyslogAppender::builder()
+            .encoder(syslog_encoder)
+            .openlog(
+                service_name,
+                log4rs_syslog::LogOption::LOG_PID | log4rs_syslog::LogOption::LOG_CONS,
+                log4rs_syslog::Facility::Daemon,
+            )
+            .build(),
+    );
+
+    // Set up logging which will be routed to stdout
+    let stdout_appender = Box::new(ConsoleAppender::builder().build());
+
+    let config_builder = Config::builder();
+    let config_builder =
+        config_builder.appender(log4rs::config::Appender::builder().build("syslog", syslog));
+    let config_builder = if stdout_flag {
+        config_builder
+            .appender(log4rs::config::Appender::builder().build("stdout", stdout_appender))
+    } else {
+        config_builder
+    };
+
+    let root_builder = log4rs::config::Root::builder();
+    let root_builder = root_builder.appender("syslog");
+    let root_builder = if stdout_flag {
+        root_builder.appender("stdout")
+    } else {
+        root_builder
+    };
+    let root_config = root_builder.build(log_level);
+
+    let config = config_builder.build(root_config)?;
+
+    // Start the logger
+    log4rs::init_config(config)?;
+    Ok(())
+}
+
+fn get_log_level() -> Result<LevelFilter, Error> {
+    // Manually check for a "-l {log-level}" command line argument specifying a log level
+    // Doing it this way so that entities which use this module (apps, services) can have any
+    // number of additional command arguments
+    let mut args = env::args();
+
+    // Navigate to the "-l" option
+    let config_arg_pos = args.position(|arg| arg == "-l");
+
+    if let Some(_pos) = config_arg_pos {
+        // The config path will be the arg immediately after "-l"
+        match args.next() {
+            Some(path) => match path.as_str() {
+                "error" => Ok(LevelFilter::Error),
+                "warn" => Ok(LevelFilter::Warn),
+                "info" => Ok(LevelFilter::Info),
+                "debug" => Ok(LevelFilter::Debug),
+                "trace" => Ok(LevelFilter::Trace),
+                _ => bail!("The '-l' arg was specified, but an invalid log level was provided"),
+            },
+            None => bail!("The '-l' arg was specified, but no log level was provided"),
+        }
+    } else {
+        // The "-l" arg wasn't specified, so we can go ahead with the default
+        Ok(LevelFilter::Debug)
+    }
+}
+
+fn get_stdout_flag() -> bool {
+    // Manually check for a "--stdout" command line argument requesting logging via stdout
+    // Doing it this way so that entities which use this module (apps, services) can have any
+    // number of additional command arguments
+    let mut args = env::args();
+
+    // Navigate to the "--stdout" option
+    let config_arg_pos = args.position(|arg| arg == "--stdout");
+
+    if let Some(_pos) = config_arg_pos {
+        true
+    } else {
+        // The "--stdout" arg wasn't specified, so we can go ahead with the default
+        false
+    }
+}

--- a/docs/ecosystem/linux-docs/logging.rst
+++ b/docs/ecosystem/linux-docs/logging.rst
@@ -78,36 +78,31 @@ Rust
 ~~~~
 
 Rust programs will use the standard `log framework crate <https://docs.rs/log/0.4.6/log/>`__ in
-conjunction with a crate capable of writing syslog messages.
-For example, using `syslog <https://docs.rs/syslog/4.0.1/syslog/>`__:
+conjunction with a crate capable of writing syslog messages. The ``kubos-system`` crate provides
+a `common interface <https://github.com/kubos/kubos/blob/master/apis/system-api/src/logger.rs>`__
+for initializing the syslog interface. The ``kubos-service`` crate re-exports this
+interface for usage when building services:
 
 .. code-block:: rust
 
+    use failure::{Error, SyncFailure};
+    use kubos_service::Logger;
     use log::{debug, error};
     
-    use failure::{Error, SyncFailure};
-    use syslog::Facility;
-    
     fn main() -> Result<(), Error> {
-        if let Err(error) = syslog::init(
-            // Log using the User facility (Kubos services will use LOG_DAEMON)
-            Facility::LOG_USER,
-            // Set the minimum log level we care about
-            log::LevelFilter::Debug,
-            // Set the application/program name
-            Some("log-test"),
-            // Have to do `map_err(SyncFailure::new)` in order to convert
-            // error-chain Error into something `failure` can handle
-        ).map_err(SyncFailure::new)
-        {
-            eprintln!("Failed to start logging: {}", error);
-        }
+        // Set the application/program name
+        Logger::init("log-test").unwrap();
     
         debug!("this is a debug {}", "message");
         error!("this is an error!");
         Ok(())
     }
 
+Utilizing the ``kubos_system::logger`` interface also exposes two optional command line arguments:
+
+- The ``--stdout`` flag will enable logging to stdout.
+- The ``-l log-level`` flag will control the verbosity of the logging. The following 
+  log levels are available: ``error``, ``warn``, ``info``, and ``debug``.
 
 Python
 ~~~~~~

--- a/docs/tutorials/comms-service.rst
+++ b/docs/tutorials/comms-service.rst
@@ -114,8 +114,6 @@ Edit the ``Cargo.toml`` file to have the following dependencies::
     kubos-service = { git = "https://github.com/kubos/kubos" }
     kubos-system = { git = "https://github.com/kubos/kubos" }
     log = "^0.4.0"
-    log4rs = "0.8"
-    log4rs-syslog = "3.0"
     serial = "0.4"
 
 All the dependencies, with the exception of ``serial``, should be common to all services
@@ -142,48 +140,13 @@ Logging
 We'll start by initializing our logging:
 
 .. code-block:: rust
-
+    
+    use kubos_service::Logger;
     use log::*;
-    use log4rs::append::console::ConsoleAppender;
-    use log4rs::encode::pattern::PatternEncoder;
-    use log4rs_syslog::SyslogAppender;
 
-    // Initialize logging for the service
-    // All messages will be routed to syslog and echoed to the console
-    fn log_init() -> ServiceResult<()> {
-        // Use custom PatternEncoder to avoid duplicate timestamps in logs.
-        let syslog_encoder = Box::new(PatternEncoder::new("{m}"));
-        // Set up logging which will be routed to syslog for processing
-        let syslog = Box::new(
-            SyslogAppender::builder()
-                .encoder(syslog_encoder)
-                .openlog(
-                    "radio-service",
-                    log4rs_syslog::LogOption::LOG_PID | log4rs_syslog::LogOption::LOG_CONS,
-                    log4rs_syslog::Facility::Daemon,
-                )
-                .build(),
-        );
-
-        // Set up logging which will be routed to stdout
-        let stdout = Box::new(ConsoleAppender::builder().build());
-
-        // Combine the loggers into one master config
-        let config = log4rs::config::Config::builder()
-            .appender(log4rs::config::Appender::builder().build("syslog", syslog))
-            .appender(log4rs::config::Appender::builder().build("stdout", stdout))
-            .build(
-                log4rs::config::Root::builder()
-                    .appender("syslog")
-                    .appender("stdout")
-                    // Set the minimum logging level to record
-                    .build(log::LevelFilter::Debug),
-            )?;
-
-        // Start the logger
-        log4rs::init_config(config)?;
-
-        Ok(())
+    fn main() {
+        // Initialize logging for the service
+        Logger::init("radio-service").unwrap();
     }
 
 Serial Initialization
@@ -403,8 +366,8 @@ After setting up logging, we'll want to fetch our service's configuration settin
 .. code-block:: rust
 
     fn main() -> ServiceResult<()> {
-        // Initialize logging for the program
-        log_init()?;
+        // Initialize logging for the service
+        Logger::init("radio-service").unwrap();
 
         // Get the main service configuration from the system's config.toml file
         let service_config = kubos_system::Config::new("radio-service")?;
@@ -440,8 +403,8 @@ The initialization should look like this:
 .. code-block:: rust
 
     fn main() -> ServiceResult<()> {
-        // Initialize logging for the program
-        log_init()?;
+        // Initialize logging for the service
+        Logger::init("radio-service").unwrap();
 
         // Get the main service configuration from the system's config.toml file
         let service_config = kubos_system::Config::new("radio-service")?;
@@ -479,8 +442,8 @@ For the moment, we'll put a loop at the end of our program to keep from exiting.
 .. code-block:: rust
 
     fn main() -> ServiceResult<()> {
-        // Initialize logging for the program
-        log_init()?;
+        // Initialize logging for the service
+        Logger::init("radio-service").unwrap();
 
         // Get the main service configuration from the system's config.toml file
         let service_config = kubos_system::Config::new("radio-service")?;
@@ -527,10 +490,8 @@ All together, our code so far should look like this:
     
     use comms_service::*;
     use failure::*;
+    use kubos_service::Logger;
     use log::*;
-    use log4rs::append::console::ConsoleAppender;
-    use log4rs::encode::pattern::PatternEncoder;
-    use log4rs_syslog::SyslogAppender;
     use serial;
     use serial::prelude::*;
     use std::cell::RefCell;
@@ -543,44 +504,6 @@ All together, our code so far should look like this:
     // Maximum number of bytes to attempt to read at one time
     const MAX_READ: usize = 48;
     const TIMEOUT: Duration = Duration::from_millis(100);
-    
-    // Initialize logging for the service
-    // All messages will be routed to syslog and echoed to the console
-    fn log_init() -> ServiceResult<()> {
-        // Use custom PatternEncoder to avoid duplicate timestamps in logs.
-        let syslog_encoder = Box::new(PatternEncoder::new("{m}"));
-        // Set up logging which will be routed to syslog for processing
-        let syslog = Box::new(
-            SyslogAppender::builder()
-                .encoder(syslog_encoder)
-                .openlog(
-                    "radio-service",
-                    log4rs_syslog::LogOption::LOG_PID | log4rs_syslog::LogOption::LOG_CONS,
-                    log4rs_syslog::Facility::Daemon,
-                )
-                .build(),
-        );
-    
-        // Set up logging which will be routed to stdout
-        let stdout = Box::new(ConsoleAppender::builder().build());
-    
-        // Combine the loggers into one master config
-        let config = log4rs::config::Config::builder()
-            .appender(log4rs::config::Appender::builder().build("syslog", syslog))
-            .appender(log4rs::config::Appender::builder().build("stdout", stdout))
-            .build(
-                log4rs::config::Root::builder()
-                    .appender("syslog")
-                    .appender("stdout")
-                    // Set the minimum logging level to record
-                    .build(log::LevelFilter::Debug),
-            )?;
-    
-        // Start the logger
-        log4rs::init_config(config)?;
-    
-        Ok(())
-    }
     
     // Initialize the serial bus connection for reading and writing from/to the "radio"
     pub fn serial_init(bus: &str) -> ServiceResult<Arc<Mutex<RefCell<serial::SystemPort>>>> {
@@ -681,9 +604,9 @@ All together, our code so far should look like this:
     }
     
     fn main() -> ServiceResult<()> {
-        // Initialize logging for the program
-        log_init()?;
-    
+        // Initialize logging for the service
+        Logger::init("radio-service").unwrap();
+
         // Get the main service configuration from the system's config.toml file
         let service_config = kubos_system::Config::new("test-comms")?;
     
@@ -984,11 +907,11 @@ We can now define and start our GraphQL front-end in the main code:
     use crate::model::*;
     use crate::schema::*;
     
-    use kubos_service::Service;
+    use kubos_service::{Logger, Service};
 
     fn main() -> ServiceResult<()> {
-        // Initialize logging for the program
-        log_init()?;
+        // Initialize logging for the service
+        Logger::init("radio-service").unwrap();
 
         // Get the main service configuration from the system's config.toml file
         let service_config = kubos_system::Config::new("radio-service")?;

--- a/examples/rust-c-service/service/Cargo.toml
+++ b/examples/rust-c-service/service/Cargo.toml
@@ -9,4 +9,3 @@ extern-lib = { path = "../extern-lib" }
 kubos-service = { path = "../../../services/kubos-service" }
 juniper = "0.11"
 log = "^0.4.0"
-syslog = "4.0"

--- a/examples/rust-c-service/service/src/main.rs
+++ b/examples/rust-c-service/service/src/main.rs
@@ -22,17 +22,11 @@ mod schema;
 
 use crate::model::Subsystem;
 use crate::schema::{MutationRoot, QueryRoot};
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use log::error;
-use syslog::Facility;
 
 fn main() {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("example-service"),
-    )
-    .unwrap();
+    Logger::init("example-service").unwrap();
 
     Service::new(
         Config::new("example-service")

--- a/examples/rust-service/Cargo.toml
+++ b/examples/rust-service/Cargo.toml
@@ -9,4 +9,3 @@ kubos-service = { path = "../../services/kubos-service" }
 juniper =  "0.11"
 log = "^0.4.0"
 mount = "0.3.0"
-syslog = "4.0"

--- a/examples/rust-service/src/main.rs
+++ b/examples/rust-service/src/main.rs
@@ -24,9 +24,8 @@ mod schema;
 
 use crate::model::Subsystem;
 use crate::schema::{MutationRoot, QueryRoot};
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use log::error;
-use syslog::Facility;
 
 /*
 fn main() {
@@ -55,12 +54,7 @@ fn main() {
 */
 
 fn main() {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("example-service"),
-    )
-    .unwrap();
+    Logger::init("example-service").unwrap();
 
     Service::new(
         Config::new("example-service")

--- a/examples/serial-comms-service/Cargo.toml
+++ b/examples/serial-comms-service/Cargo.toml
@@ -11,7 +11,5 @@ juniper =  "0.11"
 kubos-system = { path = "../../apis/system-api" }
 kubos-service = { path = "../../services/kubos-service" }
 log = "^0.4.0"
-log4rs = "0.8"
-log4rs-syslog = "3.0"
 rust-uart = { path = "../../hal/rust-hal/rust-uart" }
 serial = "0.4"

--- a/services/app-service/Cargo.toml
+++ b/services/app-service/Cargo.toml
@@ -17,7 +17,6 @@ nix = "0.11.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-syslog = "4.0"
 toml = "0.4"
 uuid = { version = "0.6", features = ["v4"] }
 

--- a/services/app-service/src/main.rs
+++ b/services/app-service/src/main.rs
@@ -29,17 +29,11 @@ mod tests;
 
 use crate::registry::AppRegistry;
 use failure::Error;
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use log::error;
-use syslog::Facility;
 
 fn main() -> Result<(), Error> {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("kubos-app-service"),
-    )
-    .unwrap();
+    Logger::init("kubos-app-service").unwrap();
 
     let config = Config::new("app-service").map_err(|err| {
         error!("Failed to load service config: {:?}", err);

--- a/services/app-service/tests/utils/rust-proj/Cargo.lock
+++ b/services/app-service/tests/utils/rust-proj/Cargo.lock
@@ -465,6 +465,9 @@ name = "kubos-system"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs-syslog 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/services/clyde-3g-eps-service/Cargo.toml
+++ b/services/clyde-3g-eps-service/Cargo.toml
@@ -15,7 +15,6 @@ juniper =  "0.11"
 kubos-service = { path = "../kubos-service" }
 log = "^0.4.0"
 rust-i2c = { path = "../../hal/rust-hal/rust-i2c" }
-syslog = "4.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/services/clyde-3g-eps-service/src/main.rs
+++ b/services/clyde-3g-eps-service/src/main.rs
@@ -413,17 +413,11 @@ mod tests;
 use crate::models::subsystem::Subsystem;
 use crate::schema::mutation::Root as MutationRoot;
 use crate::schema::query::Root as QueryRoot;
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use log::error;
-use syslog::Facility;
 
 fn main() {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("clyde-3g-eps-service"),
-    )
-    .unwrap();
+    Logger::init("clyde-3g-eps-service").unwrap();
 
     let config = Config::new("clyde-3g-eps-service")
         .map_err(|err| {

--- a/services/file-service/Cargo.toml
+++ b/services/file-service/Cargo.toml
@@ -11,7 +11,6 @@ file-protocol = { path = "../../libs/file-protocol" }
 kubos-system = { path = "../../apis/system-api" }
 log = "^0.4.0"
 serde_cbor = "0.8"
-syslog = "4.0"
 
 [dev-dependencies]
 blake2-rfc = "0.2.18"

--- a/services/file-service/src/main.rs
+++ b/services/file-service/src/main.rs
@@ -17,17 +17,12 @@
 #![deny(warnings)]
 
 use file_service::*;
+use kubos_system::logger as ServiceLogger;
 use kubos_system::Config as ServiceConfig;
 use log::{error, warn};
-use syslog::Facility;
 
 fn main() {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("kubos-file-service"),
-    )
-    .unwrap();
+    ServiceLogger::init("file-transfer-service").unwrap();
 
     let config = ServiceConfig::new("file-transfer-service")
         .map_err(|err| {

--- a/services/iobc-supervisor-service/Cargo.toml
+++ b/services/iobc-supervisor-service/Cargo.toml
@@ -9,4 +9,3 @@ juniper =  "0.11"
 isis-iobc-supervisor = { path = "../../apis/isis-iobc-supervisor" }
 kubos-service = { path = "../kubos-service" }
 log = "^0.4.0"
-syslog = "4.0"

--- a/services/iobc-supervisor-service/src/main.rs
+++ b/services/iobc-supervisor-service/src/main.rs
@@ -99,16 +99,10 @@ mod schema;
 
 use crate::model::Supervisor;
 use crate::schema::{MutationRoot, QueryRoot};
-use kubos_service::{Config, Service};
-use syslog::Facility;
+use kubos_service::{Config, Logger, Service};
 
 fn main() {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("iobc-supervisor-service"),
-    )
-    .unwrap();
+    Logger::init("iobc-supervisor-service").unwrap();
 
     Service::new(
         Config::new("iobc-supervisor-service")

--- a/services/isis-ants-service/Cargo.toml
+++ b/services/isis-ants-service/Cargo.toml
@@ -10,7 +10,6 @@ isis-ants-api = { path = "../../apis/isis-ants-api" }
 juniper =  "0.11"
 kubos-service = { path = "../kubos-service" }
 log = "^0.4.0"
-syslog = "4.0"
 
 [dev-dependencies]
 serde = "1.0"

--- a/services/isis-ants-service/src/main.rs
+++ b/services/isis-ants-service/src/main.rs
@@ -357,9 +357,8 @@ pub use crate::objects::*;
 use crate::schema::{MutationRoot, QueryRoot};
 use failure::format_err;
 use isis_ants_api::AntSResult;
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use log::error;
-use syslog::Facility;
 
 mod model;
 mod objects;
@@ -368,12 +367,7 @@ mod schema;
 mod tests;
 
 fn main() -> AntSResult<()> {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("isis-ants-service"),
-    )
-    .unwrap();
+    Logger::init("isis-ants-service").unwrap();
 
     let config = Config::new("isis-ants-service")
         .map_err(|err| {

--- a/services/kubos-service/src/lib.rs
+++ b/services/kubos-service/src/lib.rs
@@ -109,5 +109,5 @@ mod macros;
 mod service;
 
 pub use crate::service::{Context, Service};
-pub use kubos_system::logger;
+pub use kubos_system::logger as Logger;
 pub use kubos_system::Config;

--- a/services/kubos-service/src/lib.rs
+++ b/services/kubos-service/src/lib.rs
@@ -109,4 +109,5 @@ mod macros;
 mod service;
 
 pub use crate::service::{Context, Service};
+pub use kubos_system::logger;
 pub use kubos_system::Config;

--- a/services/local-comms-service/Cargo.toml
+++ b/services/local-comms-service/Cargo.toml
@@ -9,6 +9,3 @@ failure = "0.1.3"
 comms-service = { path = "../../libs/comms-service" }
 kubos-system = { path = "../../apis/system-api" }
 log = "^0.4.0"
-syslog = "4.0"
-log4rs = "*"
-log4rs-syslog = "*"

--- a/services/mai400-service/Cargo.toml
+++ b/services/mai400-service/Cargo.toml
@@ -10,7 +10,6 @@ juniper =  "0.11"
 kubos-service = { path = "../kubos-service" }
 log = "^0.4.0"
 mai400-api = { path = "../../apis/mai400-api" }
-syslog = "4.0"
 
 [dev-dependencies]
 serde = "1.0"

--- a/services/mai400-service/src/main.rs
+++ b/services/mai400-service/src/main.rs
@@ -418,19 +418,13 @@ mod tests;
 use crate::model::{ReadData, Subsystem};
 pub use crate::objects::*;
 use crate::schema::{MutationRoot, QueryRoot};
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use log::error;
 use mai400_api::MAIResult;
 use std::sync::Arc;
-use syslog::Facility;
 
 fn main() -> MAIResult<()> {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("mai400-service"),
-    )
-    .unwrap();
+    Logger::init("mai400-service").unwrap();
 
     Service::new(
         Config::new("mai400-service")

--- a/services/monitor-service/Cargo.toml
+++ b/services/monitor-service/Cargo.toml
@@ -10,7 +10,6 @@ juniper = "0.11"
 kubos-service = { path = "../kubos-service" }
 log = "^0.4.0"
 regex = "1"
-syslog = "4.0"
 
 [dev-dependencies]
 serde = "1.0"

--- a/services/monitor-service/src/main.rs
+++ b/services/monitor-service/src/main.rs
@@ -58,9 +58,8 @@
 extern crate juniper;
 
 use crate::schema::{MutationRoot, QueryRoot};
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use log::error;
-use syslog::Facility;
 
 mod meminfo;
 mod objects;
@@ -70,12 +69,7 @@ mod schema;
 mod userinfo;
 
 fn main() {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("kubos-monitor-service"),
-    )
-    .unwrap();
+    Logger::init("kubos-monitor-service").unwrap();
 
     let config = Config::new("monitor-service")
         .map_err(|err| {

--- a/services/novatel-oem6-service/Cargo.toml
+++ b/services/novatel-oem6-service/Cargo.toml
@@ -13,7 +13,6 @@ juniper =  "0.11"
 kubos-service = { path = "../kubos-service" }
 log = "^0.4.0"
 novatel-oem6-api = { path = "../../apis/novatel-oem6-api" }
-syslog = "4.0"
 
 [dev-dependencies]
 serde_json = "1.0.10"

--- a/services/novatel-oem6-service/src/main.rs
+++ b/services/novatel-oem6-service/src/main.rs
@@ -327,19 +327,13 @@ mod tests;
 use crate::model::{LockData, Subsystem};
 pub use crate::objects::*;
 use crate::schema::{MutationRoot, QueryRoot};
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use log::error;
 use novatel_oem6_api::OEMResult;
 use std::sync::Arc;
-use syslog::Facility;
 
 fn main() -> OEMResult<()> {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("novatel-oem6-service"),
-    )
-    .unwrap();
+    Logger::init("novatel-oem6-service").unwrap();
 
     let config = Config::new("novatel-oem6-service")
         .map_err(|err| {

--- a/services/nsl-duplex-d2-comms-service/Cargo.toml
+++ b/services/nsl-duplex-d2-comms-service/Cargo.toml
@@ -11,4 +11,3 @@ juniper =  "0.11"
 kubos-service = { path = "../../services/kubos-service" }
 log = "^0.4.0"
 nsl-duplex-d2 = { path = "../../apis/nsl-duplex-d2" }
-syslog = "4.0"

--- a/services/nsl-duplex-d2-comms-service/src/main.rs
+++ b/services/nsl-duplex-d2-comms-service/src/main.rs
@@ -230,20 +230,14 @@ use crate::model::Subsystem;
 use crate::schema::{MutationRoot, QueryRoot};
 use comms_service::*;
 use failure::Error;
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use std::sync::{Arc, Mutex};
-use syslog::Facility;
 
 // Generic return type
 type NslDuplexCommsResult<T> = Result<T, Error>;
 
 fn main() -> NslDuplexCommsResult<()> {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("nsl-duplex-comms-service"),
-    )
-    .unwrap();
+    Logger::init("nsl-duplex-comms-service").unwrap();
 
     let service_config = Config::new("nsl-duplex-comms-service").map_err(|err| {
         error!("Failed to load service config: {:?}", err);

--- a/services/shell-service/Cargo.toml
+++ b/services/shell-service/Cargo.toml
@@ -12,4 +12,3 @@ kubos-system = { path = "../../apis/system-api" }
 log = "^0.4.0"
 serde_cbor = "0.8"
 shell-protocol = { path = "../../libs/shell-protocol" }
-syslog = "4.0"

--- a/services/shell-service/src/main.rs
+++ b/services/shell-service/src/main.rs
@@ -16,18 +16,13 @@
 
 #![deny(warnings)]
 
+use kubos_system::logger as ServiceLogger;
 use kubos_system::Config as ServiceConfig;
 use log::{error, info, warn};
 use shell_service::*;
-use syslog::Facility;
 
 fn main() {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("kubos-shell-service"),
-    )
-    .unwrap();
+    ServiceLogger::init("kubos-shell-service").unwrap();
 
     let config = ServiceConfig::new("shell-service")
         .map_err(|err| {

--- a/services/telemetry-service/Cargo.toml
+++ b/services/telemetry-service/Cargo.toml
@@ -14,7 +14,6 @@ log = "^0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-syslog = "4.0"
 tar = "0.4"
 time = "0.1"
 

--- a/services/telemetry-service/src/main.rs
+++ b/services/telemetry-service/src/main.rs
@@ -209,18 +209,12 @@ mod schema;
 mod udp;
 
 use crate::schema::{MutationRoot, QueryRoot, Subsystem};
-use kubos_service::{Config, Service};
+use kubos_service::{Config, Logger, Service};
 use kubos_telemetry_db::Database;
 use log::error;
-use syslog::Facility;
 
 fn main() {
-    syslog::init(
-        Facility::LOG_DAEMON,
-        log::LevelFilter::Debug,
-        Some("kubos-telemetry-service"),
-    )
-    .unwrap();
+    Logger::init("kubos-telemetry-service").unwrap();
 
     let config = Config::new("telemetry-service")
         .map_err(|err| {


### PR DESCRIPTION
This was done to add the convenience flag ``--stdout`` for stdout logging, which is super useful when testing locally, and much nicer than copying and pasting the required code each time.