### PR TITLE
Unnecessary clone of payload data when creating raw spacepacket

### DIFF
--- a/libs/comms-service/src/spacepacket.rs
+++ b/libs/comms-service/src/spacepacket.rs
@@ -134,7 +134,9 @@ impl LinkPacket for SpacePacket {
         bytes.write_u16::<BigEndian>(header_2)?;
         bytes.write_u64::<BigEndian>(self.secondary_header.command_id)?;
         bytes.write_u16::<BigEndian>(self.secondary_header.destination_port)?;
-        bytes.append(&mut self.payload.clone());
+
+        // bytes.append(&mut self.payload.clone());
+        bytes.extend(&self.payload);
 
         Ok(bytes)
     }


### PR DESCRIPTION
vec.append consumes another vec. The payload had to be cloned to be
consumed, Then the elements are "moved" (copied) into the vec. (2 copies)

vec.extend does not consume the provided slice, only copies the elements
to the end of the vec. (1 copy)