### PR TITLE
update docs syntax for app service args

### DIFF
--- a/docs/ecosystem/services/app-service.rst
+++ b/docs/ecosystem/services/app-service.rst
@@ -332,7 +332,7 @@ To pass additional arguments to the underlying application, the ``args`` input a
 For example::
 
     mutation {
-        startApp(name: "mission-app", args: "--verbose --release") {
+        startApp(name: "mission-app", args: ["--verbose", "--release"]) {
             success
         }
     }


### PR DESCRIPTION
a small PR to update the app-service syntax in the docs 
fixes #555 