### PR TITLE
Updating app and telemetry service unit tests to use Drop

### DIFF
--- a/services/app-service/tests/test_apps.rs
+++ b/services/app-service/tests/test_apps.rs
@@ -96,7 +96,6 @@ macro_rules! test_query {
                 ));
             });
 
-            fixture.teardown();
             assert!(result.is_ok());
         }
     };

--- a/services/app-service/tests/test_kill.rs
+++ b/services/app-service/tests/test_kill.rs
@@ -148,8 +148,6 @@ fn kill_good() {
         }"#,
     );
 
-    fixture.teardown();
-
     assert_eq!(
         result["appStatus"][0]["name"].as_str().unwrap(),
         "rust-proj"
@@ -193,8 +191,6 @@ fn kill_app_bad_name() {
            "success": false
         }
     });
-
-    fixture.teardown();
 
     assert_eq!(result, expected);
 }
@@ -246,8 +242,6 @@ fn kill_app_not_running() {
            "success": false
         }
     });
-
-    fixture.teardown();
 
     assert_eq!(result, expected);
 }
@@ -325,8 +319,6 @@ fn kill_custom_signal() {
             }
         }"#,
     );
-
-    fixture.teardown();
 
     assert_eq!(
         result["appStatus"][0]["name"].as_str().unwrap(),

--- a/services/app-service/tests/test_monitor.rs
+++ b/services/app-service/tests/test_monitor.rs
@@ -165,8 +165,6 @@ fn monitor_good() {
         }"#,
     );
 
-    fixture.teardown();
-
     assert_eq!(
         result["appStatus"][0]["name"].as_str().unwrap(),
         "rust-proj"
@@ -211,8 +209,6 @@ fn monitor_existing() {
 
     // If we try to start the app a second time, it should fail
     let result = send_query(config.clone(), start_app);
-
-    fixture.teardown();
 
     assert_eq!(
         result["startApp"]["errors"].as_str().unwrap(),

--- a/services/app-service/tests/test_python_app.rs
+++ b/services/app-service/tests/test_python_app.rs
@@ -100,8 +100,6 @@ fn app_single_pos_arg() {
 
     thread::sleep(Duration::from_millis(400));
 
-    fixture.teardown();
-
     assert!(result["startApp"]["success"].as_bool().unwrap());
 }
 
@@ -137,8 +135,6 @@ fn app_single_flag() {
 
     thread::sleep(Duration::from_millis(400));
 
-    fixture.teardown();
-
     assert!(result["startApp"]["success"].as_bool().unwrap());
 }
 
@@ -173,8 +169,6 @@ fn app_flag_arg() {
     );
 
     thread::sleep(Duration::from_millis(400));
-
-    fixture.teardown();
 
     assert!(result["startApp"]["success"].as_bool().unwrap());
 }
@@ -212,8 +206,6 @@ fn app_failure() {
     );
 
     thread::sleep(Duration::from_millis(400));
-
-    fixture.teardown();
 
     assert_eq!(
         result["startApp"]["errors"].as_str().unwrap(),

--- a/services/app-service/tests/test_rust_app.rs
+++ b/services/app-service/tests/test_rust_app.rs
@@ -102,8 +102,6 @@ fn app_no_args() {
         }"#,
     );
 
-    fixture.teardown();
-
     // The test app is setup to verify arguments, so for this case we want to make sure it failed
     // as expected
     assert_eq!(
@@ -142,8 +140,6 @@ fn app_single_pos_arg() {
         }"#,
     );
 
-    fixture.teardown();
-
     assert!(result["startApp"]["success"].as_bool().unwrap());
 }
 
@@ -176,8 +172,6 @@ fn app_single_flag() {
             }
         }"#,
     );
-
-    fixture.teardown();
 
     assert!(result["startApp"]["success"].as_bool().unwrap());
 }
