### PR TITLE
Added new options for controlling the file protocol

### DIFF
--- a/clients/kubos-file-client/src/main.rs
+++ b/clients/kubos-file-client/src/main.rs
@@ -162,39 +162,35 @@ fn main() {
         .arg(
             Arg::with_name("host_ip")
                 .help("IP address of the local host to use")
-                .long("host_ip")
-                .short("-h")
+                .long("host-ip")
                 .takes_value(true)
                 .default_value("0.0.0.0"),
         )
         .arg(
             Arg::with_name("host_port")
                 .help("UDP port that the file transfer service will send responses to")
-                .long("host_port")
-                .short("-P")
+                .long("host-port")
                 .takes_value(true)
                 .default_value("8080"),
         )
         .arg(
             Arg::with_name("remote_ip")
                 .help("IP address of the file transfer service to connect to")
-                .long("remote_ip")
-                .short("-r")
+                .long("remote-ip")
                 .takes_value(true)
                 .default_value("0.0.0.0"),
         )
         .arg(
             Arg::with_name("remote_port")
                 .help("UDP port of the file transfer service to connect to")
-                .long("remote_port")
-                .short("-p")
+                .long("remote-port")
                 .takes_value(true)
                 .default_value("8040"),
         )
         .arg(
             Arg::with_name("storage_prefix")
                 .help("Folder name used for transfer storage")
-                .long("storage_prefix")
+                .long("storage-prefix")
                 .short("-s")
                 .takes_value(true)
                 .default_value("file-storage"),
@@ -202,7 +198,7 @@ fn main() {
         .arg(
             Arg::with_name("transfer_chunk_size")
                 .help("Chunk size used for transfer chunking")
-                .long("transfer_chunk_size")
+                .long("transfer-chunk-size")
                 .short("-c")
                 .takes_value(true)
                 .default_value("1024"),
@@ -210,14 +206,14 @@ fn main() {
         .arg(
             Arg::with_name("hash_chunk_size")
                 .help("Chunk size used when hashing for file storage")
-                .long("hash_chunk_size")
+                .long("hash-chunk-size")
                 .takes_value(true)
                 .default_value("2048"),
         )
         .arg(
             Arg::with_name("hold_count")
                 .help("Internal hold counter controlling retry length")
-                .long("hold_count")
+                .long("hold-count")
                 .short("-t")
                 .takes_value(true)
                 .default_value("6"),
@@ -225,7 +221,7 @@ fn main() {
         .arg(
             Arg::with_name("inter_chunk_delay")
                 .help("Delay (in milliseconds) between each chunk transmission")
-                .long("inter_chunk_delay")
+                .long("inter-chunk-delay")
                 .short("-d")
                 .takes_value(true)
                 .default_value("1"),
@@ -233,7 +229,7 @@ fn main() {
         .arg(
             Arg::with_name("max_chunks_transmit")
                 .help("Maximum number of chunks to transmit in one go")
-                .long("max_chunks_transmit")
+                .long("max-chunks-transmit")
                 .short("-m")
                 .takes_value(true),
         )

--- a/clients/kubos-file-client/src/main.rs
+++ b/clients/kubos-file-client/src/main.rs
@@ -163,6 +163,7 @@ fn main() {
             Arg::with_name("host_ip")
                 .help("IP address of the local host to use")
                 .long("host-ip")
+                .short("-h")
                 .takes_value(true)
                 .default_value("0.0.0.0"),
         )
@@ -170,6 +171,7 @@ fn main() {
             Arg::with_name("host_port")
                 .help("UDP port that the file transfer service will send responses to")
                 .long("host-port")
+                .short("-P")
                 .takes_value(true)
                 .default_value("8080"),
         )
@@ -177,6 +179,7 @@ fn main() {
             Arg::with_name("remote_ip")
                 .help("IP address of the file transfer service to connect to")
                 .long("remote-ip")
+                .short("-r")
                 .takes_value(true)
                 .default_value("0.0.0.0"),
         )
@@ -184,6 +187,7 @@ fn main() {
             Arg::with_name("remote_port")
                 .help("UDP port of the file transfer service to connect to")
                 .long("remote-port")
+                .short("-p")
                 .takes_value(true)
                 .default_value("8040"),
         )

--- a/docs/ecosystem/services/file.rst
+++ b/docs/ecosystem/services/file.rst
@@ -164,13 +164,20 @@ defined in the system's :doc:`config.toml <../services/service-config>` file:
         - ``timeout`` - `Default: 2.` The length of time, in seconds, for which the service
           should wait for new messages from the client once a file protocol transaction has
           been started
-        - ``chunk_size`` - `Default: 4096.` Each file is broken up into equally sized
+        - ``transfer_chunk_size`` - `Default: 1024.` Each file is broken up into equally sized
           chunks prior to transfer. This option specifies the size of those chunks
           in bytes.
+        - ``hash_chunk_size`` - `Default: 2048.` Each file is broken up into equally sized
+          chunks which are used to calculate the file's hash. This option specifies the size
+          of those chunks.
         - ``hold_count`` - `Default: 5.` The number of times the protocol waits for
           a new message before ending the transaction.
         - ``downlink_ip`` - `Required` The IP address that the file service responds to.
         - ``downlink_port`` - `Required` The port that the file service responds to.
+        - ``inter_chunk_delay`` - `Default: 1` The delay, in milliseconds, taken 
+            between the transmission of each chunk.
+        - ``max_chunks_transmit`` - `Optional` The maximum number of chunks to transmit before
+            waiting on a response. The default is to transmit the entire file.
 
     - ``[file-transfer-service.addr]``
 

--- a/docs/ecosystem/services/file.rst
+++ b/docs/ecosystem/services/file.rst
@@ -142,7 +142,6 @@ resume transmitting file chunk data.
 .. note::
 
     This timeout is currently hardcoded to two seconds.
-    It will be a configurable option in a future release.
 
 In order to support simultaneous client connections, whenever a message is received
 on the main UDP socket, a new socket is spawned in order to handle the rest
@@ -175,7 +174,7 @@ defined in the system's :doc:`config.toml <../services/service-config>` file:
         - ``downlink_ip`` - `Required` The IP address that the file service responds to.
         - ``downlink_port`` - `Required` The port that the file service responds to.
         - ``inter_chunk_delay`` - `Default: 1` The delay, in milliseconds, taken 
-            between the transmission of each chunk.
+            between the transmission of each chunk. This is to allow manual flow control.
         - ``max_chunks_transmit`` - `Optional` The maximum number of chunks to transmit before
             waiting on a response. The default is to transmit the entire file.
 

--- a/docs/tutorials/file-transfer.rst
+++ b/docs/tutorials/file-transfer.rst
@@ -55,10 +55,16 @@ Optional arguments:
     - ``-P {host_port}`` - Default: `8080`. The UDP port that the file transfer service will send responses to.
     - ``-s {storage_prefix}`` - Default: `file-storage`. Name of the directory which should be used
       for temporary file transfer storage.
-    - ``-c {chunk_size}`` - Default: `4096`. Size, in bytes, of the individual chunks the file
-      should be broken into before transfer.
+    - ``-c {transfer_chunk_size}`` - Default: `1024`. Size, in bytes, of the individual chunks the 
+      file should be broken into before transfer.
     - ``-t {hold_count}`` - Default: `6`. The number of times the client should fail to receive data
       from the endpoint service before giving up and exiting.
+    - ``-d {inter_chunk_delay}`` - Default: `1`. The delay in milliseconds between
+      each chunk transmission.
+    - ``-m {max_chunks_transmit}`` - Default: None. The maximum number of chunks to transmit 
+      before waiting for a response. The default is to transmit the whole file.
+    - ``--hash_chunk_size`` - Default: `2048`: The chunk size, in bytes, to be used when 
+      generating the file's hash.
 
 Sending a File to an OBC
 ------------------------

--- a/libs/file-protocol/src/lib.rs
+++ b/libs/file-protocol/src/lib.rs
@@ -23,7 +23,7 @@
 //! use std::time::Duration;
 //!
 //! fn upload() -> Result<(), ProtocolError> {
-//!     let config = FileProtocolConfig::new(Some("storage/dir".to_owned()), 4096, 5);
+//!     let config = FileProtocolConfig::new(Some("storage/dir".to_owned()), 1024, 5, 1, None, 2048);
 //!     let f_protocol = FileProtocol::new("0.0.0.0", "0.0.0.0:7000", config);
 //!
 //!     # ::std::fs::File::create("client.txt").unwrap();
@@ -54,7 +54,7 @@
 //! use std::time::Duration;
 //!
 //! fn download() -> Result<(), ProtocolError> {
-//!     let config = FileProtocolConfig::new(None, 4096, 5);
+//!     let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
 //!     let f_protocol = FileProtocol::new("0.0.0.0", "0.0.0.0:7000", config);
 //!
 //!     let channel_id = f_protocol.generate_channel()?;

--- a/libs/file-protocol/src/protocol.rs
+++ b/libs/file-protocol/src/protocol.rs
@@ -140,7 +140,7 @@ impl Protocol {
     /// ```no_run
     /// use file_protocol::*;
     ///
-    /// let config = FileProtocolConfig::new(Some("my/file/storage".to_owned()), 4096, 5);
+    /// let config = FileProtocolConfig::new(Some("my/file/storage".to_owned()), 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "192.168.0.1:7000", config);
     /// ```
     ///
@@ -180,7 +180,7 @@ impl Protocol {
     /// use file_protocol::*;
     /// use serde_cbor::ser;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     /// let message = ser::to_vec_packed(&"ping").unwrap();
     ///
@@ -210,7 +210,7 @@ impl Protocol {
     /// use file_protocol::*;
     /// use std::time::Duration;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     ///
     /// let message = match f_protocol.recv(Some(Duration::from_secs(1))) {
@@ -242,7 +242,7 @@ impl Protocol {
     /// ```no_run
     /// use file_protocol::*;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     ///
     /// let channel_id = f_protocol.generate_channel();
@@ -271,7 +271,7 @@ impl Protocol {
     /// ```no_run
     /// use file_protocol::*;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     ///
     /// # ::std::fs::File::create("client.txt").unwrap();
@@ -313,7 +313,7 @@ impl Protocol {
     /// ```no_run
     /// use file_protocol::*;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     ///
     /// # ::std::fs::File::create("client.txt").unwrap();
@@ -355,7 +355,7 @@ impl Protocol {
     /// ```no_run
     /// use file_protocol::*;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     /// let channel_id = f_protocol.generate_channel().unwrap();
     ///
@@ -384,7 +384,7 @@ impl Protocol {
     /// ```no_run
     /// use file_protocol::*;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     ///
     /// # ::std::fs::File::create("client.txt").unwrap();
@@ -434,8 +434,6 @@ impl Protocol {
     /// * channel_id - ID of channel to communicate over
     /// * hash - Hash of file corresponding to chunks
     /// * chunks - List of chunk ranges to transmit
-    /// * inter_chunk_delay - Delay duration between each chunk transmission
-    /// * max_chunks_transmit - Maximum number of chunks to actually transmit
     fn send_chunks(
         &self,
         channel_id: u32,
@@ -484,7 +482,7 @@ impl Protocol {
     /// use file_protocol::*;
     /// use std::time::Duration;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     ///
     /// f_protocol.message_engine(
@@ -641,7 +639,7 @@ impl Protocol {
     /// use file_protocol::*;
     /// use std::time::Duration;
     ///
-    /// let config = FileProtocolConfig::new(None, 4096, 5);
+    /// let config = FileProtocolConfig::new(None, 1024, 5, 1, None, 2048);
     /// let f_protocol = FileProtocol::new("0.0.0.0:8000", "0.0.0.0:7000", config);
     ///
     /// if let Ok(message) = f_protocol.recv(Some(Duration::from_millis(100))) {

--- a/libs/file-protocol/src/protocol.rs
+++ b/libs/file-protocol/src/protocol.rs
@@ -415,7 +415,13 @@ impl Protocol {
         target_path: &str,
         mode: Option<u32>,
     ) -> Result<(), ProtocolError> {
-        match storage::finalize_file(&self.config.storage_prefix, hash, target_path, mode) {
+        match storage::finalize_file(
+            &self.config.storage_prefix,
+            hash,
+            target_path,
+            mode,
+            self.config.hash_chunk_size,
+        ) {
             Ok(_) => {
                 self.send(&messages::operation_success(channel_id, hash)?)?;
                 storage::delete_file(&self.config.storage_prefix, hash)?;

--- a/libs/file-protocol/src/storage.rs
+++ b/libs/file-protocol/src/storage.rs
@@ -253,6 +253,7 @@ pub fn validate_file(
 /// Create temporary folder for chunks
 /// Stream copy file from mutable space to immutable space
 /// Move folder to hash of contents
+/// Import file into chunked storage for transfer
 pub fn initialize_file(
     prefix: &str,
     source_path: &str,
@@ -261,73 +262,34 @@ pub fn initialize_file(
 ) -> Result<(String, u32, u32), ProtocolError> {
     let storage_path = format!("{}/storage", prefix);
 
+    // Confirm file exists
     fs::metadata(source_path).map_err(|err| ProtocolError::StorageError {
         action: format!("stat file {}", source_path),
         err,
     })?;
 
-    // Copy input file to storage area and calculate hash
+    // Create necessary storage directory
     fs::create_dir_all(&storage_path).map_err(|err| ProtocolError::StorageError {
         action: format!("create dir {}", storage_path),
         err,
     })?;
 
+    // Create a temp copy of the file to use for hashing and chunking
     let temp_path = Path::new(&storage_path).join(format!(".{}", time::get_time().nsec));
-    let mut hasher = Blake2s::new(HASH_SIZE);
-    {
-        let input = File::open(&source_path).map_err(|err| ProtocolError::StorageError {
-            action: format!("open {:?}", source_path),
-            err,
-        })?;
-        let mut reader = BufReader::with_capacity(hash_chunk_size, input);
-        let mut output = File::create(&temp_path).map_err(|err| ProtocolError::StorageError {
-            action: format!("create/open {:?} for writing", temp_path),
-            err,
-        })?;
+    fs::copy(&source_path, &temp_path).map_err(|err| ProtocolError::StorageError {
+        action: format!("copy {:?} to temp file {:?}", source_path, temp_path),
+        err,
+    })?;
 
-        // Need to bring in blake2fs here to create hash
-        loop {
-            let length = {
-                let chunk = reader
-                    .fill_buf()
-                    .map_err(|err| ProtocolError::StorageError {
-                        action: "read chunk from source".to_owned(),
-                        err,
-                    })?;
-                if chunk.is_empty() {
-                    output
-                        .sync_all()
-                        .map_err(|err| ProtocolError::StorageError {
-                            action: format!("failed to sync {:?}", temp_path),
-                            err,
-                        })?;
-                    break;
-                }
-                hasher.update(&chunk);
-                output
-                    .write(&chunk)
-                    .map_err(|err| ProtocolError::StorageError {
-                        action: "write chunk".to_owned(),
-                        err,
-                    })?;
-                chunk.len()
-            };
-            reader.consume(length);
-            thread::sleep(Duration::from_millis(2));
-        }
-    }
-    let hash_result = hasher.finalize();
-    let mut hash = String::from("");
-    for c in hash_result.as_bytes().iter() {
-        hash = format!("{}{:02x}", hash, c);
-    }
+    // Calculate hash of temp file
+    let hash = calc_file_hash(&source_path, hash_chunk_size)?;
 
+    // Chunk and store temp file into hash directory
     let mut output = File::open(&temp_path).map_err(|err| ProtocolError::StorageError {
         action: format!("open temp file {:?}", temp_path),
         err,
     })?;
     let mut index = 0;
-
     loop {
         let mut chunk = vec![0u8; transfer_chunk_size];
         match output.read(&mut chunk) {
@@ -359,14 +321,15 @@ pub fn initialize_file(
     }
 }
 
-// Copy temporary data chunks into permanent file?
+// Export received chunks into final file and verify correct file hash
 pub fn finalize_file(
     prefix: &str,
     hash: &str,
     target_path: &str,
     mode: Option<u32>,
+    hash_chunk_size: usize,
 ) -> Result<(), ProtocolError> {
-    // Double check that all the chunks of the file are present and the hash matches up
+    // Double check that all the chunks of the file are present
     let (result, _) = validate_file(prefix, hash, None)?;
 
     if !result {
@@ -384,6 +347,7 @@ pub fn finalize_file(
         err,
     })?;
 
+    // Set exported file's mode
     if let Some(mode_val) = mode {
         file.set_permissions(Permissions::from_mode(mode_val))
             .map_err(|err| ProtocolError::StorageError {
@@ -392,8 +356,7 @@ pub fn finalize_file(
             })?;
     }
 
-    let mut calc_hash = Blake2s::new(HASH_SIZE);
-
+    // Iterate through chunks and reassemble file
     let mut load_chunk_err = None;
     for chunk_num in 0..num_chunks {
         let chunk = match load_chunk(prefix, hash, chunk_num) {
@@ -409,8 +372,6 @@ pub fn finalize_file(
             }
         };
 
-        // Update our verification hash
-        calc_hash.update(&chunk);
         // Write the chunk to the destination file
         file.write_all(&chunk)
             .map_err(|err| ProtocolError::StorageError {
@@ -423,16 +384,11 @@ pub fn finalize_file(
         return Err(e);
     }
 
-    let calc_hash_str = calc_hash
-        .finalize()
-        .as_bytes()
-        .iter()
-        .map(|val| format!("{:02x}", val))
-        .collect::<String>();
+    // Calculate hash of exported file
+    let calc_hash_str = calc_file_hash(&target_path, hash_chunk_size)?;
 
+    // Final determination if file was correctly received and assembled
     if calc_hash_str == hash {
-        // TODO: Do we want to clean up the temporary directory here?
-        // Alternatively, the service can be resposible for that
         Ok(())
     } else {
         // If the hash doesn't match then we start over
@@ -473,4 +429,40 @@ pub fn delete_storage(prefix: &str) -> Result<(), ProtocolError> {
     })?;
 
     Ok(())
+}
+
+/// Calculate the blake2s hash for a file at given path
+fn calc_file_hash(path: &str, hash_chunk_size: usize) -> Result<String, ProtocolError> {
+    let mut hasher = Blake2s::new(HASH_SIZE);
+    let input = File::open(&path).map_err(|err| ProtocolError::StorageError {
+        action: format!("open {:?}", path),
+        err,
+    })?;
+    let mut reader = BufReader::with_capacity(hash_chunk_size, input);
+
+    // Need to bring in blake2fs here to create hash
+    loop {
+        let length = {
+            let chunk = reader
+                .fill_buf()
+                .map_err(|err| ProtocolError::StorageError {
+                    action: "read chunk from source".to_owned(),
+                    err,
+                })?;
+            if chunk.is_empty() {
+                break;
+            }
+            hasher.update(&chunk);
+            chunk.len()
+        };
+        reader.consume(length);
+        thread::sleep(Duration::from_millis(2));
+    }
+
+    Ok(hasher
+        .finalize()
+        .as_bytes()
+        .iter()
+        .map(|val| format!("{:02x}", val))
+        .collect::<String>())
 }

--- a/services/file-service/src/lib.rs
+++ b/services/file-service/src/lib.rs
@@ -49,13 +49,15 @@ pub fn recv_loop(config: &ServiceConfig) -> Result<(), failure::Error> {
     let transfer_chunk_size = match config.get("transfer_chunk_size") {
         Some(val) => val.as_integer().unwrap_or(1024),
         None => 1024,
-    } as usize;
+    };
 
     // Get the chunk size to be used for hashing
     let hash_chunk_size = match config.get("hash_chunk_size") {
-        Some(val) => val.as_integer().unwrap_or(2048),
-        None => 2048,
+        Some(val) => val.as_integer().unwrap_or(transfer_chunk_size * 2),
+        None => transfer_chunk_size * 2,
     } as usize;
+
+    let transfer_chunk_size = transfer_chunk_size as usize;
 
     let hold_count = match config.get("hold_count") {
         Some(val) => val.as_integer().unwrap_or(5),
@@ -92,6 +94,8 @@ pub fn recv_loop(config: &ServiceConfig) -> Result<(), failure::Error> {
     info!("Starting file transfer service");
     info!("Listening on {}", host);
     info!("Downlinking to {}:{}", downlink_ip, downlink_port);
+    info!("Transfer Chunk {}", transfer_chunk_size);
+    info!("Hash Chunk Size {}", hash_chunk_size);
 
     let f_config = FileProtocolConfig::new(
         prefix,

--- a/services/file-service/tests/common/mod.rs
+++ b/services/file-service/tests/common/mod.rs
@@ -35,7 +35,7 @@ macro_rules! service_new {
                         r#"
                 [file-transfer-service]
                 storage_dir = "{}"
-                chunk_size = {}
+                transfer_chunk_size = {}
                 hold_count = 5
                 downlink_ip = "127.0.0.1"
                 downlink_port = {}
@@ -65,7 +65,14 @@ pub fn download(
     chunk_size: u32,
 ) -> Result<(), ProtocolError> {
     let hold_count = 5;
-    let f_config = FileProtocolConfig::new(prefix, chunk_size as usize, hold_count);
+    let f_config = FileProtocolConfig::new(
+        prefix,
+        chunk_size as usize,
+        hold_count,
+        1,
+        None,
+        (chunk_size as usize) * 2,
+    );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);
 
@@ -104,7 +111,14 @@ pub fn download_partial(
     chunk_size: u32,
 ) -> Result<(), ProtocolError> {
     let hold_count = 5;
-    let f_config = FileProtocolConfig::new(prefix, chunk_size as usize, hold_count);
+    let f_config = FileProtocolConfig::new(
+        prefix,
+        chunk_size as usize,
+        hold_count,
+        1,
+        None,
+        (chunk_size as usize) * 2,
+    );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);
 
@@ -159,7 +173,14 @@ pub fn upload(
     chunk_size: u32,
 ) -> Result<String, ProtocolError> {
     let hold_count = 5;
-    let f_config = FileProtocolConfig::new(prefix, chunk_size as usize, hold_count);
+    let f_config = FileProtocolConfig::new(
+        prefix,
+        chunk_size as usize,
+        hold_count,
+        1,
+        None,
+        (chunk_size as usize) * 2,
+    );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);
 
@@ -196,7 +217,14 @@ pub fn upload_partial(
     chunk_size: u32,
 ) -> Result<String, ProtocolError> {
     let hold_count = 5;
-    let f_config = FileProtocolConfig::new(prefix, chunk_size as usize, hold_count);
+    let f_config = FileProtocolConfig::new(
+        prefix,
+        chunk_size as usize,
+        hold_count,
+        1,
+        None,
+        (chunk_size as usize) * 2,
+    );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);
 
@@ -232,7 +260,14 @@ pub fn cleanup(
     chunk_size: u32,
 ) -> Result<(), ProtocolError> {
     let hold_count = 5;
-    let f_config = FileProtocolConfig::new(prefix, chunk_size as usize, hold_count);
+    let f_config = FileProtocolConfig::new(
+        prefix,
+        chunk_size as usize,
+        hold_count,
+        1,
+        None,
+        (chunk_size as usize) * 2,
+    );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);
 

--- a/test/integration/large_download/src/main.rs
+++ b/test/integration/large_download/src/main.rs
@@ -34,7 +34,7 @@ macro_rules! service_new {
                         r#"
                 [file-transfer-service]
                 storage_dir = "{}"
-                chunk_size = {}
+                transfer_chunk_size = {}
                 hold_count = 5
                 downlink_ip = "127.0.0.1"
                 downlink_port = {}
@@ -121,7 +121,14 @@ pub fn download(
     chunk_size: u32,
 ) -> Result<(), ProtocolError> {
     let hold_count = 5;
-    let f_config = FileProtocolConfig::new(prefix, chunk_size as usize, hold_count);
+    let f_config = FileProtocolConfig::new(
+        prefix,
+        chunk_size as usize,
+        hold_count,
+        1,
+        None,
+        (chunk_size as usize) * 2,
+    );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);
 

--- a/test/integration/large_download/src/main.rs
+++ b/test/integration/large_download/src/main.rs
@@ -35,6 +35,7 @@ macro_rules! service_new {
                 [file-transfer-service]
                 storage_dir = "{}"
                 transfer_chunk_size = {}
+                hash_chunk_size = {}
                 hold_count = 5
                 downlink_ip = "127.0.0.1"
                 downlink_port = {}
@@ -42,7 +43,11 @@ macro_rules! service_new {
                 ip = "127.0.0.1"
                 port = {}
                 "#,
-                        $storage_dir, $chunk_size, $down_port, $port
+                        $storage_dir,
+                        $chunk_size,
+                        $chunk_size * 64,
+                        $down_port,
+                        $port
                     ),
                 )
                 .unwrap(),
@@ -127,7 +132,7 @@ pub fn download(
         hold_count,
         1,
         None,
-        (chunk_size as usize) * 2,
+        (chunk_size as usize) * 64,
     );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);

--- a/test/integration/large_upload/src/main.rs
+++ b/test/integration/large_upload/src/main.rs
@@ -34,7 +34,7 @@ macro_rules! service_new {
                         r#"
                 [file-transfer-service]
                 storage_dir = "{}"
-                chunk_size = {}
+                transfer_chunk_size = {}
                 hold_count = 5
                 downlink_ip = "127.0.0.1"
                 downlink_port = {}
@@ -124,7 +124,14 @@ pub fn upload(
     chunk_size: u32,
 ) -> Result<String, ProtocolError> {
     let hold_count = 5;
-    let f_config = FileProtocolConfig::new(prefix, chunk_size as usize, hold_count);
+    let f_config = FileProtocolConfig::new(
+        prefix,
+        chunk_size as usize,
+        hold_count,
+        1,
+        None,
+        (chunk_size as usize) * 2,
+    );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);
 

--- a/test/integration/large_upload/src/main.rs
+++ b/test/integration/large_upload/src/main.rs
@@ -35,6 +35,7 @@ macro_rules! service_new {
                 [file-transfer-service]
                 storage_dir = "{}"
                 transfer_chunk_size = {}
+                hash_chunk_size = {}
                 hold_count = 5
                 downlink_ip = "127.0.0.1"
                 downlink_port = {}
@@ -42,7 +43,11 @@ macro_rules! service_new {
                 ip = "127.0.0.1"
                 port = {}
                 "#,
-                        $storage_dir, $chunk_size, $down_port, $port
+                        $storage_dir,
+                        $chunk_size,
+                        $chunk_size * 64,
+                        $down_port,
+                        $port
                     ),
                 )
                 .unwrap(),
@@ -123,14 +128,14 @@ pub fn upload(
     prefix: Option<String>,
     chunk_size: u32,
 ) -> Result<String, ProtocolError> {
-    let hold_count = 5;
+    let hold_count = 20;
     let f_config = FileProtocolConfig::new(
         prefix,
         chunk_size as usize,
         hold_count,
         1,
         None,
-        (chunk_size as usize) * 2,
+        (chunk_size as usize) * 64,
     );
     let f_protocol =
         FileProtocol::new(&format!("{}:{}", host_ip, host_port), remote_addr, f_config);


### PR DESCRIPTION
New control options:
- `hash_chunk_size` - Controls the chunk size used when hashing the file.
- `inter_chunk_delay` - Controls the delay between transmission of individual chunks
- `max_chunks_transmit` - Controls maximum number of chunks to transmit before waiting on response

Also:
- Cleaned up kubos-file-client a bit.
- Renamed original `chunk_size` to `transfer_chunk_size`