### PR TITLE
Increasing scheduler 'start app' response wait time to match app service

### DIFF
--- a/services/scheduler-service/src/app.rs
+++ b/services/scheduler-service/src/app.rs
@@ -41,8 +41,9 @@ pub struct StartAppGraphQL {
 
 // Helper function for sending query to app service
 pub fn service_query(query: &str, hosturl: &str) -> Result<StartAppGraphQL, SchedulerError> {
+    // The app service will wait 300ms to see if an app completes before returning its response to us
     let client = Client::builder()
-        .timeout(Duration::from_millis(200))
+        .timeout(Duration::from_millis(350))
         .build()
         .map_err(|e| SchedulerError::QueryError { err: e.to_string() })?;
     let mut map = HashMap::new();


### PR DESCRIPTION
When kicking off an app, the app service [waits 300ms](https://github.com/kubos/kubos/blob/master/services/app-service/src/registry.rs#L722) to see if the app immediately returns before returning its GraphQL response.

The scheduler is currently only waiting 200ms to hear back from the app service.

The PR bumps the scheduler's wait time to better match the app service's behavior