@@ -212,8 +206,6 @@ fn app_flag_arg() {
         }"#,
     );
 
-    fixture.teardown();
-
     assert!(result["startApp"]["success"].as_bool().unwrap());
 }
 
@@ -246,8 +238,6 @@ fn app_custom_config() {
             }
         }"#,
     );
-
-    fixture.teardown();
 
     assert!(result["startApp"]["success"].as_bool().unwrap());
 }

--- a/services/app-service/tests/test_uninstall.rs
+++ b/services/app-service/tests/test_uninstall.rs
@@ -143,7 +143,6 @@ fn uninstall_last_app() {
         "No such file or directory (os error 2)"
     );
 
-    fixture.teardown();
     assert!(result.is_ok());
 }
 
@@ -196,7 +195,6 @@ fn uninstall_notlast_app() {
     // Our app directory should still exist since there's a version left in the registry
     assert_eq!(fixture.registry_dir.path().join("dummy").exists(), true);
 
-    fixture.teardown();
     assert!(result.is_ok());
 }
 
@@ -255,7 +253,6 @@ fn uninstall_all_app() {
     // Our app directory should now no longer exist
     assert_eq!(fixture.registry_dir.path().join("dummy").exists(), false);
 
-    fixture.teardown();
     assert!(result.is_ok());
 }
 
@@ -347,7 +344,6 @@ fn uninstall_new_app() {
     // Our app directory should still exist since there's a version left in the registry
     assert_eq!(fixture.registry_dir.path().join("dummy").exists(), true);
 
-    fixture.teardown();
     assert!(result.is_ok());
 }
 
@@ -410,7 +406,6 @@ fn uninstall_unmonitor() {
         assert!(result["appStatus"].as_array().unwrap().is_empty());
     });
 
-    fixture.teardown();
     assert!(result.is_ok());
 }
 
@@ -493,7 +488,6 @@ fn uninstall_all_unmonitor() {
     // Our app directory should now no longer exist
     assert_eq!(fixture.registry_dir.path().join("dummy").exists(), false);
 
-    fixture.teardown();
     assert!(result.is_ok());
 }
 
@@ -546,8 +540,6 @@ fn uninstall_running() {
             result
         );
     });
-
-    fixture.teardown();
 
     assert!(result.is_ok());
 
@@ -609,8 +601,6 @@ fn uninstall_all_running() {
             result
         );
     });
-
-    fixture.teardown();
 
     assert!(result.is_ok());
 
@@ -680,7 +670,6 @@ fn uninstall_kill() {
     assert!(signal::kill(pid, None).is_ok());
     thread::sleep(Duration::from_secs(3));
 
-    fixture.teardown();
     // Now it should be dead
     assert!(!signal::kill(pid, None).is_ok());
 }

--- a/services/app-service/tests/utils/mod.rs
+++ b/services/app-service/tests/utils/mod.rs
@@ -271,8 +271,10 @@ impl AppServiceFixture {
         self.join_handle = Some(handle);
         self.sender = Some(tx);
     }
+}
 
