### PR TITLE
Return nonzero return code when transfer fails

### DIFF
--- a/clients/kubos-file-client/src/main.rs
+++ b/clients/kubos-file-client/src/main.rs
@@ -325,6 +325,7 @@ fn main() {
 
     if let Err(err) = result {
         error!("Operation failed: {}", err);
+        std::process::exit(1);
     } else {
         info!("Operation successful");
     }


### PR DESCRIPTION
I'm using kubos-file-client as a Python subprocess for my proof of concept Python ground station because I haven't make a proper Python bindings for it, but when transfer fails, kubos-file-client lies and return 0. So, my ground station cannot know that the transfer fails, so it will not schedule transfer at next pass. 

To fix this, I exit with return code 1 when there is error

Fixes https://github.com/kubos/kubos/issues/346
Better solution is to implement https://github.com/kubos/kubos/issues/536