### PR TITLE
Bumping pnet to 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kubos-system 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1961,31 +1961,31 @@ dependencies = [
 
 [[package]]
 name = "pnet"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_datalink 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_transport 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_datalink 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_transport 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pnet_base"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pnet_datalink"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2001,27 +2001,27 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros_support"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pnet_packet"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_macros 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_macros_support 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_macros_support 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pnet_sys"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2031,13 +2031,13 @@ dependencies = [
 
 [[package]]
 name = "pnet_transport"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3277,7 +3277,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "comms-service 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3654,7 +3654,7 @@ dependencies = [
 "checksum input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
 "checksum ioctl-rs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3d862c86f7867f19b693ec86765e0252d82e53d4240b9b629815675a0714ad1"
+"checksum ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf7762e2b430ad80cbef992a1d4f15a15d9d4068bdd8e57acb0a3d21d0cf7f40"
 "checksum iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2440ae846e7a8c7f9b401db8f6e31b4ea5e7d3688b91761337da7e054520c75b"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum juniper 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d95deabb0bc5e15f508d48017b3791502e734a3d64c261d8ef9658899f04f351"
@@ -3719,14 +3719,14 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
-"checksum pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63d693c84430248366146e3181ff9d330243464fa9e6146c372b2f3eb2e2d8e7"
-"checksum pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4df28acf2fcc77436dd2b91a9a0c2bb617f9ca5f2acefee1a4135058b9f9801f"
-"checksum pnet_datalink 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b34f8ca857599d05b6b082e9baff8d27c54cb9c26568cf3c0993a5755816966"
+"checksum pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cf9ef46222a90a9d1e35bb4fa208e1076c6663a02d8ecf3e264fd5001ab6e8e"
+"checksum pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d818b94d0897cd22f7a18f6c2a94f7ae1dfcedc194bf1665880f6c1155e051"
+"checksum pnet_datalink 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "557ff7deb5ad2b35ac17a495d629d64dfeacf02e7f4834974dceb5e2cc544d55"
 "checksum pnet_macros 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f16d1fa7fd0edebc36055587b8b5af8a109bbc29a55fb484a37e2029b971a7"
-"checksum pnet_macros_support 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84684f2cddefc37a06f2fe2ca4dcc3457fc3b282734b5246507d8ee75d2780ae"
-"checksum pnet_packet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a6cdcdaddc5174f18286298842a4e31cd3cc018933d42af51434b1fa07dcbe"
-"checksum pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "682b2eca84cc440bce8336813f78eb6d3cb0fed89fe0e87ae22acfca8363f176"
-"checksum pnet_transport 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5faa55dcf725487a699adcff88dfea8f17ea34fa2640528866d9acbb4e3a104f"
+"checksum pnet_macros_support 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6158bbc3627b9ce01526f5ff8b9895224a0dc96c27baaf79cda0f703a4898ea"
+"checksum pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7efa93f5572ed735852737232ba7539977799861642aaba05de87b6a03dc0f74"
+"checksum pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab2f8311f738773513fc8192a77e8f77461d97333184c23597a23cb9eb0bd0eb"
+"checksum pnet_transport 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "40851df523364df420e1c85e4885319656904a189a9352657ececcb3c2314fc0"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"

--- a/clients/uart-comms-client/Cargo.toml
+++ b/clients/uart-comms-client/Cargo.toml
@@ -9,6 +9,6 @@ byteorder = "1.2.7"
 clap = "2.32"
 comms-service = { path = "../../libs/comms-service" }
 failure = "0.1.2"
-pnet = "0.22.0"
+pnet = "0.23.0"
 serde_json = "1.0"
 serial = "0.4"

--- a/libs/comms-service/Cargo.toml
+++ b/libs/comms-service/Cargo.toml
@@ -10,7 +10,7 @@ failure = "0.1.3"
 juniper =  "0.9.2"
 kubos-system = { path = "../../apis/system-api" }
 log = "^0.4.0"
-pnet = "0.22.0"
+pnet = "0.23.0"
 reqwest = "0.9"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
This [issue](https://github.com/libpnet/libpnet/issues/391) is causing problems in the `cargo install` step of our vagrant provisioning. Bumping pnet to `0.23.0` resolves the issue.