### PR TITLE
Monitor Service loadavg

### DIFF
--- a/docs/ecosystem/services/monitor-service.rst
+++ b/docs/ecosystem/services/monitor-service.rst
@@ -126,6 +126,37 @@ The query has the following response fields:
       without swapping
     - ``lowFree`` - The amount of free memory which can be used by the kernel
 
+LoadAvg Query
+-------------
+
+The ``loadAvg`` query can be used to get information about the system's processor utilization. It
+operates by reading `/proc/loadavg` and parsing available values to return averaged processor
+load, counts of active processes, and last process ID status.
+
+All values are recorded in double precision floats to avoid any potential truncation, and simplify output.
+
+It has the following schema::
+
+    {
+        loadAvg {
+            load1m: Float
+            load5m: Float
+            load15m: Float
+            processesActive: Float
+            processesTotal: Float
+            lastPid: Float
+        }
+    }
+
+The response fields:
+
+    - ``load1m`` - System load averaged over the past minute
+    - ``load5m`` - System load averaged over the past five minutes
+    - ``load15m`` - System load averaged over the past fifteen minutes 
+    - ``processesActive`` - Processes active at the instant of reading /proc/loadavg 
+    - ``processesTotal`` - Processes running on the system in total
+    - ``lastPid`` - Last spawned Process ID on the system
+
 .. note::
 
     Not all response fields are available on all systems.

--- a/services/monitor-service/src/loadavg.rs
+++ b/services/monitor-service/src/loadavg.rs
@@ -32,7 +32,7 @@ impl LoadAvg {
         Default::default()
     }
 
