### PR TITLE
Feature gating GraphQL functionality

### DIFF
--- a/libs/comms-service/Cargo.toml
+++ b/libs/comms-service/Cargo.toml
@@ -4,10 +4,14 @@ version = "0.1.0"
 authors = ["William Greer <wgreer184@gmail.com>", "Sam Justice <sam.justice1@gmail.com"]
 edition = "2018"
 
+[features]
+default = ["graphql"]
+graphql = ["juniper"]
+
 [dependencies]
 byteorder = "1.2.7"
 failure = "0.1.3"
-juniper =  "0.9.2"
+juniper =  { version = "0.9.2", optional = true }
 kubos-system = { path = "../../apis/system-api" }
 log = "^0.4.0"
 pnet = "0.23.0"

--- a/libs/comms-service/src/lib.rs
+++ b/libs/comms-service/src/lib.rs
@@ -70,6 +70,7 @@
 //! ip = "192.168.8.2"
 //! ```
 
+#[cfg(feature = "graphql")]
 #[macro_use]
 extern crate juniper;
 

--- a/libs/comms-service/src/packet.rs
+++ b/libs/comms-service/src/packet.rs
@@ -23,6 +23,7 @@ use crate::CommsResult;
 #[repr(u8)]
 pub enum PayloadType {
     /// Packet intended for GraphQL request/response
+    #[cfg(features = "graphql")]
     GraphQL,
     /// Packet intended for UDP passthrough
     UDP,
@@ -33,6 +34,7 @@ pub enum PayloadType {
 impl From<u16> for PayloadType {
     fn from(num: u16) -> PayloadType {
         match num {
+            #[cfg(features = "graphql")]
             0 => PayloadType::GraphQL,
             1 => PayloadType::UDP,
             other => PayloadType::Unknown(other),
@@ -43,6 +45,7 @@ impl From<u16> for PayloadType {
 impl From<PayloadType> for u16 {
     fn from(value: PayloadType) -> u16 {
         match value {
+            #[cfg(features = "graphql")]
             PayloadType::GraphQL => 0,
             PayloadType::UDP => 1,
             PayloadType::Unknown(value) => value as u16,

--- a/libs/comms-service/src/telemetry.rs
+++ b/libs/comms-service/src/telemetry.rs
@@ -20,7 +20,8 @@ use crate::errors::*;
 use std::sync::{Arc, Mutex};
 
 /// Generic telemetry collected by the communication service.
-#[derive(Default, GraphQLObject)]
+#[derive(Default)]
+#[cfg_attr(feature = "graphql", derive(GraphQLObject))]
 pub struct CommsTelemetry {
     /// Errors that have occured within the communication service.
     pub errors: Vec<String>,


### PR DESCRIPTION
We would like a version of the comms service framework which only handles UDP traffic. These changes place the functionality for handling GraphQL traffic behind a feature. 

Currently the feature is enabled by default but can be easily disabled in the `Cargo.toml` like so:

```toml
[dependencies]
comms-service = { path = "path/to/comms-service", default-features = false }
```