-    pub fn teardown(&mut self) {
+impl Drop for AppServiceFixture {
+    fn drop(&mut self) {
         if self.sender.is_some() {
             self.sender.take().unwrap().send(true).unwrap();
         }

--- a/services/telemetry-service/tests/test_delete.rs
+++ b/services/telemetry-service/tests/test_delete.rs
@@ -43,7 +43,7 @@ fn test_delete_ge() {
     let port = 8112;
     let udp = 8122;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let mutation = r#"mutation {
             delete(timestampGe: 1004) {
@@ -104,8 +104,6 @@ fn test_delete_ge() {
     });
     let query_result = do_query(Some(port), query);
 
-    teardown(handle, sender);
-
     assert_eq!(mutation_result, mutation_expected);
     assert_eq!(query_result, query_expected);
 }
@@ -119,7 +117,7 @@ fn test_delete_le() {
     let port = 8113;
     let udp = 8123;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let mutation = r#"mutation {
             delete(timestampLe: 1008) {
@@ -168,8 +166,6 @@ fn test_delete_le() {
     });
     let query_result = do_query(Some(port), query);
 
-    teardown(handle, sender);
-
     assert_eq!(mutation_result, mutation_expected);
     assert_eq!(query_result, query_expected);
 }
@@ -183,7 +179,7 @@ fn test_delete_range() {
     let port = 8114;
     let udp = 8124;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let mutation = r#"mutation {
             delete(timestampGe: 1001, timestampLe: 1009) {
@@ -232,8 +228,6 @@ fn test_delete_range() {
     });
     let query_result = do_query(Some(port), query);
 
-    teardown(handle, sender);
-
     assert_eq!(mutation_result, mutation_expected);
     assert_eq!(query_result, query_expected);
 }
@@ -247,7 +241,7 @@ fn test_delete_subsystem() {
     let port = 8115;
     let udp = 8125;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let mutation = r#"mutation {
             delete(subsystem: "eps") {
@@ -310,8 +304,6 @@ fn test_delete_subsystem() {
     });
     let query_result = do_query(Some(port), query);
 
-    teardown(handle, sender);
-
     assert_eq!(mutation_result, mutation_expected);
     assert_eq!(query_result, query_expected);
 }
@@ -325,7 +317,7 @@ fn test_delete_parameter() {
     let port = 8116;
     let udp = 8126;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let mutation = r#"mutation {
             delete(parameter: "voltage") {
@@ -379,8 +371,6 @@ fn test_delete_parameter() {
         }
     });
     let query_result = do_query(Some(port), query);
-
-    teardown(handle, sender);
 
     assert_eq!(mutation_result, mutation_expected);
     assert_eq!(query_result, query_expected);

--- a/services/telemetry-service/tests/test_empty_db.rs
+++ b/services/telemetry-service/tests/test_empty_db.rs
@@ -24,9 +24,9 @@ fn test() {
     let db_dir = TempDir::new().unwrap();
     let db_path = db_dir.path().join("test.db");
     let db = db_path.to_str().unwrap();
-    let (handle, sender) = setup(db, None, None, None);
+    let _fixture = TelemetryServiceFixture::setup(db, None, None, None);
     let res = do_query(None, "{telemetry{timestamp,subsystem,parameter,value}}");
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({

--- a/services/telemetry-service/tests/test_filter_parameter.rs
+++ b/services/telemetry-service/tests/test_filter_parameter.rs
@@ -36,13 +36,13 @@ fn test_parameter() {
     let port = 8111;
     let udp = 8121;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let res = do_query(
         Some(port),
         "{telemetry(parameter: \"voltage\"){parameter,value}}",
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({
@@ -65,7 +65,7 @@ fn test_parameters_multiple() {
     let port = 8112;
     let udp = 8122;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let res = do_query(
         Some(port),
@@ -76,7 +76,7 @@ fn test_parameters_multiple() {
         }
     }"#,
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({
@@ -101,7 +101,7 @@ fn test_parameters_single() {
     let port = 8113;
     let udp = 8123;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let res = do_query(
         Some(port),
@@ -112,7 +112,7 @@ fn test_parameters_single() {
         }
     }"#,
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({
@@ -135,7 +135,7 @@ fn test_conflict() {
     let port = 8114;
     let udp = 8124;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let res = do_query(
         Some(port),
@@ -146,7 +146,7 @@ fn test_conflict() {
         }
     }"#,
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({

--- a/services/telemetry-service/tests/test_filter_subsystem.rs
+++ b/services/telemetry-service/tests/test_filter_subsystem.rs
@@ -30,12 +30,12 @@ fn test() {
     let db_dir = TempDir::new().unwrap();
     let db_path = db_dir.path().join("test.db");
     let db = db_path.to_str().unwrap();
-    let (handle, sender) = setup(db, None, None, Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, None, None, Some(SQL));
     let res = do_query(
         None,
         "{telemetry(subsystem: \"gps\"){timestamp,subsystem,parameter,value}}",
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({

--- a/services/telemetry-service/tests/test_filter_timestamp.rs
+++ b/services/telemetry-service/tests/test_filter_timestamp.rs
@@ -38,11 +38,9 @@ fn test_ge() {
     let port = 8112;
     let udp = 8122;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let ge_res = do_query(Some(port), "{telemetry(timestampGe: 1004){value}}");
-
-    teardown(handle, sender);
 
     assert_eq!(
         ge_res,
@@ -66,11 +64,9 @@ fn test_le() {
     let port = 8113;
     let udp = 8123;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let le_res = do_query(Some(port), "{telemetry(timestampLe: 1002){value}}");
-
-    teardown(handle, sender);
 
     assert_eq!(
         le_res,
@@ -95,14 +91,12 @@ fn test_range() {
     let port = 8114;
     let udp = 8124;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let range_res = do_query(
         Some(port),
         "{telemetry(timestampGe: 1001, timestampLe:1003){value}}",
     );
-
-    teardown(handle, sender);
 
     assert_eq!(
         range_res,
@@ -127,14 +121,12 @@ fn test_single() {
     let port = 8115;
     let udp = 8125;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let single_res = do_query(
         Some(port),
         "{telemetry(timestampGe: 1003, timestampLe:1003){value}}",
     );
-
-    teardown(handle, sender);
 
     assert_eq!(
         single_res,

--- a/services/telemetry-service/tests/test_insert.rs
+++ b/services/telemetry-service/tests/test_insert.rs
@@ -31,7 +31,7 @@ fn test_insert_auto_timestamp() {
     let port = 8111;
     let udp = 8121;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
 
     let mutation = r#"mutation {
             insert(subsystem: "test2", parameter: "voltage", value: "4.0") {
@@ -67,8 +67,6 @@ fn test_insert_auto_timestamp() {
     });
     let query_result = do_query(Some(port), query);
 
-    teardown(handle, sender);
-
     assert_eq!(mutation_result, mutation_expected);
     assert_eq!(query_result, query_expected);
 }
@@ -82,7 +80,7 @@ fn test_insert_custom_timestamp() {
     let port = 8112;
     let udp = 8122;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
 
     let mutation = r#"mutation {
             insert(timestamp: 5, subsystem: "test2", parameter: "voltage", value: "4.0") {
@@ -120,8 +118,6 @@ fn test_insert_custom_timestamp() {
     });
     let query_result = do_query(Some(port), query);
 
-    teardown(handle, sender);
-
     assert_eq!(mutation_result, mutation_expected);
     assert_eq!(query_result, query_expected);
 }
@@ -135,7 +131,7 @@ fn test_insert_multi_auto() {
     let port = 8113;
     let udp = 8123;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
 
     let mutation_expected = json!({
         "data": {
@@ -161,7 +157,6 @@ fn test_insert_multi_auto() {
 
         let mutation_result = do_query(Some(port), &mutation);
         if mutation_result != mutation_expected {
-            teardown(handle, sender);
             panic!();
         }
         sleep(Duration::from_millis(1));
@@ -207,8 +202,6 @@ fn test_insert_multi_auto() {
     });
     let query_result = do_query(Some(port), query);
 
-    teardown(handle, sender);
-
     assert_eq!(query_result, query_expected);
 }
 
@@ -221,7 +214,7 @@ fn test_insert_current_timestamp() {
     let port = 8114;
     let udp = 8124;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
 
     let time = time::now_utc().to_timespec();
     let now = time.sec as f64 + (time.nsec as f64 / 1000000000.0);
@@ -253,8 +246,6 @@ fn test_insert_current_timestamp() {
         }"#;
 
     let query_result = do_query(Some(port), query);
-
-    teardown(handle, sender);
 
     assert_eq!(mutation_result, mutation_expected);
 

--- a/services/telemetry-service/tests/test_insert_bulk.rs
+++ b/services/telemetry-service/tests/test_insert_bulk.rs
@@ -28,13 +28,12 @@ macro_rules! test_mutation_query_results {
         let port: u16 = 8110 + $port_offset;
         let udp: u16 = 8210 + $port_offset;
 
-        let (handle, sender) = setup(db, Some(port), Some(udp), None);
+        let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
         let mutation_expected = json!($mutation_expected);
         let mutation_result = do_query(Some(port), $mutation);
         let query_expected = json!($query_expected);
 
         let query_result = do_query(Some(port), $query);
-        teardown(handle, sender);
 
         assert_eq!(mutation_result, mutation_expected);
         assert_eq!(query_result, query_expected);

--- a/services/telemetry-service/tests/test_limit.rs
+++ b/services/telemetry-service/tests/test_limit.rs
@@ -38,12 +38,12 @@ fn test() {
     let db_dir = TempDir::new().unwrap();
     let db_path = db_dir.path().join("test.db");
     let db = db_path.to_str().unwrap();
-    let (handle, sender) = setup(db, None, None, Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, None, None, Some(SQL));
     let res = do_query(
         None,
         "{telemetry(limit: 2, timestampGe: 1008){timestamp,subsystem,parameter,value}}",
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({

--- a/services/telemetry-service/tests/test_ping.rs
+++ b/services/telemetry-service/tests/test_ping.rs
@@ -24,9 +24,9 @@ fn test() {
     let db_dir = TempDir::new().unwrap();
     let db_path = db_dir.path().join("test.db");
     let db = db_path.to_str().unwrap();
-    let (handle, sender) = setup(db, None, None, None);
+    let _fixture = TelemetryServiceFixture::setup(db, None, None, None);
     let res = do_query(None, "{ping}");
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({

--- a/services/telemetry-service/tests/test_route.rs
+++ b/services/telemetry-service/tests/test_route.rs
@@ -45,7 +45,7 @@ fn test_route_file() {
     let port = 8111;
     let udp = 8121;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("output");
@@ -58,8 +58,6 @@ fn test_route_file() {
     );
 
     do_query(Some(port), &query);
-
-    teardown(handle, sender);
 
     let mut output_file = File::open(output_path).unwrap();
     let mut contents = String::new();
@@ -93,7 +91,7 @@ fn test_route_response() {
     let port = 8112;
     let udp = 8122;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     // Use a file that won't have a randomly generated path
     let output_path = "output";
@@ -107,7 +105,6 @@ fn test_route_response() {
 
     let res = do_query(Some(port), &query);
 
-    teardown(handle, sender);
     // Since it's not a temporary file, we'll need to delete it ourselves
     fs::remove_file(output_path).unwrap();
 
@@ -129,7 +126,7 @@ fn test_route_filter() {
     let port = 8113;
     let udp = 8123;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("output");
@@ -149,8 +146,6 @@ fn test_route_filter() {
     );
 
     do_query(Some(port), &query);
-
-    teardown(handle, sender);
 
     let mut output_file = File::open(output_path).unwrap();
     let mut contents = String::new();
@@ -176,7 +171,7 @@ fn test_route_compress_file() {
     let port = 8114;
     let udp = 8124;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let output_dir = TempDir::new().unwrap();
     let output_name = "output";
@@ -190,8 +185,6 @@ fn test_route_compress_file() {
     );
 
     do_query(Some(port), &query);
-
-    teardown(handle, sender);
 
     let tar_path = output_dir.path().join(format!("{}.tar.gz", output_name));
     let result_dir = output_dir.path().join("final");
@@ -234,7 +227,7 @@ fn test_route_compress_response() {
     let port = 8115;
     let udp = 8125;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     // Use a file that won't have a randomly generated path
     let output_path = "compressed-output";
@@ -248,7 +241,6 @@ fn test_route_compress_response() {
 
     let res = do_query(Some(port), &query);
 
-    teardown(handle, sender);
     // Since it's not a temporary file, we'll need to delete it ourselves
     fs::remove_file(&format!("{}.tar.gz", output_path)).unwrap();
 
@@ -270,7 +262,7 @@ fn test_route_parameters() {
     let port = 8116;
     let udp = 8126;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("output");
@@ -288,8 +280,6 @@ fn test_route_parameters() {
     );
 
     do_query(Some(port), &query);
-
-    teardown(handle, sender);
 
     let mut output_file = File::open(output_path).unwrap();
     let mut contents = String::new();
@@ -318,7 +308,7 @@ fn test_route_conflict() {
     let port = 8117;
     let udp = 8127;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), Some(SQL));
 
     let res = do_query(
         Some(port),
@@ -329,7 +319,7 @@ fn test_route_conflict() {
         }
     }"#,
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({

--- a/services/telemetry-service/tests/test_select_all.rs
+++ b/services/telemetry-service/tests/test_select_all.rs
@@ -30,9 +30,9 @@ fn test() {
     let db_dir = TempDir::new().unwrap();
     let db_path = db_dir.path().join("test.db");
     let db = db_path.to_str().unwrap();
-    let (handle, sender) = setup(db, None, None, Some(SQL));
+    let _fixture = TelemetryServiceFixture::setup(db, None, None, Some(SQL));
     let res = do_query(None, "{telemetry{timestamp,subsystem,parameter,value}}");
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({

--- a/services/telemetry-service/tests/test_udp.rs
+++ b/services/telemetry-service/tests/test_udp.rs
@@ -31,7 +31,7 @@ fn test_udp_timestamp() {
     let port = 8111;
     let udp = 8121;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
 
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let service = format!("0.0.0.0:{}", udp);
@@ -73,7 +73,7 @@ fn test_udp_timestamp() {
         Some(port),
         "{telemetry{timestamp,subsystem,parameter,value}}",
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({
@@ -98,7 +98,7 @@ fn test_udp_no_timestamp() {
     let port = 8112;
     let udp = 8122;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
 
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let service = format!("0.0.0.0:{}", udp);
@@ -142,7 +142,7 @@ fn test_udp_no_timestamp() {
     ::std::thread::sleep(Duration::from_secs(1));
 
     let res = do_query(Some(port), "{telemetry{subsystem,parameter,value}}");
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({
@@ -167,7 +167,7 @@ fn test_udp_bulk_timestamp() {
     let port = 8113;
     let udp = 8123;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
 
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let service = format!("0.0.0.0:{}", udp);
@@ -201,7 +201,7 @@ fn test_udp_bulk_timestamp() {
         Some(port),
         "{telemetry{timestamp,subsystem,parameter,value}}",
     );
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({
@@ -226,7 +226,7 @@ fn test_udp_bulk_no_timestamp() {
     let port = 8114;
     let udp = 8124;
 
-    let (handle, sender) = setup(db, Some(port), Some(udp), None);
+    let _fixture = TelemetryServiceFixture::setup(db, Some(port), Some(udp), None);
 
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let service = format!("0.0.0.0:{}", udp);
@@ -258,7 +258,7 @@ fn test_udp_bulk_no_timestamp() {
     ::std::thread::sleep(Duration::from_secs(1));
 
     let res = do_query(Some(port), "{telemetry{subsystem,parameter,value}}");
-    teardown(handle, sender);
+
     assert_eq!(
         res,
         json!({


### PR DESCRIPTION
The app and telemetry service unit tests currently use a custom `teardown` function to clean up at the end of a test. Converting them to use the standard Rust `drop` function that way they don't have to be explicitly called