-    fn parse_f64(avg: &str) -> Option<f64> {
+    fn parse_avg(avg: &str) -> Option<f64> {
         avg.parse().ok()
     }
 
@@ -52,9 +52,9 @@ impl LoadAvg {
 
         // Parsers which can safely fail
         if split_vec.len() >= 3 {
-            load_avg.load_1m = Self::parse_f64(split_vec[0]);
-            load_avg.load_5m = Self::parse_f64(split_vec[1]);
-            load_avg.load_15m = Self::parse_f64(split_vec[2]);
+            load_avg.load_1m = Self::parse_avg(split_vec[0]);
+            load_avg.load_5m = Self::parse_avg(split_vec[1]);
+            load_avg.load_15m = Self::parse_avg(split_vec[2]);
         }
 
         if split_vec.len() > 3 {
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn loadavg_parse() {
-        let info: Result<LoadAvg, failure::Error> = LoadAvg::parse(RAW0);
+        let info = LoadAvg::parse(RAW0);
         assert_eq!(
             info.ok(),
             Some(LoadAvg {
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn loadavg_partial() {
-        let info: Result<LoadAvg, failure::Error> = LoadAvg::parse(RAW_PARTIAL);
+        let info = LoadAvg::parse(RAW_PARTIAL);
         assert_eq!(
             info.ok(),
             Some(LoadAvg {
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn loadavg_weird() {
-        let info: Result<LoadAvg, failure::Error> = LoadAvg::parse(RAW_WEIRD);
+        let info = LoadAvg::parse(RAW_WEIRD);
         assert_eq!(
             info.ok(),
             Some(LoadAvg {
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn bad_data() {
-        let info: Result<LoadAvg, failure::Error> = LoadAvg::parse(RAW_BAD);
+        let info = LoadAvg::parse(RAW_BAD);
         assert_eq!(
             info.ok(),
             Some(LoadAvg {
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn no_data() {
-        let info: Result<LoadAvg, failure::Error> = LoadAvg::parse(EMPTY);
+        let info = LoadAvg::parse(EMPTY);
         assert_eq!(
             info.ok(),
             Some(LoadAvg {

--- a/services/monitor-service/src/loadavg.rs
+++ b/services/monitor-service/src/loadavg.rs
@@ -117,7 +117,7 @@ impl LoadAvg {
         self.processes_total
     }
 
-    // Total threads launched on the system
+    // Last process ID launched on the system
     pub fn last_pid(&self) -> Option<u64> {
         self.last_pid
     }

--- a/services/monitor-service/src/loadavg.rs
+++ b/services/monitor-service/src/loadavg.rs
@@ -1,0 +1,140 @@
+//
+// Copyright (C) 2022 Xplore Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::f64;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::str;
+
+#[derive(Clone, Debug, Default, PartialEq, PartialOrd)]
+pub struct LoadAvg {
+    load_1m: Option<f64>,
+    load_5m: Option<f64>,
+    load_15m: Option<f64>,
+    processes_active: Option<u64>,
+    processes_total:  Option<u64>,
+    last_pid: Option<u64>,
+}
+
+impl LoadAvg {
+    pub fn new() -> Self {
+        Self {
+            load_1m: None,
+            load_5m: None,
+            load_15m: None,
+            processes_active: None,
+            processes_total: None,
+            last_pid: None,
+        }
+    }
+
+    fn parse_f64(avg: &str) -> Option<f64> {
+        match avg.parse::<f64>() {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
+    }
+
+    fn parse_u64(s: &str) -> Option<u64>{
+        match s.parse::<u64>() {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
+    }
+
+    pub fn parse<R>(mut raw: R) -> Result<LoadAvg, failure::Error>
+    where
+        R: BufRead,
+    {
+        let mut load_avg: LoadAvg = LoadAvg::new();
+        let mut buf = String::new();
+        let _len = raw.read_line(&mut buf)?;
+        let ws = buf.split_whitespace();
+        let split_vec = ws.collect::<Vec<_>>().to_owned();
+        let split_procs = split_vec[3].split('/').collect::<Vec<_>>();
+
+        load_avg.load_1m = Self::parse_f64(split_vec[0]);
+        load_avg.load_5m = Self::parse_f64(split_vec[1]);
+        load_avg.load_15m = Self::parse_f64(split_vec[2]);
+        load_avg.processes_active =Self::parse_u64(split_procs[0]);
+        load_avg.processes_total = Self::parse_u64(split_procs[1]);
+        load_avg.last_pid = Self::parse_u64(split_vec[4]);
+
+        Ok(load_avg)
+    }
+
+    pub fn from_proc() -> Result<LoadAvg, failure::Error> {
+        let file = File::open("/proc/loadavg")?;
+        let reader = BufReader::new(file);
+
+        Self::parse(reader)
+    }
+
+    // System load averaged over the past one minute
+    pub fn load_1m(&self) -> Option<f64> {
+        self.load_1m
+    }
+
+    // System load averaged over the past five minutes
+    pub fn load_5m(&self) -> Option<f64> {
+        self.load_5m
+    }
+
+    // System load averaged over the past fifteen minutes
+    pub fn load_15m(&self) -> Option<f64> {
+        self.load_15m
+    }
+
+    // System active processes
+    pub fn processes_active(&self) -> Option<u64> {
+        self.processes_active
+    }
+
+
+    // System total number of processes
+    pub fn processes_total(&self) -> Option<u64> {
+        self.processes_total
+    }
+
+    // Total threads launched on the system
+    pub fn last_pid(&self) -> Option<u64> {
+        self.last_pid
+    }
+} 
+
+#[cfg(test)]
+#[allow(clippy::unreadable_literal)]
+mod tests {
+    use super::*;
+
+    const RAW0: &[u8] = b"0.03 0.05 0.06 1/541 6275\n";
+    //const RAW1: &[u8] = b"0.19 0.13 0.09 1/543 11348\n";
+    //const RAW_PARTIAL: &[u8] = b"0.19 0.13 \n";
+
+    #[test]
+    fn loadavg_parse() {
+        let info: Result<LoadAvg, failure::Error> = LoadAvg::parse(RAW0);
+        assert_eq!(
+            info.ok(),
+            Some(LoadAvg {
+                load_1m: Some(0.03),
+                load_5m: Some(0.05),
+                load_15m: Some(0.06),
+                processes_active: Some(1),
+                processes_total: Some(541),
+                last_pid: Some(6275),
+            })
+        );
+    }
+}

--- a/services/monitor-service/src/loadavg.rs
+++ b/services/monitor-service/src/loadavg.rs
@@ -132,7 +132,7 @@ mod tests {
     const RAW_PARTIAL: &[u8] = b"0.19 0.13 2.6 \n";
     const RAW_BAD: &[u8] = b"bad data 12.0\n";
     const RAW_WEIRD: &[u8] = b"0.19 0.13 2.6 bobloblaw 11348\n";
-    const EMPTY : &[u8] = b"   ";
+    const EMPTY: &[u8] = b"   ";
 
     #[test]
     fn loadavg_parse() {

--- a/services/monitor-service/src/loadavg.rs
+++ b/services/monitor-service/src/loadavg.rs
@@ -29,28 +29,15 @@ pub struct LoadAvg {
 
 impl LoadAvg {
     pub fn new() -> Self {
-        Self {
-            load_1m: None,
-            load_5m: None,
-            load_15m: None,
-            processes_active: None,
-            processes_total: None,
-            last_pid: None,
-        }
+        Default::default()
     }
 
     fn parse_f64(avg: &str) -> Option<f64> {
-        match avg.parse::<f64>() {
-            Ok(v) => Some(v),
-            Err(_) => None,
-        }
+        avg.parse().ok()
     }
 
     fn parse_u64(s: &str) -> Option<u64> {
-        match s.parse::<u64>() {
-            Ok(v) => Some(v),
-            Err(_) => None,
-        }
+        s.parse().ok()
     }
 
     pub fn parse<R>(mut raw: R) -> Result<LoadAvg, failure::Error>

--- a/services/monitor-service/src/main.rs
+++ b/services/monitor-service/src/main.rs
@@ -36,9 +36,9 @@
 //!     load_1m: Float
 //!     load_5m: Float
 //!     load_15m: Float
-//!     processes_active: Int
-//!     processes_total: Int
-//!     last_pid: Int
+//!     processes_active: Float
+//!     processes_total: Float
+//!     last_pid: Float
 //! }
 //!
 //! type MemInfo {

--- a/services/monitor-service/src/main.rs
+++ b/services/monitor-service/src/main.rs
@@ -31,10 +31,10 @@
 //!     memInfo: MemInfo!
 //!     ps(pids: [Int!] = null): [ProcInfo!]!
 //! }
-//! 
+//!
 //! type LoadAvg {
 //!     load_1m: Float
-//!     load_5m: Float 
+//!     load_5m: Float
 //!     load_15m: Float
 //!     processes_active: Int
 //!     processes_total: Int

--- a/services/monitor-service/src/main.rs
+++ b/services/monitor-service/src/main.rs
@@ -31,6 +31,15 @@
 //!     memInfo: MemInfo!
 //!     ps(pids: [Int!] = null): [ProcInfo!]!
 //! }
+//! 
+//! type LoadAvg {
+//!     load_1m: Float
+//!     load_5m: Float 
+//!     load_15m: Float
+//!     processes_active: Int
+//!     processes_total: Int
+//!     last_pid: Int
+//! }
 //!
 //! type MemInfo {
 //!     total: Int
@@ -61,6 +70,7 @@ use crate::schema::{MutationRoot, QueryRoot};
 use kubos_service::{Config, Logger, Service};
 use log::error;
 
+mod loadavg;
 mod meminfo;
 mod objects;
 #[macro_use]

--- a/services/monitor-service/src/objects.rs
+++ b/services/monitor-service/src/objects.rs
@@ -23,13 +23,13 @@ pub struct LoadAvgResponse {
 }
 
 graphql_object!(LoadAvgResponse: () |&self| {
-    field one_minute_avg() -> Option<f64> {
+    field load_1m() -> Option<f64> {
         self.avgs.load_1m().map(|v| v as f64)
     }
-    field five_minute_avg() -> Option<f64> {
+    field load_5m() -> Option<f64> {
         self.avgs.load_5m().map(|v| v as f64)
     }
-    field fifteen_minute_avg() -> Option<f64> {
+    field load_15m() -> Option<f64> {
         self.avgs.load_15m().map(|v| v as f64)
     }
     field processes_active() -> Option<f64> {

--- a/services/monitor-service/src/objects.rs
+++ b/services/monitor-service/src/objects.rs
@@ -24,13 +24,13 @@ pub struct LoadAvgResponse {
 
 graphql_object!(LoadAvgResponse: () |&self| {
     field load_1m() -> Option<f64> {
-        self.avgs.load_1m().map(|v| v as f64)
+        self.avgs.load_1m()
     }
     field load_5m() -> Option<f64> {
-        self.avgs.load_5m().map(|v| v as f64)
+        self.avgs.load_5m()
     }
     field load_15m() -> Option<f64> {
-        self.avgs.load_15m().map(|v| v as f64)
+        self.avgs.load_15m()
     }
     field processes_active() -> Option<f64> {
         self.avgs.processes_active().map(|v| v as f64)

--- a/services/monitor-service/src/objects.rs
+++ b/services/monitor-service/src/objects.rs
@@ -18,7 +18,7 @@ use crate::meminfo::MemInfo;
 use crate::process::ProcStat;
 use crate::userinfo::UserInfo;
 
-pub struct LoadAvgResponse{
+pub struct LoadAvgResponse {
     pub avgs: LoadAvg,
 }
 

--- a/services/monitor-service/src/objects.rs
+++ b/services/monitor-service/src/objects.rs
@@ -13,9 +13,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+use crate::loadavg::LoadAvg;
 use crate::meminfo::MemInfo;
 use crate::process::ProcStat;
 use crate::userinfo::UserInfo;
+
+pub struct LoadAvgResponse{
+    pub avgs: LoadAvg,
+}
+
+graphql_object!(LoadAvgResponse: () |&self| {
+    field one_minute_avg() -> Option<f64> {
+        self.avgs.load_1m().map(|v| v as f64)
+    }
+    field five_minute_avg() -> Option<f64> {
+        self.avgs.load_5m().map(|v| v as f64)
+    }
+    field fifteen_minute_avg() -> Option<f64> {
+        self.avgs.load_15m().map(|v| v as f64)
+    }
+    field processes_active() -> Option<f64> {
+        self.avgs.processes_active().map(|v| v as f64)
+    }
+    field processes_total() -> Option<f64> {
+        self.avgs.processes_total().map(|v| v as f64)
+    }
+    field last_pid() -> Option<f64> {
+        self.avgs.last_pid().map(|v| v as f64)
+    }
+});
 
 pub struct MemInfoResponse {
     pub info: MemInfo,

--- a/services/monitor-service/src/schema.rs
+++ b/services/monitor-service/src/schema.rs
@@ -16,6 +16,7 @@
 
 use juniper::{self, FieldError, FieldResult};
 
+use crate::loadavg;
 use crate::meminfo;
 use crate::objects::*;
 use crate::process;
@@ -46,6 +47,12 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
         };
 
         Ok(pids_vec.into_iter().map(PSResponse::new).collect())
+    }
+
+    field load_avg(&executor) -> FieldResult<LoadAvgResponse> {
+        loadavg::LoadAvg::from_proc()
+            .map(|avgs| LoadAvgResponse{ avgs })
+            .map_err(|err| FieldError::new(err, juniper::Value::null()))
     }
 });
 

--- a/services/monitor-service/src/schema.rs
+++ b/services/monitor-service/src/schema.rs
@@ -51,7 +51,7 @@ graphql_object!(QueryRoot: Context as "Query" |&self| {
 
     field load_avg(&executor) -> FieldResult<LoadAvgResponse> {
         loadavg::LoadAvg::from_proc()
-            .map(|avgs| LoadAvgResponse{ avgs })
+            .map(|avgs| LoadAvgResponse { avgs })
             .map_err(|err| FieldError::new(err, juniper::Value::null()))
     }
 });


### PR DESCRIPTION
The ``loadAvg`` query can be used to get information about the system's processor utilization. It operates by reading `/proc/loadavg` and parsing available values to return averaged processor load, counts of active processes, and last process ID status.


<img width="1508" alt="Screen Shot 2022-12-19 at 1 37 50 PM" src="https://user-images.githubusercontent.com/489062/208529134-24800666-8bb1-4ebe-b3b4-baf67a6eb3d5.png">

Open to suggestions on naming and pattern. I primarily followed the MemInfo monitor as example.
