### PR TITLE
Fix incorrect debug logs from rust-mission-app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ target/
 # python packages
 *.egg-info/
 dist/
+
+# During local SDK development, the following directories may be created
+app-registry/

--- a/examples/rust-mission-app/README.rst
+++ b/examples/rust-mission-app/README.rst
@@ -22,7 +22,18 @@ Usage
 
 Optional Arguments::
 
+    -c, --config        Optional path to a config file
     -s, --cmd_string    Command argument string passed into OnCommand behavior specifying which
     subcommand logic to execute
     -i, --cmd_int       When executing the 'safemode' subcommand, specifies how long the program
     should sleep for, in seconds
+
+.. note::
+
+    When starting a Rust-based app from within the Kubos SDK manually, the default ``/etc/kubos-config.toml`` config
+    file will likely not exist, and so you will need to provide a config file. It will be similar to this::
+
+        $ cargo run -- -c /home/vagrant/kubos/tools/local_config.toml
+
+    The ``--`` characters make sure that the following parameters are passed to the underlying
+    program, rather than to ``cargo``.

--- a/examples/rust-mission-app/src/main.rs
+++ b/examples/rust-mission-app/src/main.rs
@@ -126,8 +126,8 @@ fn main() -> Result<(), Error> {
                     }
                 }
                 Err(err) => {
-                    error!("Monitor service mutation failed: {}", err);
-                    bail!("Monitor service mutation failed: {}", err);
+                    error!("Telemetry service mutation failed: {}", err);
+                    bail!("Telemetry service mutation failed: {}", err);
                 }
             }
         }


### PR DESCRIPTION
I ran into issues running this in the SDK, first because I didn't realize that it required a config file, and second because it was logging connection errors to the monitor service when it was really the telemetry service.

https://github.com/kubos/kubos/tree/master/examples/rust-mission-app